### PR TITLE
feat: Add configurable addon auto-loading on startup

### DIFF
--- a/elisp/emacs-mcp-addons.el
+++ b/elisp/emacs-mcp-addons.el
@@ -44,12 +44,21 @@
   :group 'emacs-mcp-addons)
 
 (defcustom emacs-mcp-addon-auto-load-list
-  '((claude-code-mcp . claude-code)
-    (cider-mcp . cider)
-    (org-ai-mcp . org-ai))
+  '((cider . cider)
+    (claude-code . claude-code)
+    (org-ai . org-ai)
+    (org-kanban . org-kanban))
   "Alist of (ADDON . TRIGGER-FEATURE).
-When TRIGGER-FEATURE is loaded, ADDON will be auto-loaded."
+When TRIGGER-FEATURE is loaded, ADDON will be auto-loaded.
+Addon names correspond to files: emacs-mcp-ADDON.el"
   :type '(alist :key-type symbol :value-type symbol)
+  :group 'emacs-mcp-addons)
+
+(defcustom emacs-mcp-addon-always-load nil
+  "List of addons to always load when `emacs-mcp-mode' is enabled.
+These load regardless of whether the trigger feature is present.
+Example: \\='(cider org-kanban package-lint)"
+  :type '(repeat symbol)
   :group 'emacs-mcp-addons)
 
 ;;;; Registry
@@ -144,6 +153,24 @@ Uses `emacs-mcp-addon-auto-load-list' to determine mappings."
         ;; Otherwise, set up deferred loading
         (with-eval-after-load trigger
           (emacs-mcp-addon-load addon))))))
+
+;;;###autoload
+(defun emacs-mcp-addons-load-always ()
+  "Load all addons in `emacs-mcp-addon-always-load'.
+Called during `emacs-mcp-initialize' to load user's preferred addons."
+  (interactive)
+  (dolist (addon emacs-mcp-addon-always-load)
+    (emacs-mcp-addon-load addon)))
+
+;;;###autoload
+(defun emacs-mcp-addons-setup ()
+  "Set up addon system: load always-load addons and enable auto-loading.
+This is the main entry point, called from `emacs-mcp-initialize'."
+  (interactive)
+  ;; First load always-load addons
+  (emacs-mcp-addons-load-always)
+  ;; Then set up deferred auto-loading for feature-triggered addons
+  (emacs-mcp-addons-auto-load))
 
 ;;;; Registration (for addon authors)
 

--- a/elisp/emacs-mcp.el
+++ b/elisp/emacs-mcp.el
@@ -66,6 +66,19 @@
   :type 'boolean
   :group 'emacs-mcp)
 
+(defcustom emacs-mcp-auto-enable nil
+  "Automatically enable `emacs-mcp-mode' when Emacs starts.
+Set this to t in your config to have emacs-mcp ready on startup."
+  :type 'boolean
+  :group 'emacs-mcp)
+
+(defcustom emacs-mcp-setup-addons t
+  "Set up addon system during initialization.
+When non-nil, loads addons from `emacs-mcp-addon-always-load'
+and enables auto-loading for feature-triggered addons."
+  :type 'boolean
+  :group 'emacs-mcp)
+
 ;;; Require submodules
 
 (require 'emacs-mcp-memory)
@@ -73,6 +86,10 @@
 (require 'emacs-mcp-triggers)
 (require 'emacs-mcp-workflows)
 (require 'emacs-mcp-api)
+(require 'emacs-mcp-addons)
+
+;; Forward declaration for byte-compiler
+(declare-function emacs-mcp-addons-setup "emacs-mcp-addons")
 
 ;; Optional: transient menus
 (when (require 'transient nil t)
@@ -103,6 +120,10 @@
 
     ;; Set up hooks
     (emacs-mcp-setup-hooks)
+
+    ;; Set up addons (always-load + auto-load triggers)
+    (when emacs-mcp-setup-addons
+      (emacs-mcp-addons-setup))
 
     (setq emacs-mcp--initialized t)
     (message "emacs-mcp initialized (C-c m for menu)")))
@@ -156,13 +177,13 @@ keybindings for AI-assisted development.
 ;;; Auto-load on init (optional)
 
 (defun emacs-mcp--maybe-auto-enable ()
-  "Maybe enable emacs-mcp-mode automatically."
-  (when (and (boundp 'emacs-mcp-auto-enable)
-             emacs-mcp-auto-enable)
+  "Maybe enable `emacs-mcp-mode' automatically.
+Controlled by `emacs-mcp-auto-enable'."
+  (when emacs-mcp-auto-enable
     (emacs-mcp-mode 1)))
 
-;; Uncomment to auto-enable:
-;; (add-hook 'after-init-hook #'emacs-mcp--maybe-auto-enable)
+;; Set up auto-enable hook (runs if emacs-mcp-auto-enable is t)
+(add-hook 'after-init-hook #'emacs-mcp--maybe-auto-enable)
 
 (provide 'emacs-mcp)
 ;;; emacs-mcp.el ends here


### PR DESCRIPTION
## Summary

Adds user-configurable addon loading for emacs-mcp startup:

- **`emacs-mcp-auto-enable`** - Enable emacs-mcp-mode when Emacs starts
- **`emacs-mcp-addon-always-load`** - List of addons to load immediately
- **`emacs-mcp-setup-addons`** - Control addon setup during init

## Usage

```elisp
;; In your Emacs config:
(setq emacs-mcp-auto-enable t)
(setq emacs-mcp-addon-always-load '(cider org-kanban package-lint))
(require 'emacs-mcp)
```

## Changes

- Fixed addon naming in auto-load-list (`cider-mcp` → `cider`)
- Added `emacs-mcp-addons-setup` as main entry point
- Hook auto-enable via `after-init-hook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)