### PR TITLE
feat: Add async nREPL startup and CIDER middleware

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,12 +9,12 @@
         {:git/url "https://github.com/unravel-team/mcp-clojure-sdk.git"
          :git/sha "039cf220ac6bb3858f71e823016035e257a5380d"}
 
-        ;; nREPL client support  
+        ;; nREPL client support
         nrepl/bencode {:mvn/version "1.2.0"}
 
-        ;; Logging
+        ;; Logging - Timbre with SLF4J bridge
         com.taoensso/timbre {:mvn/version "6.8.0"}
-        org.slf4j/slf4j-nop {:mvn/version "2.0.16"}}
+        com.fzakaria/slf4j-timbre {:mvn/version "0.4.1"}}
 
  :aliases
  {:mcp
@@ -23,12 +23,18 @@
 
   :dev
   {:extra-paths ["dev" "test"]
-   :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}}
+   :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}
+                cider/cider-nrepl {:mvn/version "0.58.0"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}}}
 
   :nrepl
   {:extra-paths ["dev" "test"]
-   :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
-   :main-opts ["-m" "nrepl.cmdline" "--port" "7910"]}
+   :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}
+                cider/cider-nrepl {:mvn/version "0.58.0"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}}
+   :main-opts ["-m" "nrepl.cmdline"
+               "--port" "7910"
+               "--middleware" "[cider.nrepl/cider-middleware,refactor-nrepl.middleware/wrap-refactor]"]}
 
   :test
   {:extra-paths ["test"]


### PR DESCRIPTION
## Summary
- Add cider-nrepl 0.58.0 and refactor-nrepl 3.11.0 middleware to deps.edn
- Replace slf4j-nop with slf4j-timbre for proper logging
- Add async nREPL spawn on addon enable (non-blocking)
- Add auto-connect CIDER with timer-based polling

## Changes
This PR fixes the CIDER warnings about missing cider-nrepl middleware:
```
WARNING: CIDER requires cider-nrepl to be fully functional.
WARNING: clj-refactor and refactor-nrepl are out of sync.
```

### deps.edn
- Added `cider/cider-nrepl {:mvn/version "0.58.0"}`
- Added `refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}`
- Added `--middleware` flag to inject middleware properly
- Replaced `org.slf4j/slf4j-nop` with `com.fzakaria/slf4j-timbre` for proper logging

### emacs-mcp-cider.el
- **Async nREPL startup**: Uses `start-process` for non-blocking server spawn
- **Auto-connect**: Timer-based polling to connect CIDER when nREPL becomes available
- **Customization**: Port, retry interval, max retries all configurable
- **Minor mode hooks**: Auto-start on enable if configured
- **Transient menu**: New nREPL server controls (start/stop/auto-connect)

## Test plan
- [ ] Start Emacs with `emacs-mcp-cider-auto-start-nrepl` set to `t`
- [ ] Verify Emacs startup is not blocked
- [ ] Verify CIDER connects automatically when nREPL is ready
- [ ] Verify no CIDER middleware warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)