### PR TITLE
feat: Add standardized addon lifecycle system

### DIFF
--- a/elisp/addons/emacs-mcp-addon-template.el
+++ b/elisp/addons/emacs-mcp-addon-template.el
@@ -131,6 +131,32 @@
 ;;    ["Query"
 ;;     ("q" "Query memory" emacs-mcp-template-query-memory)]])
 
+;;;; Addon Lifecycle Functions (NEW - recommended approach)
+
+;; These functions are called automatically by the addon system:
+
+(defun emacs-mcp-template--addon-init ()
+  "Synchronous init - runs immediately after loading.
+Use for lightweight setup that must complete before use."
+  (require 'emacs-mcp-api nil t)
+  ;; Example: setup keybindings, hooks
+  (message "emacs-mcp-template: initialized"))
+
+(defun emacs-mcp-template--addon-async-init ()
+  "Asynchronous init - runs in background after loading.
+Use for long-running startup (servers, subprocesses).
+Should return a process object if starting a subprocess."
+  ;; Example: start a server
+  ;; (when emacs-mcp-template-auto-start
+  ;;   (start-process "my-server" "*my-server*" "my-command"))
+  nil)
+
+(defun emacs-mcp-template--addon-shutdown ()
+  "Shutdown - runs when addon is unloaded.
+Use for cleanup (stopping servers, saving state)."
+  ;; Example: stop server, save state
+  (message "emacs-mcp-template: shutdown complete"))
+
 ;;;; Registration
 
 ;; Register this addon with emacs-mcp
@@ -140,7 +166,11 @@
    :version "0.1.0"
    :description "Template addon for emacs-mcp"
    :requires '(emacs-mcp-api)
-   :provides '(emacs-mcp-template-mode)))
+   :provides '(emacs-mcp-template-mode)
+   ;; Lifecycle hooks (all optional):
+   :init #'emacs-mcp-template--addon-init
+   :async-init #'emacs-mcp-template--addon-async-init
+   :shutdown #'emacs-mcp-template--addon-shutdown))
 
 (provide 'emacs-mcp-addon-template)
 ;;; emacs-mcp-addon-template.el ends here

--- a/elisp/addons/emacs-mcp-cider.el
+++ b/elisp/addons/emacs-mcp-cider.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025 Pedro G. Branquinho
 ;; Author: Pedro G. Branquinho <pedrogbranquinho@gmail.com>
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "28.1") (cider "1.0"))
 ;; Keywords: tools, clojure, mcp
 ;; SPDX-License-Identifier: MIT
@@ -16,6 +16,8 @@
 ;; - Save REPL results to memory
 ;; - Query memory for previous solutions
 ;; - Auto-log REPL sessions
+;; - Auto-start nREPL server (async, non-blocking)
+;; - Auto-connect CIDER when nREPL becomes available
 ;;
 ;; Usage:
 ;;   (emacs-mcp-addon-load 'cider)
@@ -23,6 +25,10 @@
 ;;
 ;; Or enable auto-loading when CIDER loads:
 ;;   (emacs-mcp-addons-auto-load)
+;;
+;; For auto-start nREPL on addon load:
+;;   (setq emacs-mcp-cider-auto-start-nrepl t)
+;;   (add-to-list 'emacs-mcp-addon-always-load 'cider)
 
 ;;; Code:
 
@@ -34,6 +40,9 @@
 (declare-function cider-nrepl-eval-sync "cider-nrepl")
 (declare-function cider-last-sexp "cider-eval")
 (declare-function cider-interactive-eval "cider-eval")
+(declare-function cider-connect-clj "cider")
+(declare-function cider-connected-p "cider-connection")
+(declare-function cider-repl-buffers "cider-connection")
 
 ;;;; Customization
 
@@ -53,10 +62,164 @@
   :type 'integer
   :group 'emacs-mcp-cider)
 
+(defcustom emacs-mcp-cider-auto-start-nrepl nil
+  "When non-nil, automatically start nREPL server on addon load.
+The server starts asynchronously and does not block Emacs startup."
+  :type 'boolean
+  :group 'emacs-mcp-cider)
+
+(defcustom emacs-mcp-cider-auto-connect t
+  "When non-nil, automatically connect CIDER when nREPL is available.
+Works with both auto-started and externally started nREPL servers."
+  :type 'boolean
+  :group 'emacs-mcp-cider)
+
+(defcustom emacs-mcp-cider-nrepl-port 7910
+  "Default port for nREPL server."
+  :type 'integer
+  :group 'emacs-mcp-cider)
+
+(defcustom emacs-mcp-cider-project-dir nil
+  "Project directory for starting nREPL.
+If nil, uses the current project root or `default-directory'."
+  :type '(choice (const nil) directory)
+  :group 'emacs-mcp-cider)
+
+(defcustom emacs-mcp-cider-connect-retry-interval 1.0
+  "Seconds between connection retry attempts."
+  :type 'number
+  :group 'emacs-mcp-cider)
+
+(defcustom emacs-mcp-cider-connect-max-retries 30
+  "Maximum number of connection retry attempts (0 = unlimited)."
+  :type 'integer
+  :group 'emacs-mcp-cider)
+
 ;;;; Internal
 
 (defvar emacs-mcp-cider--last-eval nil
   "Last evaluated expression and result for potential saving.")
+
+(defvar emacs-mcp-cider--nrepl-process nil
+  "Process object for auto-started nREPL server.")
+
+(defvar emacs-mcp-cider--connect-timer nil
+  "Timer for auto-connect retry attempts.")
+
+(defvar emacs-mcp-cider--connect-attempts 0
+  "Number of connection attempts made.")
+
+;;;; Async nREPL Start & Auto-Connect
+
+(defun emacs-mcp-cider--project-dir ()
+  "Get the project directory for nREPL."
+  (or emacs-mcp-cider-project-dir
+      (when (fboundp 'project-root)
+        (when-let* ((proj (project-current)))
+          (project-root proj)))
+      default-directory))
+
+(defun emacs-mcp-cider--port-open-p (port)
+  "Check if PORT is accepting connections."
+  (condition-case nil
+      (let ((proc (make-network-process
+                   :name "nrepl-check"
+                   :host "localhost"
+                   :service port
+                   :nowait nil)))
+        (delete-process proc)
+        t)
+    (error nil)))
+
+(defun emacs-mcp-cider--start-nrepl-async ()
+  "Start nREPL server asynchronously in background.
+Does not block Emacs startup."
+  (let* ((default-directory (emacs-mcp-cider--project-dir))
+         (port (number-to-string emacs-mcp-cider-nrepl-port))
+         (buf-name "*nREPL-server*"))
+    (message "emacs-mcp-cider: Starting nREPL on port %s..." port)
+    (setq emacs-mcp-cider--nrepl-process
+          (start-process "nrepl-server" buf-name
+                         "clojure" "-M:nrepl"))))
+
+(defun emacs-mcp-cider--try-connect ()
+  "Try to connect CIDER to nREPL.  Returns t if successful."
+  (when (and (featurep 'cider)
+             (fboundp 'cider-connect-clj)
+             (not (cider-connected-p))
+             (emacs-mcp-cider--port-open-p emacs-mcp-cider-nrepl-port))
+    (condition-case err
+        (progn
+          (cider-connect-clj (list :host "localhost"
+                                   :port emacs-mcp-cider-nrepl-port))
+          (message "emacs-mcp-cider: Connected to nREPL on port %d"
+                   emacs-mcp-cider-nrepl-port)
+          t)
+      (error
+       (message "emacs-mcp-cider: Connection failed: %s" (error-message-string err))
+       nil))))
+
+(defun emacs-mcp-cider--auto-connect-tick ()
+  "Timer callback for auto-connect attempts."
+  (setq emacs-mcp-cider--connect-attempts (1+ emacs-mcp-cider--connect-attempts))
+  (cond
+   ;; Already connected - stop trying
+   ((and (featurep 'cider) (cider-connected-p))
+    (emacs-mcp-cider--stop-auto-connect)
+    (message "emacs-mcp-cider: Already connected"))
+   ;; Successfully connected
+   ((emacs-mcp-cider--try-connect)
+    (emacs-mcp-cider--stop-auto-connect))
+   ;; Max retries reached
+   ((and (> emacs-mcp-cider-connect-max-retries 0)
+         (>= emacs-mcp-cider--connect-attempts emacs-mcp-cider-connect-max-retries))
+    (emacs-mcp-cider--stop-auto-connect)
+    (message "emacs-mcp-cider: Auto-connect gave up after %d attempts"
+             emacs-mcp-cider--connect-attempts))))
+
+(defun emacs-mcp-cider--start-auto-connect ()
+  "Start the auto-connect timer."
+  (unless emacs-mcp-cider--connect-timer
+    (setq emacs-mcp-cider--connect-attempts 0)
+    (setq emacs-mcp-cider--connect-timer
+          (run-with-timer emacs-mcp-cider-connect-retry-interval
+                          emacs-mcp-cider-connect-retry-interval
+                          #'emacs-mcp-cider--auto-connect-tick))
+    (message "emacs-mcp-cider: Auto-connect started (checking every %.1fs)"
+             emacs-mcp-cider-connect-retry-interval)))
+
+(defun emacs-mcp-cider--stop-auto-connect ()
+  "Stop the auto-connect timer."
+  (when emacs-mcp-cider--connect-timer
+    (cancel-timer emacs-mcp-cider--connect-timer)
+    (setq emacs-mcp-cider--connect-timer nil)))
+
+;;;###autoload
+(defun emacs-mcp-cider-start-nrepl ()
+  "Start nREPL server and auto-connect CIDER.
+Non-blocking - runs in background."
+  (interactive)
+  (emacs-mcp-cider--start-nrepl-async)
+  (when emacs-mcp-cider-auto-connect
+    (emacs-mcp-cider--start-auto-connect)))
+
+;;;###autoload
+(defun emacs-mcp-cider-auto-connect ()
+  "Start polling for nREPL and connect when available.
+Use this when nREPL is started externally."
+  (interactive)
+  (emacs-mcp-cider--start-auto-connect))
+
+;;;###autoload
+(defun emacs-mcp-cider-stop-nrepl ()
+  "Stop the auto-started nREPL server."
+  (interactive)
+  (emacs-mcp-cider--stop-auto-connect)
+  (when (and emacs-mcp-cider--nrepl-process
+             (process-live-p emacs-mcp-cider--nrepl-process))
+    (kill-process emacs-mcp-cider--nrepl-process)
+    (setq emacs-mcp-cider--nrepl-process nil)
+    (message "emacs-mcp-cider: nREPL server stopped")))
 
 ;;;; Context Functions
 
@@ -171,6 +334,10 @@
 (transient-define-prefix emacs-mcp-cider-transient ()
   "MCP integration menu for CIDER."
   ["emacs-mcp + CIDER"
+   ["nREPL Server"
+    ("n" "Start nREPL (async)" emacs-mcp-cider-start-nrepl)
+    ("N" "Stop nREPL" emacs-mcp-cider-stop-nrepl)
+    ("c" "Auto-connect" emacs-mcp-cider-auto-connect)]
    ["Evaluate"
     ("e" "Eval with context" emacs-mcp-cider-eval-with-context)]
    ["Memory"
@@ -221,6 +388,39 @@ Shows output in REPL buffer for collaborative debugging."
         :repl-type (when (and (featurep 'cider) (boundp 'cider-repl-type))
                      cider-repl-type)))
 
+;;;; Addon Lifecycle Functions
+
+(defun emacs-mcp-cider--addon-init ()
+  "Synchronous init for cider addon.
+Sets up keybindings and loads required features."
+  (require 'emacs-mcp-api nil t)
+  (message "emacs-mcp-cider: initialized"))
+
+(defun emacs-mcp-cider--addon-async-init ()
+  "Asynchronous init for cider addon.
+Starts nREPL server in background if configured.
+Returns the process object for lifecycle tracking."
+  (when emacs-mcp-cider-auto-start-nrepl
+    (emacs-mcp-cider--start-nrepl-async)
+    ;; Register timer with addon system for cleanup
+    (when emacs-mcp-cider-auto-connect
+      (emacs-mcp-cider--start-auto-connect)
+      (when emacs-mcp-cider--connect-timer
+        (when (fboundp 'emacs-mcp-addon-register-timer)
+          (emacs-mcp-addon-register-timer 'cider emacs-mcp-cider--connect-timer))))
+    ;; Return process for lifecycle tracking
+    emacs-mcp-cider--nrepl-process))
+
+(defun emacs-mcp-cider--addon-shutdown ()
+  "Shutdown function for cider addon.
+Stops nREPL server and cleans up timers."
+  (emacs-mcp-cider--stop-auto-connect)
+  (when (and emacs-mcp-cider--nrepl-process
+             (process-live-p emacs-mcp-cider--nrepl-process))
+    (kill-process emacs-mcp-cider--nrepl-process)
+    (setq emacs-mcp-cider--nrepl-process nil))
+  (message "emacs-mcp-cider: shutdown complete"))
+
 ;;;; Minor Mode
 
 ;;;###autoload
@@ -230,26 +430,30 @@ Shows output in REPL buffer for collaborative debugging."
 Provides:
 - Save REPL results to memory
 - Query past solutions
-- Clojure-aware context"
+- Clojure-aware context
+
+Note: nREPL auto-start is handled by addon lifecycle hooks.
+Set `emacs-mcp-cider-auto-start-nrepl' to t and load the addon."
   :init-value nil
   :lighter " MCP-Clj"
   :global t
   :group 'emacs-mcp-cider
   (if emacs-mcp-cider-mode
-      (progn
-        (require 'emacs-mcp-api nil t)
-        (message "emacs-mcp-cider enabled"))
-    (message "emacs-mcp-cider disabled")))
+      (message "emacs-mcp-cider mode enabled")
+    (message "emacs-mcp-cider mode disabled")))
 
 ;;;; Addon Registration
 
 (with-eval-after-load 'emacs-mcp-addons
   (emacs-mcp-addon-register
    'cider
-   :version "0.1.0"
-   :description "Integration with CIDER (Clojure IDE)"
+   :version "0.2.0"
+   :description "Integration with CIDER (Clojure IDE) - async nREPL startup"
    :requires '(cider emacs-mcp-api)
-   :provides '(emacs-mcp-cider-mode emacs-mcp-cider-transient)))
+   :provides '(emacs-mcp-cider-mode emacs-mcp-cider-transient)
+   :init #'emacs-mcp-cider--addon-init
+   :async-init #'emacs-mcp-cider--addon-async-init
+   :shutdown #'emacs-mcp-cider--addon-shutdown))
 
 (provide 'emacs-mcp-cider)
 ;;; emacs-mcp-cider.el ends here

--- a/elisp/addons/emacs-mcp-vibe-kanban.el
+++ b/elisp/addons/emacs-mcp-vibe-kanban.el
@@ -1,0 +1,214 @@
+;;; emacs-mcp-vibe-kanban.el --- Vibe Kanban integration for emacs-mcp -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Pedro G. Branquinho
+;; Author: Pedro G. Branquinho <pedrogbranquinho@gmail.com>
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools, project, kanban
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+;;
+;; This addon integrates vibe-kanban (task management MCP server) with emacs-mcp.
+;;
+;; Vibe Kanban provides a visual kanban board for task management that integrates
+;; with Claude Code and other MCP clients.
+;;
+;; Features:
+;; - Auto-start vibe-kanban server on addon load (async, non-blocking)
+;; - Auto-shutdown when addon is unloaded
+;; - Customizable port and command
+;;
+;; Usage:
+;;   ;; Add to always-load for auto-start on Emacs startup:
+;;   (add-to-list 'emacs-mcp-addon-always-load 'vibe-kanban)
+;;
+;;   ;; Or set auto-start and load manually:
+;;   (setq emacs-mcp-vibe-kanban-auto-start t)
+;;   (emacs-mcp-addon-load 'vibe-kanban)
+;;
+;; Prerequisites:
+;;   npm install -g vibe-kanban
+;;   OR
+;;   npx vibe-kanban (will auto-install)
+
+;;; Code:
+
+(require 'emacs-mcp-api)
+
+;;;; Customization
+
+(defgroup emacs-mcp-vibe-kanban nil
+  "Vibe Kanban integration for emacs-mcp."
+  :group 'emacs-mcp
+  :prefix "emacs-mcp-vibe-kanban-")
+
+(defcustom emacs-mcp-vibe-kanban-auto-start t
+  "When non-nil, automatically start vibe-kanban server on addon load.
+The server starts asynchronously and does not block Emacs startup."
+  :type 'boolean
+  :group 'emacs-mcp-vibe-kanban)
+
+(defcustom emacs-mcp-vibe-kanban-command "npx"
+  "Command to run vibe-kanban.
+Default is `npx' which auto-installs if needed."
+  :type 'string
+  :group 'emacs-mcp-vibe-kanban)
+
+(defcustom emacs-mcp-vibe-kanban-args '("vibe-kanban")
+  "Arguments to pass to the vibe-kanban command."
+  :type '(repeat string)
+  :group 'emacs-mcp-vibe-kanban)
+
+(defcustom emacs-mcp-vibe-kanban-port 3333
+  "Port for vibe-kanban server."
+  :type 'integer
+  :group 'emacs-mcp-vibe-kanban)
+
+(defcustom emacs-mcp-vibe-kanban-project-dir nil
+  "Project directory for vibe-kanban.
+If nil, uses current project root or `default-directory'."
+  :type '(choice (const nil) directory)
+  :group 'emacs-mcp-vibe-kanban)
+
+;;;; Internal Variables
+
+(defvar emacs-mcp-vibe-kanban--process nil
+  "Process object for the vibe-kanban server.")
+
+(defvar emacs-mcp-vibe-kanban--buffer-name "*vibe-kanban*"
+  "Buffer name for vibe-kanban output.")
+
+;;;; Helper Functions
+
+(defun emacs-mcp-vibe-kanban--project-dir ()
+  "Get the project directory for vibe-kanban."
+  (or emacs-mcp-vibe-kanban-project-dir
+      (when (fboundp 'project-root)
+        (when-let* ((proj (project-current)))
+          (project-root proj)))
+      default-directory))
+
+(defun emacs-mcp-vibe-kanban--running-p ()
+  "Return non-nil if vibe-kanban server is running."
+  (and emacs-mcp-vibe-kanban--process
+       (process-live-p emacs-mcp-vibe-kanban--process)))
+
+;;;; Server Control
+
+(defun emacs-mcp-vibe-kanban--start-async ()
+  "Start vibe-kanban server asynchronously.
+Returns the process object."
+  (unless (emacs-mcp-vibe-kanban--running-p)
+    (let* ((default-directory (emacs-mcp-vibe-kanban--project-dir))
+           (buf (get-buffer-create emacs-mcp-vibe-kanban--buffer-name)))
+      (message "emacs-mcp-vibe-kanban: Starting server...")
+      (setq emacs-mcp-vibe-kanban--process
+            (apply #'start-process
+                   "vibe-kanban"
+                   buf
+                   emacs-mcp-vibe-kanban-command
+                   emacs-mcp-vibe-kanban-args))
+      ;; Set up process sentinel for status messages
+      (set-process-sentinel
+       emacs-mcp-vibe-kanban--process
+       (lambda (proc event)
+         (message "emacs-mcp-vibe-kanban: %s" (string-trim event))))
+      emacs-mcp-vibe-kanban--process)))
+
+(defun emacs-mcp-vibe-kanban--stop ()
+  "Stop the vibe-kanban server."
+  (when (emacs-mcp-vibe-kanban--running-p)
+    (kill-process emacs-mcp-vibe-kanban--process)
+    (setq emacs-mcp-vibe-kanban--process nil)
+    (message "emacs-mcp-vibe-kanban: Server stopped")))
+
+;;;; Interactive Commands
+
+;;;###autoload
+(defun emacs-mcp-vibe-kanban-start ()
+  "Start the vibe-kanban server."
+  (interactive)
+  (if (emacs-mcp-vibe-kanban--running-p)
+      (message "emacs-mcp-vibe-kanban: Server already running")
+    (emacs-mcp-vibe-kanban--start-async)))
+
+;;;###autoload
+(defun emacs-mcp-vibe-kanban-stop ()
+  "Stop the vibe-kanban server."
+  (interactive)
+  (emacs-mcp-vibe-kanban--stop))
+
+;;;###autoload
+(defun emacs-mcp-vibe-kanban-restart ()
+  "Restart the vibe-kanban server."
+  (interactive)
+  (emacs-mcp-vibe-kanban--stop)
+  (sit-for 0.5)
+  (emacs-mcp-vibe-kanban--start-async))
+
+;;;###autoload
+(defun emacs-mcp-vibe-kanban-status ()
+  "Show vibe-kanban server status."
+  (interactive)
+  (message "emacs-mcp-vibe-kanban: %s"
+           (if (emacs-mcp-vibe-kanban--running-p)
+               "Running"
+             "Stopped")))
+
+;;;###autoload
+(defun emacs-mcp-vibe-kanban-show-buffer ()
+  "Show the vibe-kanban output buffer."
+  (interactive)
+  (if-let* ((buf (get-buffer emacs-mcp-vibe-kanban--buffer-name)))
+      (display-buffer buf)
+    (message "emacs-mcp-vibe-kanban: No output buffer")))
+
+;;;; Addon Lifecycle Functions
+
+(defun emacs-mcp-vibe-kanban--addon-init ()
+  "Synchronous init for vibe-kanban addon."
+  (require 'emacs-mcp-api nil t)
+  (message "emacs-mcp-vibe-kanban: initialized"))
+
+(defun emacs-mcp-vibe-kanban--addon-async-init ()
+  "Asynchronous init for vibe-kanban addon.
+Starts the server in background if auto-start is enabled.
+Returns the process object for lifecycle tracking."
+  (when emacs-mcp-vibe-kanban-auto-start
+    (emacs-mcp-vibe-kanban--start-async)))
+
+(defun emacs-mcp-vibe-kanban--addon-shutdown ()
+  "Shutdown function for vibe-kanban addon."
+  (emacs-mcp-vibe-kanban--stop)
+  (message "emacs-mcp-vibe-kanban: shutdown complete"))
+
+;;;; Transient Menu
+
+;;;###autoload (autoload 'emacs-mcp-vibe-kanban-transient "emacs-mcp-vibe-kanban" nil t)
+(transient-define-prefix emacs-mcp-vibe-kanban-transient ()
+  "Vibe Kanban control menu."
+  ["Vibe Kanban"
+   ["Server"
+    ("s" "Start" emacs-mcp-vibe-kanban-start)
+    ("S" "Stop" emacs-mcp-vibe-kanban-stop)
+    ("r" "Restart" emacs-mcp-vibe-kanban-restart)
+    ("?" "Status" emacs-mcp-vibe-kanban-status)]
+   ["View"
+    ("b" "Show buffer" emacs-mcp-vibe-kanban-show-buffer)]])
+
+;;;; Addon Registration
+
+(with-eval-after-load 'emacs-mcp-addons
+  (emacs-mcp-addon-register
+   'vibe-kanban
+   :version "0.1.0"
+   :description "Vibe Kanban task management server"
+   :requires '(emacs-mcp-api)
+   :provides '(emacs-mcp-vibe-kanban-transient)
+   :init #'emacs-mcp-vibe-kanban--addon-init
+   :async-init #'emacs-mcp-vibe-kanban--addon-async-init
+   :shutdown #'emacs-mcp-vibe-kanban--addon-shutdown))
+
+(provide 'emacs-mcp-vibe-kanban)
+;;; emacs-mcp-vibe-kanban.el ends here

--- a/elisp/emacs-mcp-addons.el
+++ b/elisp/emacs-mcp-addons.el
@@ -47,7 +47,8 @@
   '((cider . cider)
     (claude-code . claude-code)
     (org-ai . org-ai)
-    (org-kanban . org-kanban))
+    (org-kanban . org-kanban)
+    (vibe-kanban . vibe-kanban))
   "Alist of (ADDON . TRIGGER-FEATURE).
 When TRIGGER-FEATURE is loaded, ADDON will be auto-loaded.
 Addon names correspond to files: emacs-mcp-ADDON.el"
@@ -65,10 +66,19 @@ Example: \\='(cider org-kanban package-lint)"
 
 (defvar emacs-mcp-addon--registry (make-hash-table :test 'eq)
   "Hash table of registered addons.
-Keys are addon symbols, values are plists with :loaded, :version, :description.")
+Keys are addon symbols, values are plists with :loaded, :version, :description,
+:init, :async-init, :shutdown, and runtime state.")
 
 (defvar emacs-mcp-addon--hooks nil
   "Alist of (FEATURE . ADDON) for deferred loading.")
+
+(defvar emacs-mcp-addon--processes (make-hash-table :test 'eq)
+  "Hash table tracking async processes started by addons.
+Keys are addon symbols, values are process objects.")
+
+(defvar emacs-mcp-addon--timers (make-hash-table :test 'eq)
+  "Hash table tracking timers started by addons.
+Keys are addon symbols, values are lists of timer objects.")
 
 ;;;; Core Functions
 
@@ -88,9 +98,85 @@ Keys are addon symbols, values are plists with :loaded, :version, :description."
   "Return non-nil if ADDON is already loaded."
   (plist-get (gethash addon emacs-mcp-addon--registry) :loaded))
 
+(defun emacs-mcp-addon-running-p (addon)
+  "Return non-nil if ADDON has active async processes or timers."
+  (or (when-let* ((proc (gethash addon emacs-mcp-addon--processes)))
+        (process-live-p proc))
+      (when-let* ((timers (gethash addon emacs-mcp-addon--timers)))
+        (cl-some #'timerp timers))))
+
+;;;; Lifecycle Management
+
+(defun emacs-mcp-addon--run-init (addon)
+  "Run the :init function for ADDON if defined."
+  (when-let* ((props (gethash addon emacs-mcp-addon--registry))
+              (init-fn (plist-get props :init)))
+    (condition-case err
+        (progn
+          (funcall init-fn)
+          (message "emacs-mcp addon %s: init completed" addon))
+      (error
+       (message "emacs-mcp addon %s: init failed: %s" addon (error-message-string err))))))
+
+(defun emacs-mcp-addon--run-async-init (addon)
+  "Run the :async-init function for ADDON if defined.
+The async-init function should return a process object or nil."
+  (when-let* ((props (gethash addon emacs-mcp-addon--registry))
+              (async-init-fn (plist-get props :async-init)))
+    (condition-case err
+        (let ((result (funcall async-init-fn)))
+          ;; Track returned process if any
+          (when (processp result)
+            (puthash addon result emacs-mcp-addon--processes))
+          (message "emacs-mcp addon %s: async-init started" addon))
+      (error
+       (message "emacs-mcp addon %s: async-init failed: %s" addon (error-message-string err))))))
+
+(defun emacs-mcp-addon--run-shutdown (addon)
+  "Run the :shutdown function for ADDON if defined."
+  (when-let* ((props (gethash addon emacs-mcp-addon--registry))
+              (shutdown-fn (plist-get props :shutdown)))
+    (condition-case err
+        (progn
+          (funcall shutdown-fn)
+          (message "emacs-mcp addon %s: shutdown completed" addon))
+      (error
+       (message "emacs-mcp addon %s: shutdown failed: %s" addon (error-message-string err))))))
+
+(defun emacs-mcp-addon--cleanup (addon)
+  "Clean up processes and timers for ADDON."
+  ;; Kill process if running
+  (when-let* ((proc (gethash addon emacs-mcp-addon--processes)))
+    (when (process-live-p proc)
+      (kill-process proc))
+    (remhash addon emacs-mcp-addon--processes))
+  ;; Cancel timers
+  (when-let* ((timers (gethash addon emacs-mcp-addon--timers)))
+    (dolist (timer timers)
+      (when (timerp timer)
+        (cancel-timer timer)))
+    (remhash addon emacs-mcp-addon--timers)))
+
+(defun emacs-mcp-addon-register-process (addon process)
+  "Register PROCESS as belonging to ADDON for lifecycle management."
+  (puthash addon process emacs-mcp-addon--processes))
+
+(defun emacs-mcp-addon-register-timer (addon timer)
+  "Register TIMER as belonging to ADDON for lifecycle management."
+  (let ((existing (gethash addon emacs-mcp-addon--timers)))
+    (puthash addon (cons timer existing) emacs-mcp-addon--timers)))
+
+(defun emacs-mcp-addon-unregister-timer (addon timer)
+  "Unregister TIMER from ADDON."
+  (when-let* ((timers (gethash addon emacs-mcp-addon--timers)))
+    (puthash addon (delq timer timers) emacs-mcp-addon--timers)))
+
+;;;; Load/Unload
+
 ;;;###autoload
 (defun emacs-mcp-addon-load (addon)
   "Load ADDON if available and not already loaded.
+After loading, runs :init (sync) then :async-init (non-blocking).
 Returns t if loaded successfully, nil otherwise."
   (interactive
    (list (intern (completing-read "Load addon: "
@@ -106,11 +192,43 @@ Returns t if loaded successfully, nil otherwise."
       (puthash addon (plist-put (gethash addon emacs-mcp-addon--registry)
                                 :loaded t)
                emacs-mcp-addon--registry)
+      ;; Run lifecycle hooks
+      (emacs-mcp-addon--run-init addon)
+      (emacs-mcp-addon--run-async-init addon)
       (message "Loaded emacs-mcp addon: %s" addon)
       t))
    (t
     (message "Addon %s not found" addon)
     nil)))
+
+;;;###autoload
+(defun emacs-mcp-addon-unload (addon)
+  "Unload ADDON, running shutdown hooks and cleaning up resources."
+  (interactive
+   (list (intern (completing-read "Unload addon: "
+                                  (emacs-mcp-addon-list-loaded)
+                                  nil t))))
+  (when (emacs-mcp-addon-loaded-p addon)
+    ;; Run shutdown hook
+    (emacs-mcp-addon--run-shutdown addon)
+    ;; Clean up processes and timers
+    (emacs-mcp-addon--cleanup addon)
+    ;; Mark as unloaded
+    (puthash addon (plist-put (gethash addon emacs-mcp-addon--registry)
+                              :loaded nil)
+             emacs-mcp-addon--registry)
+    (message "Unloaded emacs-mcp addon: %s" addon)
+    t))
+
+;;;###autoload
+(defun emacs-mcp-addon-restart (addon)
+  "Restart ADDON by unloading and reloading it."
+  (interactive
+   (list (intern (completing-read "Restart addon: "
+                                  (emacs-mcp-addon-list-loaded)
+                                  nil t))))
+  (emacs-mcp-addon-unload addon)
+  (emacs-mcp-addon-load addon))
 
 (defun emacs-mcp-addon-list-available ()
   "Return list of available addon symbols."
@@ -177,10 +295,33 @@ This is the main entry point, called from `emacs-mcp-initialize'."
 (defun emacs-mcp-addon-register (addon &rest props)
   "Register ADDON with PROPS.
 PROPS is a plist that may contain:
+
+Metadata:
   :version     - Version string
   :description - One-line description
   :requires    - List of required features
-  :provides    - List of provided features/commands"
+  :provides    - List of provided features/commands
+
+Lifecycle hooks:
+  :init        - Function to run synchronously after loading.
+                 Use for lightweight setup that must complete before use.
+
+  :async-init  - Function to run asynchronously after loading.
+                 Should return a process object if starting a subprocess.
+                 Use for long-running startup (e.g., starting nREPL, npx).
+                 Non-blocking - does not delay Emacs startup.
+
+  :shutdown    - Function to run when unloading the addon.
+                 Use for cleanup (stopping servers, saving state).
+
+Example:
+  (emacs-mcp-addon-register
+   \\='my-addon
+   :version \"1.0.0\"
+   :description \"My cool addon\"
+   :init #\\='my-addon-setup-keybindings
+   :async-init #\\='my-addon-start-server
+   :shutdown #\\='my-addon-stop-server)"
   (puthash addon props emacs-mcp-addon--registry))
 
 ;;;; Info command
@@ -195,14 +336,25 @@ PROPS is a plist that may contain:
       (insert "=== emacs-mcp Addons ===\n\n")
       (insert "Available addons:\n")
       (dolist (addon (emacs-mcp-addon-list-available))
-        (let ((loaded (emacs-mcp-addon-loaded-p addon))
-              (props (gethash addon emacs-mcp-addon--registry)))
-          (insert (format "  %s %s\n"
+        (let* ((loaded (emacs-mcp-addon-loaded-p addon))
+               (running (emacs-mcp-addon-running-p addon))
+               (props (gethash addon emacs-mcp-addon--registry))
+               (has-init (plist-get props :init))
+               (has-async (plist-get props :async-init))
+               (has-shutdown (plist-get props :shutdown)))
+          (insert (format "  %s%s %s\n"
                           (if loaded "[loaded]" "[      ]")
+                          (if running "*" " ")
                           addon))
           (when-let* ((desc (plist-get props :description)))
-            (insert (format "           %s\n" desc)))))
+            (insert (format "           %s\n" desc)))
+          (when (or has-init has-async has-shutdown)
+            (insert (format "           lifecycle: %s%s%s\n"
+                            (if has-init "init " "")
+                            (if has-async "async-init " "")
+                            (if has-shutdown "shutdown" ""))))))
       (insert "\n")
+      (insert "Legend: [loaded] = loaded, * = has running process/timer\n\n")
       (insert "Addon directories:\n")
       (dolist (dir emacs-mcp-addon-directories)
         (insert (format "  %s\n" dir)))


### PR DESCRIPTION
## Summary

Adds a standardized lifecycle system for addons with three hooks:
- `:init` - Synchronous init (keybindings, lightweight setup)
- `:async-init` - Async init for non-blocking startup (servers, subprocesses)
- `:shutdown` - Cleanup when addon is unloaded

## Motivation

Different addons need different startup behaviors:
- **cider addon**: Start nREPL server asynchronously, auto-connect CIDER
- **vibe-kanban addon**: Start `npx vibe-kanban` task server
- **Other addons**: May need external services, daemons, etc.

This provides a consistent pattern without blocking Emacs startup.

## New Features

### Lifecycle Hooks
```elisp
(emacs-mcp-addon-register
 'my-addon
 :version "1.0.0"
 :description "My addon"
 :init #'my-addon-setup           ; sync setup
 :async-init #'my-addon-start-server  ; returns process
 :shutdown #'my-addon-cleanup)
```

### Addon Management
- `M-x emacs-mcp-addon-unload` - Cleanly unload with shutdown hook
- `M-x emacs-mcp-addon-restart` - Unload and reload
- `emacs-mcp-addon-running-p` - Check for active processes/timers

### Process/Timer Tracking
```elisp
;; In async-init, processes are auto-tracked if returned
;; Timers can be registered manually:
(emacs-mcp-addon-register-timer 'my-addon my-timer)
```

## Updated Addons

### emacs-mcp-cider
- Now uses lifecycle for async nREPL startup
- Auto-connects CIDER when nREPL becomes available
- Non-blocking Emacs startup

### emacs-mcp-vibe-kanban (NEW)
- Starts `npx vibe-kanban` task management server
- Example of async subprocess pattern

## Usage

```elisp
;; Enable auto-start for cider
(setq emacs-mcp-cider-auto-start-nrepl t)
(add-to-list 'emacs-mcp-addon-always-load 'cider)

;; Enable vibe-kanban
(add-to-list 'emacs-mcp-addon-always-load 'vibe-kanban)
```

## Test Plan
- [ ] Load addon with :async-init, verify non-blocking
- [ ] Unload addon, verify shutdown hook runs
- [ ] Verify process cleanup on unload
- [ ] Test emacs-mcp-addon-info shows lifecycle info

🤖 Generated with [Claude Code](https://claude.com/claude-code)