### PR TITLE
feat(org-clj): Add native Clojure org-mode parser library

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,10 @@
 
         ;; Logging - Timbre with SLF4J bridge
         com.taoensso/timbre {:mvn/version "6.8.0"}
-        com.fzakaria/slf4j-timbre {:mvn/version "0.4.1"}}
+        com.fzakaria/slf4j-timbre {:mvn/version "0.4.1"}
+
+        ;; Schema validation for org-clj
+        metosin/malli {:mvn/version "0.16.4"}}
 
  :aliases
  {:mcp

--- a/elisp/addons/emacs-mcp-addon-template.el
+++ b/elisp/addons/emacs-mcp-addon-template.el
@@ -31,7 +31,7 @@
 ;; Soft dependency - don't error if target package isn't installed
 (declare-function target-package-function "target-package")
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-template nil
   "Integration between emacs-mcp and target-package."
@@ -43,7 +43,7 @@
   :type 'boolean
   :group 'emacs-mcp-template)
 
-;;;; Internal
+;;;; Internal:
 
 (defvar emacs-mcp-template--initialized nil
   "Whether the addon has been initialized.")
@@ -54,7 +54,7 @@
     (require 'emacs-mcp-api nil t))
   (featurep 'emacs-mcp-api))
 
-;;;; Public API
+;;;; Public API:
 
 ;;;###autoload
 (defun emacs-mcp-template-get-context ()
@@ -81,7 +81,7 @@
   (when (emacs-mcp-template--ensure-api)
     (emacs-mcp-api-memory-query type nil (or limit 10))))
 
-;;;; Integration hooks (customize these for your target package)
+;;;; Integration hooks (customize these for your target package):
 
 ;; Example: Advice to add context to a target function
 ;; (defun emacs-mcp-template--add-context-advice (orig-fun &rest args)
@@ -101,7 +101,7 @@
 ;;      "note"
 ;;      '("auto-logged"))))
 
-;;;; Minor mode (optional)
+;;;; Minor mode (optional):
 
 ;;;###autoload
 (define-minor-mode emacs-mcp-template-mode
@@ -120,7 +120,7 @@
     ;; (advice-remove 'target-function #'emacs-mcp-template--add-context-advice)
     (message "emacs-mcp-template disabled")))
 
-;;;; Transient menu (optional, requires transient.el)
+;;;; Transient menu (optional, requires transient.el):
 
 ;; (transient-define-prefix emacs-mcp-template-transient ()
 ;;   "MCP integration menu for target-package."
@@ -131,7 +131,7 @@
 ;;    ["Query"
 ;;     ("q" "Query memory" emacs-mcp-template-query-memory)]])
 
-;;;; Addon Lifecycle Functions (NEW - recommended approach)
+;;;; Addon Lifecycle Functions (NEW - recommended approach):
 
 ;; These functions are called automatically by the addon system:
 
@@ -157,7 +157,7 @@ Use for cleanup (stopping servers, saving state)."
   ;; Example: stop server, save state
   (message "emacs-mcp-template: shutdown complete"))
 
-;;;; Registration
+;;;; Registration:
 
 ;; Register this addon with emacs-mcp
 (with-eval-after-load 'emacs-mcp-addons

--- a/elisp/addons/emacs-mcp-cider.el
+++ b/elisp/addons/emacs-mcp-cider.el
@@ -44,7 +44,7 @@
 (declare-function cider-connected-p "cider-connection")
 (declare-function cider-repl-buffers "cider-connection")
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-cider nil
   "Integration between CIDER and emacs-mcp."
@@ -95,7 +95,7 @@ If nil, uses the current project root or `default-directory'."
   :type 'integer
   :group 'emacs-mcp-cider)
 
-;;;; Internal
+;;;; Internal:
 
 (defvar emacs-mcp-cider--last-eval nil
   "Last evaluated expression and result for potential saving.")
@@ -109,7 +109,7 @@ If nil, uses the current project root or `default-directory'."
 (defvar emacs-mcp-cider--connect-attempts 0
   "Number of connection attempts made.")
 
-;;;; Async nREPL Start & Auto-Connect
+;;;; Async nREPL Start & Auto-Connect:
 
 (defun emacs-mcp-cider--project-dir ()
   "Get the project directory for nREPL."
@@ -221,7 +221,7 @@ Use this when nREPL is started externally."
     (setq emacs-mcp-cider--nrepl-process nil)
     (message "emacs-mcp-cider: nREPL server stopped")))
 
-;;;; Context Functions
+;;;; Context Functions:
 
 (defun emacs-mcp-cider--get-clojure-context ()
   "Get Clojure-specific context for MCP."
@@ -235,7 +235,7 @@ Use this when nREPL is started externally."
                 :repl-type (when (boundp 'cider-repl-type)
                              cider-repl-type)))))
 
-;;;; Memory Integration
+;;;; Memory Integration:
 
 ;;;###autoload
 (defun emacs-mcp-cider-save-last-result ()
@@ -295,7 +295,7 @@ Use this when nREPL is started externally."
       (goto-char (point-min)))
     (display-buffer buf)))
 
-;;;; Eval with Context
+;;;; Eval with Context:
 
 ;;;###autoload
 (defun emacs-mcp-cider-eval-with-context ()
@@ -314,10 +314,10 @@ Use this when nREPL is started externally."
                   :context ctx))
       (cider-interactive-eval expr))))
 
-;;;; Advice for auto-logging
+;;;; Advice for auto-logging:
 
 (defun emacs-mcp-cider--after-eval-advice (orig-fun &rest args)
-  "Advice to capture eval results for potential saving."
+  "Advice around ORIG-FUN with ARGS to capture eval results for saving."
   (let ((result (apply orig-fun args)))
     (when (and emacs-mcp-cider-auto-log-results
                result
@@ -328,7 +328,7 @@ Use this when nREPL is started externally."
                   :ns (when (fboundp 'cider-current-ns) (cider-current-ns)))))
     result))
 
-;;;; Transient Menu
+;;;; Transient Menu:
 
 ;;;###autoload (autoload 'emacs-mcp-cider-transient "emacs-mcp-cider" nil t)
 (transient-define-prefix emacs-mcp-cider-transient ()
@@ -353,7 +353,7 @@ Use this when nREPL is started externally."
   (setq emacs-mcp-cider-auto-log-results (not emacs-mcp-cider-auto-log-results))
   (message "Auto-log %s" (if emacs-mcp-cider-auto-log-results "enabled" "disabled")))
 
-;;;; MCP Tool API Functions
+;;;; MCP Tool API Functions:
 ;; These functions are called by the emacs-mcp Clojure server as MCP tools
 
 ;;;###autoload
@@ -388,7 +388,7 @@ Shows output in REPL buffer for collaborative debugging."
         :repl-type (when (and (featurep 'cider) (boundp 'cider-repl-type))
                      cider-repl-type)))
 
-;;;; Addon Lifecycle Functions
+;;;; Addon Lifecycle Functions:
 
 (defun emacs-mcp-cider--addon-init ()
   "Synchronous init for cider addon.
@@ -421,7 +421,7 @@ Stops nREPL server and cleans up timers."
     (setq emacs-mcp-cider--nrepl-process nil))
   (message "emacs-mcp-cider: shutdown complete"))
 
-;;;; Minor Mode
+;;;; Minor Mode:
 
 ;;;###autoload
 (define-minor-mode emacs-mcp-cider-mode
@@ -442,7 +442,7 @@ Set `emacs-mcp-cider-auto-start-nrepl' to t and load the addon."
       (message "emacs-mcp-cider mode enabled")
     (message "emacs-mcp-cider mode disabled")))
 
-;;;; Addon Registration
+;;;; Addon Registration:
 
 (with-eval-after-load 'emacs-mcp-addons
   (emacs-mcp-addon-register

--- a/elisp/addons/emacs-mcp-claude-code.el
+++ b/elisp/addons/emacs-mcp-claude-code.el
@@ -38,7 +38,7 @@
 (declare-function emacs-mcp-api-conversation-log "emacs-mcp-api")
 (declare-function emacs-mcp-api-capabilities "emacs-mcp-api")
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-claude-code nil
   "Integration between claude-code.el and emacs-mcp."
@@ -72,12 +72,12 @@ This enables persistent conversation history per project."
   :type 'boolean
   :group 'emacs-mcp-claude-code)
 
-;;;; Internal State
+;;;; Internal State:
 
 (defvar emacs-mcp-claude-code--available nil
   "Cached check for whether emacs-mcp-api is available.")
 
-;;;; Utility Functions
+;;;; Utility Functions:
 
 (defun emacs-mcp-claude-code--available-p ()
   "Check if emacs-mcp-api is available."
@@ -90,7 +90,7 @@ This enables persistent conversation history per project."
   (unless (emacs-mcp-claude-code--available-p)
     (if (require 'emacs-mcp-api nil t)
         (setq emacs-mcp-claude-code--available t)
-      (error "emacs-mcp-api not available. Load emacs-mcp first"))))
+      (error "Emacs-mcp-api not available.  Load emacs-mcp first"))))
 
 (defun emacs-mcp-claude-code--format-context-compact (ctx)
   "Format CTX as compact one-line summary."
@@ -146,7 +146,7 @@ This enables persistent conversation history per project."
         ('full (json-encode ctx))
         ('smart (emacs-mcp-claude-code--format-context-smart ctx))))))
 
-;;;; Integration Commands
+;;;; Integration Commands:
 
 ;;;###autoload
 (defun emacs-mcp-claude-code-send-with-context ()
@@ -218,10 +218,10 @@ This enables persistent conversation history per project."
   (interactive)
   (if (emacs-mcp-claude-code--available-p)
       (let ((caps (emacs-mcp-api-capabilities)))
-        (message "emacs-mcp v%s: %s"
+        (message "Emacs-mcp v%s: %s"
                  (plist-get caps :version)
                  (mapconcat #'symbol-name (plist-get caps :capabilities) ", ")))
-    (message "emacs-mcp is not loaded")))
+    (message "Emacs-mcp is not loaded")))
 
 ;;;###autoload
 (defun emacs-mcp-claude-code-get-context ()
@@ -241,7 +241,7 @@ This enables persistent conversation history per project."
       (when (fboundp 'json-mode) (json-mode)))
     (display-buffer buf)))
 
-;;;; Transient Menu
+;;;; Transient Menu:
 
 ;;;###autoload (autoload 'emacs-mcp-claude-code-transient "emacs-mcp-claude-code" nil t)
 (transient-define-prefix emacs-mcp-claude-code-transient ()
@@ -259,7 +259,7 @@ This enables persistent conversation history per project."
     ("C" "Toggle auto-context" emacs-mcp-claude-code-toggle-auto-context)
     ("L" "Toggle conversation logging" emacs-mcp-claude-code-toggle-logging)]])
 
-;;;; Toggle Commands
+;;;; Toggle Commands:
 
 (defun emacs-mcp-claude-code-toggle-auto-context ()
   "Toggle automatic context injection."
@@ -273,7 +273,7 @@ This enables persistent conversation history per project."
   (setq emacs-mcp-claude-code-log-conversations (not emacs-mcp-claude-code-log-conversations))
   (message "Conversation logging %s" (if emacs-mcp-claude-code-log-conversations "enabled" "disabled")))
 
-;;;; Hooks and Advice
+;;;; Hooks and Advice:
 
 (defun emacs-mcp-claude-code--maybe-add-context (cmd)
   "Maybe add context to CMD if auto-context is enabled."
@@ -301,7 +301,7 @@ TITLE and MESSAGE are passed to the notification."
     ;; Fall back to default
     (claude-code-default-notification title message)))
 
-;;;; Advice Functions
+;;;; Advice Functions:
 
 (defun emacs-mcp-claude-code--advise-send-command (orig-fun cmd)
   "Advice for `claude-code--do-send-command' to add context and logging.
@@ -310,7 +310,7 @@ ORIG-FUN is the original function, CMD is the command."
     (emacs-mcp-claude-code--log-command cmd)
     (funcall orig-fun enhanced-cmd)))
 
-;;;; Keymap Extensions
+;;;; Keymap Extensions:
 
 (defvar emacs-mcp-claude-code-command-map
   (let ((map (make-sparse-keymap)))
@@ -323,7 +323,7 @@ ORIG-FUN is the original function, CMD is the command."
     map)
   "Keymap for emacs-mcp-claude-code commands.")
 
-;;;; Minor Mode
+;;;; Minor Mode:
 
 ;;;###autoload
 (define-minor-mode emacs-mcp-claude-code-mode
@@ -349,13 +349,13 @@ Key bindings under `C-c c m' prefix (customizable)."
         (require 'emacs-mcp-api nil t)
         ;; Extend claude-code command map
         (define-key claude-code-command-map (kbd "M") #'emacs-mcp-claude-code-transient)
-        (message "emacs-mcp-claude-code enabled"))
+        (message "Emacs-mcp-claude-code enabled"))
     ;; Remove advice
     (advice-remove 'claude-code--do-send-command
                    #'emacs-mcp-claude-code--advise-send-command)
-    (message "emacs-mcp-claude-code disabled")))
+    (message "Emacs-mcp-claude-code disabled")))
 
-;;;; Addon Registration
+;;;; Addon Registration:
 
 (eval-after-load 'emacs-mcp-addons
   '(emacs-mcp-addon-register

--- a/elisp/addons/emacs-mcp-claude-code.el
+++ b/elisp/addons/emacs-mcp-claude-code.el
@@ -18,8 +18,8 @@
 ;; - Auto-logging of conversations to project memory
 ;;
 ;; Usage:
-;;   (require 'claude-code-mcp)
-;;   (claude-code-mcp-mode 1)
+;;   (require 'emacs-mcp-claude-code)
+;;   (emacs-mcp-claude-code-mode 1)
 ;;
 ;; This adds emacs-mcp integration to claude-code.el without modifying
 ;; the original package.
@@ -40,24 +40,24 @@
 
 ;;;; Customization
 
-(defgroup claude-code-mcp nil
+(defgroup emacs-mcp-claude-code nil
   "Integration between claude-code.el and emacs-mcp."
   :group 'claude-code
-  :prefix "claude-code-mcp-")
+  :prefix "emacs-mcp-claude-code-")
 
-(defcustom claude-code-mcp-auto-context nil
+(defcustom emacs-mcp-claude-code-auto-context nil
   "When non-nil, automatically include MCP context in commands.
 Context includes buffer info, project, git status, and relevant memory."
   :type 'boolean
-  :group 'claude-code-mcp)
+  :group 'emacs-mcp-claude-code)
 
-(defcustom claude-code-mcp-log-conversations nil
+(defcustom emacs-mcp-claude-code-log-conversations nil
   "When non-nil, log conversations to emacs-mcp memory.
 This enables persistent conversation history per project."
   :type 'boolean
-  :group 'claude-code-mcp)
+  :group 'emacs-mcp-claude-code)
 
-(defcustom claude-code-mcp-context-format 'compact
+(defcustom emacs-mcp-claude-code-context-format 'compact
   "Format for context injection.
 - `compact': Single line summary
 - `full': Complete context JSON
@@ -65,34 +65,34 @@ This enables persistent conversation history per project."
   :type '(choice (const :tag "Compact summary" compact)
                  (const :tag "Full JSON context" full)
                  (const :tag "Smart selection" smart))
-  :group 'claude-code-mcp)
+  :group 'emacs-mcp-claude-code)
 
-(defcustom claude-code-mcp-notify-on-complete t
+(defcustom emacs-mcp-claude-code-notify-on-complete t
   "When non-nil, use emacs-mcp notifications when Claude completes."
   :type 'boolean
-  :group 'claude-code-mcp)
+  :group 'emacs-mcp-claude-code)
 
 ;;;; Internal State
 
-(defvar claude-code-mcp--available nil
+(defvar emacs-mcp-claude-code--available nil
   "Cached check for whether emacs-mcp-api is available.")
 
 ;;;; Utility Functions
 
-(defun claude-code-mcp--available-p ()
+(defun emacs-mcp-claude-code--available-p ()
   "Check if emacs-mcp-api is available."
-  (or claude-code-mcp--available
-      (setq claude-code-mcp--available
+  (or emacs-mcp-claude-code--available
+      (setq emacs-mcp-claude-code--available
             (featurep 'emacs-mcp-api))))
 
-(defun claude-code-mcp--ensure-available ()
+(defun emacs-mcp-claude-code--ensure-available ()
   "Ensure emacs-mcp is available, error if not."
-  (unless (claude-code-mcp--available-p)
+  (unless (emacs-mcp-claude-code--available-p)
     (if (require 'emacs-mcp-api nil t)
-        (setq claude-code-mcp--available t)
+        (setq emacs-mcp-claude-code--available t)
       (error "emacs-mcp-api not available. Load emacs-mcp first"))))
 
-(defun claude-code-mcp--format-context-compact (ctx)
+(defun emacs-mcp-claude-code--format-context-compact (ctx)
   "Format CTX as compact one-line summary."
   (let ((buffer (plist-get ctx :buffer))
         (project (plist-get ctx :project))
@@ -102,7 +102,7 @@ This enables persistent conversation history per project."
             (or (plist-get project :name) "no-project")
             (if (plist-get git :dirty) " (modified)" ""))))
 
-(defun claude-code-mcp--format-context-smart (ctx)
+(defun emacs-mcp-claude-code--format-context-smart (ctx)
   "Format CTX with only relevant sections."
   (let ((parts '())
         (buffer (plist-get ctx :buffer))
@@ -137,23 +137,23 @@ This enables persistent conversation history per project."
           (push (format "Recent notes: %d" (length notes)) parts))))
     (string-join (nreverse parts) "\n")))
 
-(defun claude-code-mcp--get-context-string ()
-  "Get context string based on `claude-code-mcp-context-format'."
-  (when (claude-code-mcp--available-p)
+(defun emacs-mcp-claude-code--get-context-string ()
+  "Get context string based on `emacs-mcp-claude-code-context-format'."
+  (when (emacs-mcp-claude-code--available-p)
     (let ((ctx (emacs-mcp-api-get-context)))
-      (pcase claude-code-mcp-context-format
-        ('compact (claude-code-mcp--format-context-compact ctx))
+      (pcase emacs-mcp-claude-code-context-format
+        ('compact (emacs-mcp-claude-code--format-context-compact ctx))
         ('full (json-encode ctx))
-        ('smart (claude-code-mcp--format-context-smart ctx))))))
+        ('smart (emacs-mcp-claude-code--format-context-smart ctx))))))
 
 ;;;; Integration Commands
 
 ;;;###autoload
-(defun claude-code-mcp-send-with-context ()
+(defun emacs-mcp-claude-code-send-with-context ()
   "Read command and send to Claude with emacs-mcp context."
   (interactive)
-  (claude-code-mcp--ensure-available)
-  (let* ((ctx-string (claude-code-mcp--get-context-string))
+  (emacs-mcp-claude-code--ensure-available)
+  (let* ((ctx-string (emacs-mcp-claude-code--get-context-string))
          (cmd (read-string "Claude command: " nil 'claude-code-command-history))
          (full-cmd (if ctx-string
                        (format "%s\n\nContext:\n%s" cmd ctx-string)
@@ -161,10 +161,10 @@ This enables persistent conversation history per project."
     (claude-code--do-send-command full-cmd)))
 
 ;;;###autoload
-(defun claude-code-mcp-save-to-memory ()
+(defun emacs-mcp-claude-code-save-to-memory ()
   "Save selected text or prompt to project memory."
   (interactive)
-  (claude-code-mcp--ensure-available)
+  (emacs-mcp-claude-code--ensure-available)
   (let* ((text (if (use-region-p)
                    (buffer-substring-no-properties (region-beginning) (region-end))
                  (read-string "Note content: ")))
@@ -174,10 +174,10 @@ This enables persistent conversation history per project."
     (message "Saved to project memory as %s" type)))
 
 ;;;###autoload
-(defun claude-code-mcp-query-memory ()
+(defun emacs-mcp-claude-code-query-memory ()
   "Query project memory and display results."
   (interactive)
-  (claude-code-mcp--ensure-available)
+  (emacs-mcp-claude-code--ensure-available)
   (let* ((type (completing-read "Query type: "
                                 '("note" "snippet" "convention" "decision" "conversation")
                                 nil t "note"))
@@ -202,10 +202,10 @@ This enables persistent conversation history per project."
     (display-buffer buf)))
 
 ;;;###autoload
-(defun claude-code-mcp-run-workflow ()
+(defun emacs-mcp-claude-code-run-workflow ()
   "Select and run an emacs-mcp workflow."
   (interactive)
-  (claude-code-mcp--ensure-available)
+  (emacs-mcp-claude-code--ensure-available)
   (let* ((workflows (emacs-mcp-api-list-workflows))
          (names (mapcar (lambda (w) (alist-get 'name w)) workflows))
          (selected (completing-read "Run workflow: " names nil t)))
@@ -213,10 +213,10 @@ This enables persistent conversation history per project."
     (message "Workflow '%s' executed" selected)))
 
 ;;;###autoload
-(defun claude-code-mcp-show-capabilities ()
+(defun emacs-mcp-claude-code-show-capabilities ()
   "Show emacs-mcp capabilities and status."
   (interactive)
-  (if (claude-code-mcp--available-p)
+  (if (emacs-mcp-claude-code--available-p)
       (let ((caps (emacs-mcp-api-capabilities)))
         (message "emacs-mcp v%s: %s"
                  (plist-get caps :version)
@@ -224,12 +224,12 @@ This enables persistent conversation history per project."
     (message "emacs-mcp is not loaded")))
 
 ;;;###autoload
-(defun claude-code-mcp-get-context ()
+(defun emacs-mcp-claude-code-get-context ()
   "Get and display current emacs-mcp context."
   (interactive)
-  (claude-code-mcp--ensure-available)
+  (emacs-mcp-claude-code--ensure-available)
   (let* ((ctx (emacs-mcp-api-get-context))
-         (formatted (claude-code-mcp--format-context-smart ctx))
+         (formatted (emacs-mcp-claude-code--format-context-smart ctx))
          (buf (get-buffer-create "*MCP Context*")))
     (with-current-buffer buf
       (erase-buffer)
@@ -243,90 +243,90 @@ This enables persistent conversation history per project."
 
 ;;;; Transient Menu
 
-;;;###autoload (autoload 'claude-code-mcp-transient "claude-code-mcp" nil t)
-(transient-define-prefix claude-code-mcp-transient ()
+;;;###autoload (autoload 'emacs-mcp-claude-code-transient "emacs-mcp-claude-code" nil t)
+(transient-define-prefix emacs-mcp-claude-code-transient ()
   "MCP integration menu for Claude Code."
   ["emacs-mcp Integration"
    ["Context & Memory"
-    ("c" "Show context" claude-code-mcp-get-context)
-    ("s" "Send with context" claude-code-mcp-send-with-context)
-    ("m" "Save to memory" claude-code-mcp-save-to-memory)
-    ("q" "Query memory" claude-code-mcp-query-memory)]
+    ("c" "Show context" emacs-mcp-claude-code-get-context)
+    ("s" "Send with context" emacs-mcp-claude-code-send-with-context)
+    ("m" "Save to memory" emacs-mcp-claude-code-save-to-memory)
+    ("q" "Query memory" emacs-mcp-claude-code-query-memory)]
    ["Workflows & Status"
-    ("w" "Run workflow" claude-code-mcp-run-workflow)
-    ("?" "Show capabilities" claude-code-mcp-show-capabilities)]
+    ("w" "Run workflow" emacs-mcp-claude-code-run-workflow)
+    ("?" "Show capabilities" emacs-mcp-claude-code-show-capabilities)]
    ["Settings"
-    ("C" "Toggle auto-context" claude-code-mcp-toggle-auto-context)
-    ("L" "Toggle conversation logging" claude-code-mcp-toggle-logging)]])
+    ("C" "Toggle auto-context" emacs-mcp-claude-code-toggle-auto-context)
+    ("L" "Toggle conversation logging" emacs-mcp-claude-code-toggle-logging)]])
 
 ;;;; Toggle Commands
 
-(defun claude-code-mcp-toggle-auto-context ()
+(defun emacs-mcp-claude-code-toggle-auto-context ()
   "Toggle automatic context injection."
   (interactive)
-  (setq claude-code-mcp-auto-context (not claude-code-mcp-auto-context))
-  (message "Auto-context %s" (if claude-code-mcp-auto-context "enabled" "disabled")))
+  (setq emacs-mcp-claude-code-auto-context (not emacs-mcp-claude-code-auto-context))
+  (message "Auto-context %s" (if emacs-mcp-claude-code-auto-context "enabled" "disabled")))
 
-(defun claude-code-mcp-toggle-logging ()
+(defun emacs-mcp-claude-code-toggle-logging ()
   "Toggle conversation logging."
   (interactive)
-  (setq claude-code-mcp-log-conversations (not claude-code-mcp-log-conversations))
-  (message "Conversation logging %s" (if claude-code-mcp-log-conversations "enabled" "disabled")))
+  (setq emacs-mcp-claude-code-log-conversations (not emacs-mcp-claude-code-log-conversations))
+  (message "Conversation logging %s" (if emacs-mcp-claude-code-log-conversations "enabled" "disabled")))
 
 ;;;; Hooks and Advice
 
-(defun claude-code-mcp--maybe-add-context (cmd)
+(defun emacs-mcp-claude-code--maybe-add-context (cmd)
   "Maybe add context to CMD if auto-context is enabled."
-  (if (and claude-code-mcp-auto-context
-           (claude-code-mcp--available-p))
-      (let ((ctx (claude-code-mcp--get-context-string)))
+  (if (and emacs-mcp-claude-code-auto-context
+           (emacs-mcp-claude-code--available-p))
+      (let ((ctx (emacs-mcp-claude-code--get-context-string)))
         (if ctx
             (format "%s\n\n[Context: %s]" cmd ctx)
           cmd))
     cmd))
 
-(defun claude-code-mcp--log-command (cmd)
+(defun emacs-mcp-claude-code--log-command (cmd)
   "Log CMD to conversation memory if logging is enabled."
-  (when (and claude-code-mcp-log-conversations
-             (claude-code-mcp--available-p))
+  (when (and emacs-mcp-claude-code-log-conversations
+             (emacs-mcp-claude-code--available-p))
     (ignore-errors
       (emacs-mcp-api-conversation-log "user" cmd))))
 
-(defun claude-code-mcp--notification-function (title message)
+(defun emacs-mcp-claude-code--notification-function (title message)
   "Use emacs-mcp for notifications if available.
 TITLE and MESSAGE are passed to the notification."
-  (if (and claude-code-mcp-notify-on-complete
-           (claude-code-mcp--available-p))
+  (if (and emacs-mcp-claude-code-notify-on-complete
+           (emacs-mcp-claude-code--available-p))
       (emacs-mcp-api-notify (format "%s: %s" title message) "info")
     ;; Fall back to default
     (claude-code-default-notification title message)))
 
 ;;;; Advice Functions
 
-(defun claude-code-mcp--advise-send-command (orig-fun cmd)
+(defun emacs-mcp-claude-code--advise-send-command (orig-fun cmd)
   "Advice for `claude-code--do-send-command' to add context and logging.
 ORIG-FUN is the original function, CMD is the command."
-  (let ((enhanced-cmd (claude-code-mcp--maybe-add-context cmd)))
-    (claude-code-mcp--log-command cmd)
+  (let ((enhanced-cmd (emacs-mcp-claude-code--maybe-add-context cmd)))
+    (emacs-mcp-claude-code--log-command cmd)
     (funcall orig-fun enhanced-cmd)))
 
 ;;;; Keymap Extensions
 
-(defvar claude-code-mcp-command-map
+(defvar emacs-mcp-claude-code-command-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "c") 'claude-code-mcp-get-context)
-    (define-key map (kbd "s") 'claude-code-mcp-send-with-context)
-    (define-key map (kbd "m") 'claude-code-mcp-save-to-memory)
-    (define-key map (kbd "q") 'claude-code-mcp-query-memory)
-    (define-key map (kbd "w") 'claude-code-mcp-run-workflow)
-    (define-key map (kbd "M") 'claude-code-mcp-transient)
+    (define-key map (kbd "c") #'emacs-mcp-claude-code-get-context)
+    (define-key map (kbd "s") #'emacs-mcp-claude-code-send-with-context)
+    (define-key map (kbd "m") #'emacs-mcp-claude-code-save-to-memory)
+    (define-key map (kbd "q") #'emacs-mcp-claude-code-query-memory)
+    (define-key map (kbd "w") #'emacs-mcp-claude-code-run-workflow)
+    (define-key map (kbd "M") #'emacs-mcp-claude-code-transient)
     map)
-  "Keymap for claude-code-mcp commands.")
+  "Keymap for emacs-mcp-claude-code commands.")
 
 ;;;; Minor Mode
 
 ;;;###autoload
-(define-minor-mode claude-code-mcp-mode
+(define-minor-mode emacs-mcp-claude-code-mode
   "Minor mode for emacs-mcp integration with claude-code.el.
 
 When enabled, provides:
@@ -339,31 +339,31 @@ Key bindings under `C-c c m' prefix (customizable)."
   :init-value nil
   :lighter " MCP"
   :global t
-  :group 'claude-code-mcp
-  (if claude-code-mcp-mode
+  :group 'emacs-mcp-claude-code
+  (if emacs-mcp-claude-code-mode
       (progn
         ;; Add advice for context injection
         (advice-add 'claude-code--do-send-command :around
-                    #'claude-code-mcp--advise-send-command)
+                    #'emacs-mcp-claude-code--advise-send-command)
         ;; Try to load emacs-mcp-api
         (require 'emacs-mcp-api nil t)
         ;; Extend claude-code command map
-        (define-key claude-code-command-map (kbd "M") 'claude-code-mcp-transient)
-        (message "claude-code-mcp enabled"))
+        (define-key claude-code-command-map (kbd "M") #'emacs-mcp-claude-code-transient)
+        (message "emacs-mcp-claude-code enabled"))
     ;; Remove advice
     (advice-remove 'claude-code--do-send-command
-                   #'claude-code-mcp--advise-send-command)
-    (message "claude-code-mcp disabled")))
+                   #'emacs-mcp-claude-code--advise-send-command)
+    (message "emacs-mcp-claude-code disabled")))
 
 ;;;; Addon Registration
 
-(with-eval-after-load 'emacs-mcp-addons
-  (emacs-mcp-addon-register
-   'claude-code
-   :version "0.1.0"
-   :description "Integration with claude-code.el (Claude Code CLI)"
-   :requires '(claude-code emacs-mcp-api)
-   :provides '(claude-code-mcp-mode claude-code-mcp-transient)))
+(eval-after-load 'emacs-mcp-addons
+  '(emacs-mcp-addon-register
+    'claude-code
+    :version "0.1.0"
+    :description "Integration with claude-code.el (Claude Code CLI)"
+    :requires '(claude-code emacs-mcp-api)
+    :provides '(emacs-mcp-claude-code-mode emacs-mcp-claude-code-transient)))
 
 (provide 'emacs-mcp-claude-code)
 ;;; emacs-mcp-claude-code.el ends here

--- a/elisp/addons/emacs-mcp-melpazoid.el
+++ b/elisp/addons/emacs-mcp-melpazoid.el
@@ -1,0 +1,356 @@
+;;; emacs-mcp-melpazoid.el --- Melpazoid integration for emacs-mcp -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Pedro G. Branquinho
+;; Author: Pedro G. Branquinho <pedrogbranquinho@gmail.com>
+;; URL: https://github.com/BuddhiLW/emacs-mcp
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools, lisp, maint
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+;;
+;; This addon integrates melpazoid (https://github.com/riscy/melpazoid)
+;; with emacs-mcp for comprehensive MELPA submission testing.
+;;
+;; Melpazoid runs in a Docker container and performs:
+;; - package-lint checks
+;; - byte-compilation with multiple Emacs versions
+;; - checkdoc validation
+;; - melpazoid-specific style checks
+;; - license verification
+;; - load testing
+;;
+;; Features:
+;; - Run melpazoid from within Emacs
+;; - Parse and display structured results
+;; - Save results to MCP memory
+;; - Track submission readiness
+;;
+;; Requirements:
+;; - Docker must be installed and running
+;; - melpazoid repository cloned locally
+;;
+;; Usage:
+;;   (setq emacs-mcp-melpazoid-path "/path/to/melpazoid")
+;;   (emacs-mcp-addon-load 'melpazoid)
+;;   M-x emacs-mcp-melpazoid-run
+;;
+;; Or use the transient menu:
+;;   M-x emacs-mcp-melpazoid-transient
+
+;;; Code:
+
+(require 'emacs-mcp-api)
+
+;; Forward declarations
+(declare-function emacs-mcp-addon-register "emacs-mcp-addons")
+(declare-function transient-define-prefix "transient")
+
+;;;; Customization
+
+(defgroup emacs-mcp-melpazoid nil
+  "Melpazoid integration for emacs-mcp."
+  :group 'emacs-mcp
+  :prefix "emacs-mcp-melpazoid-")
+
+(defcustom emacs-mcp-melpazoid-path nil
+  "Path to the melpazoid repository.
+If nil, will attempt to find it in common locations."
+  :type '(choice (const :tag "Auto-detect" nil)
+                 (directory :tag "Path"))
+  :group 'emacs-mcp-melpazoid)
+
+(defcustom emacs-mcp-melpazoid-save-results t
+  "When non-nil, save melpazoid results to MCP memory."
+  :type 'boolean
+  :group 'emacs-mcp-melpazoid)
+
+(defcustom emacs-mcp-melpazoid-auto-detect-recipe t
+  "When non-nil, auto-detect recipe from recipes/ directory."
+  :type 'boolean
+  :group 'emacs-mcp-melpazoid)
+
+(defcustom emacs-mcp-melpazoid-timeout 300
+  "Timeout in seconds for melpazoid runs."
+  :type 'integer
+  :group 'emacs-mcp-melpazoid)
+
+;;;; Internal Variables
+
+(defvar emacs-mcp-melpazoid-transient)  ; defined by transient-define-prefix
+
+(defvar emacs-mcp-melpazoid--process nil
+  "Current melpazoid process.")
+
+(defvar emacs-mcp-melpazoid--last-results nil
+  "Last melpazoid run results.")
+
+(defvar emacs-mcp-melpazoid--buffer-name "*MCP Melpazoid*"
+  "Buffer name for melpazoid output.")
+
+(defvar emacs-mcp-melpazoid--common-paths
+  '("~/dotfiles/gitthings/melpazoid"
+    "~/melpazoid"
+    "~/projects/melpazoid"
+    "~/.local/share/melpazoid")
+  "Common paths to search for melpazoid.")
+
+;;;; Utility Functions
+
+(defun emacs-mcp-melpazoid--find-path ()
+  "Find melpazoid installation path."
+  (or emacs-mcp-melpazoid-path
+      (seq-find (lambda (p)
+                  (let ((expanded (expand-file-name p)))
+                    (and (file-directory-p expanded)
+                         (file-exists-p (expand-file-name "Makefile" expanded)))))
+                emacs-mcp-melpazoid--common-paths)
+      (error "Melpazoid not found. Set `emacs-mcp-melpazoid-path' or clone from https://github.com/riscy/melpazoid")))
+
+(defun emacs-mcp-melpazoid--docker-available-p ()
+  "Check if Docker is available and running."
+  (zerop (call-process "docker" nil nil nil "info")))
+
+(defun emacs-mcp-melpazoid--find-recipe (project-dir)
+  "Find MELPA recipe file in PROJECT-DIR."
+  (let ((recipes-dir (expand-file-name "recipes" project-dir)))
+    (when (file-directory-p recipes-dir)
+      (car (directory-files recipes-dir t "^[^.]")))))
+
+(defun emacs-mcp-melpazoid--read-recipe (recipe-file)
+  "Read recipe contents from RECIPE-FILE."
+  (when (and recipe-file (file-exists-p recipe-file))
+    (with-temp-buffer
+      (insert-file-contents recipe-file)
+      (string-trim (buffer-string)))))
+
+(defun emacs-mcp-melpazoid--parse-output (output)
+  "Parse melpazoid OUTPUT into structured results."
+  (let ((results (list :errors '()
+                       :warnings '()
+                       :info '()
+                       :sections '())))
+    ;; Parse errors
+    (let ((pos 0))
+      (while (string-match "\\[31m.*?error.*?\\[0m\\|Error:" output pos)
+        (push (match-string 0 output) (plist-get results :errors))
+        (setq pos (match-end 0))))
+    ;; Parse warnings
+    (let ((pos 0))
+      (while (string-match "\\[33m.*?warning.*?\\[0m\\|Warning:" output pos)
+        (push (match-string 0 output) (plist-get results :warnings))
+        (setq pos (match-end 0))))
+    ;; Parse sections
+    (let ((pos 0))
+      (while (string-match "^⸺ `\\([^`]+\\)`" output pos)
+        (push (match-string 1 output) (plist-get results :sections))
+        (setq pos (match-end 0))))
+    ;; Count issues
+    (plist-put results :error-count (length (plist-get results :errors)))
+    (plist-put results :warning-count (length (plist-get results :warnings)))
+    (plist-put results :success (zerop (plist-get results :error-count)))
+    results))
+
+(defun emacs-mcp-melpazoid--format-summary (results)
+  "Format RESULTS into a human-readable summary."
+  (format "Melpazoid Results:
+  Errors:   %d
+  Warnings: %d
+  Status:   %s
+  Sections: %s"
+          (plist-get results :error-count)
+          (plist-get results :warning-count)
+          (if (plist-get results :success) "PASS" "FAIL")
+          (mapconcat #'identity (plist-get results :sections) ", ")))
+
+;;;; Core Functions
+
+;;;###autoload
+(defun emacs-mcp-melpazoid-run (project-dir &optional recipe)
+  "Run melpazoid on PROJECT-DIR with optional RECIPE.
+If RECIPE is nil, attempts to auto-detect from recipes/ directory."
+  (interactive
+   (list (read-directory-name "Project directory: "
+                              (or (locate-dominating-file default-directory ".git")
+                                  default-directory))
+         nil))
+  (unless (emacs-mcp-melpazoid--docker-available-p)
+    (error "Docker is not available. Please start Docker first"))
+  (let* ((melpazoid-path (emacs-mcp-melpazoid--find-path))
+         (project-dir (expand-file-name project-dir))
+         (recipe-file (when emacs-mcp-melpazoid-auto-detect-recipe
+                        (emacs-mcp-melpazoid--find-recipe project-dir)))
+         (recipe-str (or recipe
+                         (emacs-mcp-melpazoid--read-recipe recipe-file)
+                         (read-string "MELPA recipe (or empty to skip): ")))
+         (buf (get-buffer-create emacs-mcp-melpazoid--buffer-name))
+         (cmd (if (string-empty-p recipe-str)
+                  (format "cd %s && LOCAL_REPO=%s make"
+                          (shell-quote-argument melpazoid-path)
+                          (shell-quote-argument project-dir))
+                (format "cd %s && RECIPE='%s' LOCAL_REPO=%s make"
+                        (shell-quote-argument melpazoid-path)
+                        recipe-str
+                        (shell-quote-argument project-dir)))))
+    ;; Prepare buffer
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "=" (make-string 60 ?=) "\n")
+        (insert " Melpazoid Check\n")
+        (insert (format " Project: %s\n" project-dir))
+        (when recipe-str
+          (insert (format " Recipe: %s\n" recipe-str)))
+        (insert (format " Started: %s\n" (format-time-string "%F %T")))
+        (insert "=" (make-string 60 ?=) "\n\n")
+        (insert "Running melpazoid (this may take a few minutes)...\n\n")))
+    (display-buffer buf)
+    ;; Kill any existing process
+    (when (and emacs-mcp-melpazoid--process
+               (process-live-p emacs-mcp-melpazoid--process))
+      (kill-process emacs-mcp-melpazoid--process))
+    ;; Start new process
+    (setq emacs-mcp-melpazoid--process
+          (start-process-shell-command
+           "melpazoid"
+           buf
+           cmd))
+    (set-process-sentinel
+     emacs-mcp-melpazoid--process
+     (lambda (proc event)
+       (when (string-match-p "\\(finished\\|exited\\)" event)
+         (with-current-buffer (process-buffer proc)
+           (let* ((output (buffer-string))
+                  (results (emacs-mcp-melpazoid--parse-output output)))
+             (setq emacs-mcp-melpazoid--last-results results)
+             (goto-char (point-max))
+             (insert "\n" (make-string 60 ?=) "\n")
+             (insert (emacs-mcp-melpazoid--format-summary results))
+             (insert "\n" (make-string 60 ?=) "\n")
+             ;; Save to memory if enabled
+             (when emacs-mcp-melpazoid-save-results
+               (emacs-mcp-api-memory-add
+                "note"
+                (format "Melpazoid run on %s\n%s\n\nFull output:\n%s"
+                        project-dir
+                        (emacs-mcp-melpazoid--format-summary results)
+                        output)
+                '("melpazoid" "melpa" "lint")))
+             (message "Melpazoid %s: %d errors, %d warnings"
+                      (if (plist-get results :success) "PASSED" "FAILED")
+                      (plist-get results :error-count)
+                      (plist-get results :warning-count)))))))
+    (message "Melpazoid started... check %s buffer" emacs-mcp-melpazoid--buffer-name)))
+
+;;;###autoload
+(defun emacs-mcp-melpazoid-run-current-project ()
+  "Run melpazoid on the current project."
+  (interactive)
+  (let ((root (or (locate-dominating-file default-directory ".git")
+                  (locate-dominating-file default-directory "elisp")
+                  default-directory)))
+    (emacs-mcp-melpazoid-run root)))
+
+;;;###autoload
+(defun emacs-mcp-melpazoid-stop ()
+  "Stop the current melpazoid process."
+  (interactive)
+  (when (and emacs-mcp-melpazoid--process
+             (process-live-p emacs-mcp-melpazoid--process))
+    (kill-process emacs-mcp-melpazoid--process)
+    (message "Melpazoid process stopped")))
+
+;;;###autoload
+(defun emacs-mcp-melpazoid-show-results ()
+  "Display the melpazoid results buffer."
+  (interactive)
+  (if-let* ((buf (get-buffer emacs-mcp-melpazoid--buffer-name)))
+      (display-buffer buf)
+    (message "No melpazoid results available. Run M-x emacs-mcp-melpazoid-run first")))
+
+;;;###autoload
+(defun emacs-mcp-melpazoid-save-results ()
+  "Save last melpazoid results to MCP memory."
+  (interactive)
+  (if emacs-mcp-melpazoid--last-results
+      (let ((content (with-current-buffer
+                         (get-buffer emacs-mcp-melpazoid--buffer-name)
+                       (buffer-string))))
+        (emacs-mcp-api-memory-add "note" content '("melpazoid" "melpa"))
+        (message "Saved melpazoid results to memory"))
+    (message "No melpazoid results to save")))
+
+;;;###autoload
+(defun emacs-mcp-melpazoid-status ()
+  "Return the current melpazoid status."
+  (interactive)
+  (let ((status (list :running (and emacs-mcp-melpazoid--process
+                                    (process-live-p emacs-mcp-melpazoid--process))
+                      :has-results (not (null emacs-mcp-melpazoid--last-results))
+                      :last-success (when emacs-mcp-melpazoid--last-results
+                                      (plist-get emacs-mcp-melpazoid--last-results :success))
+                      :last-errors (when emacs-mcp-melpazoid--last-results
+                                     (plist-get emacs-mcp-melpazoid--last-results :error-count))
+                      :last-warnings (when emacs-mcp-melpazoid--last-results
+                                       (plist-get emacs-mcp-melpazoid--last-results :warning-count)))))
+    (when (called-interactively-p 'any)
+      (message "Melpazoid: %s, Last run: %s (%d errors, %d warnings)"
+               (if (plist-get status :running) "running" "idle")
+               (if (plist-get status :has-results)
+                   (if (plist-get status :last-success) "PASS" "FAIL")
+                 "no results")
+               (or (plist-get status :last-errors) 0)
+               (or (plist-get status :last-warnings) 0)))
+    status))
+
+;;;; Transient Menu
+
+;;;###autoload (autoload 'emacs-mcp-melpazoid-transient "emacs-mcp-melpazoid" nil t)
+(with-eval-after-load 'transient
+  (transient-define-prefix emacs-mcp-melpazoid-transient ()
+    "Melpazoid MELPA testing menu."
+    ["Melpazoid - MELPA Submission Testing"
+     ["Run"
+      ("r" "Run on project" emacs-mcp-melpazoid-run-current-project)
+      ("R" "Run on directory" emacs-mcp-melpazoid-run)
+      ("s" "Stop" emacs-mcp-melpazoid-stop)]
+     ["Results"
+      ("v" "View results" emacs-mcp-melpazoid-show-results)
+      ("S" "Save to memory" emacs-mcp-melpazoid-save-results)
+      ("?" "Status" emacs-mcp-melpazoid-status)]]))
+
+;;;; Minor Mode
+
+;;;###autoload
+(define-minor-mode emacs-mcp-melpazoid-mode
+  "Minor mode for melpazoid integration.
+
+Provides Docker-based MELPA submission testing with:
+- Full melpazoid test suite
+- Multiple Emacs version testing
+- Comprehensive lint checks
+- Results tracking in MCP memory"
+  :init-value nil
+  :lighter " MCP-Mz"
+  :global t
+  :group 'emacs-mcp-melpazoid
+  (if emacs-mcp-melpazoid-mode
+      (progn
+        (require 'emacs-mcp-api nil t)
+        (message "emacs-mcp-melpazoid enabled"))
+    (emacs-mcp-melpazoid-stop)
+    (message "emacs-mcp-melpazoid disabled")))
+
+;;;; Addon Registration
+
+(with-eval-after-load 'emacs-mcp-addons
+  (emacs-mcp-addon-register
+   'melpazoid
+   :version "0.1.0"
+   :description "Melpazoid Docker-based MELPA testing"
+   :requires '(emacs-mcp-api)
+   :provides '(emacs-mcp-melpazoid-mode emacs-mcp-melpazoid-transient)))
+
+(provide 'emacs-mcp-melpazoid)
+;;; emacs-mcp-melpazoid.el ends here

--- a/elisp/addons/emacs-mcp-melpazoid.el
+++ b/elisp/addons/emacs-mcp-melpazoid.el
@@ -78,7 +78,9 @@ If nil, will attempt to find it in common locations."
 
 ;;;; Internal Variables
 
-(defvar emacs-mcp-melpazoid-transient)  ; defined by transient-define-prefix
+;; Forward declarations for byte-compiler (defined at runtime by transient)
+(defvar emacs-mcp-melpazoid--transient-menu)
+(declare-function emacs-mcp-melpazoid--transient-menu "emacs-mcp-melpazoid")
 
 (defvar emacs-mcp-melpazoid--process nil
   "Current melpazoid process.")
@@ -306,19 +308,26 @@ If RECIPE is nil, attempts to auto-detect from recipes/ directory."
 
 ;;;; Transient Menu
 
-;;;###autoload (autoload 'emacs-mcp-melpazoid-transient "emacs-mcp-melpazoid" nil t)
-(with-eval-after-load 'transient
-  (transient-define-prefix emacs-mcp-melpazoid-transient ()
-    "Melpazoid MELPA testing menu."
-    ["Melpazoid - MELPA Submission Testing"
-     ["Run"
-      ("r" "Run on project" emacs-mcp-melpazoid-run-current-project)
-      ("R" "Run on directory" emacs-mcp-melpazoid-run)
-      ("s" "Stop" emacs-mcp-melpazoid-stop)]
-     ["Results"
-      ("v" "View results" emacs-mcp-melpazoid-show-results)
-      ("S" "Save to memory" emacs-mcp-melpazoid-save-results)
-      ("?" "Status" emacs-mcp-melpazoid-status)]]))
+;;;###autoload
+(defun emacs-mcp-melpazoid-transient ()
+  "Melpazoid MELPA testing menu."
+  (interactive)
+  (if (require 'transient nil t)
+      (progn
+        (unless (fboundp 'emacs-mcp-melpazoid--transient-menu)
+          (transient-define-prefix emacs-mcp-melpazoid--transient-menu ()
+            "Melpazoid MELPA testing menu."
+            ["Melpazoid - MELPA Submission Testing"
+             ["Run"
+              ("r" "Run on project" emacs-mcp-melpazoid-run-current-project)
+              ("R" "Run on directory" emacs-mcp-melpazoid-run)
+              ("s" "Stop" emacs-mcp-melpazoid-stop)]
+             ["Results"
+              ("v" "View results" emacs-mcp-melpazoid-show-results)
+              ("S" "Save to memory" emacs-mcp-melpazoid-save-results)
+              ("?" "Status" emacs-mcp-melpazoid-status)]]))
+        (emacs-mcp-melpazoid--transient-menu))
+    (message "Transient package not available. Use M-x emacs-mcp-melpazoid-run-current-project")))
 
 ;;;; Minor Mode
 

--- a/elisp/addons/emacs-mcp-melpazoid.el
+++ b/elisp/addons/emacs-mcp-melpazoid.el
@@ -47,7 +47,7 @@
 (declare-function emacs-mcp-addon-register "emacs-mcp-addons")
 (declare-function transient-define-prefix "transient")
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-melpazoid nil
   "Melpazoid integration for emacs-mcp."
@@ -76,7 +76,7 @@ If nil, will attempt to find it in common locations."
   :type 'integer
   :group 'emacs-mcp-melpazoid)
 
-;;;; Internal Variables
+;;;; Internal Variables:
 
 ;; Forward declarations for byte-compiler (defined at runtime by transient)
 (defvar emacs-mcp-melpazoid--transient-menu)
@@ -98,7 +98,7 @@ If nil, will attempt to find it in common locations."
     "~/.local/share/melpazoid")
   "Common paths to search for melpazoid.")
 
-;;;; Utility Functions
+;;;; Utility Functions:
 
 (defun emacs-mcp-melpazoid--find-path ()
   "Find melpazoid installation path."
@@ -166,7 +166,7 @@ If nil, will attempt to find it in common locations."
           (if (plist-get results :success) "PASS" "FAIL")
           (mapconcat #'identity (plist-get results :sections) ", ")))
 
-;;;; Core Functions
+;;;; Core Functions:
 
 ;;;###autoload
 (defun emacs-mcp-melpazoid-run (project-dir &optional recipe)
@@ -289,7 +289,7 @@ If RECIPE is nil, attempts to auto-detect from recipes/ directory."
   (interactive)
   (let ((status (list :running (and emacs-mcp-melpazoid--process
                                     (process-live-p emacs-mcp-melpazoid--process))
-                      :has-results (not (null emacs-mcp-melpazoid--last-results))
+                      :has-results (and emacs-mcp-melpazoid--last-results t)
                       :last-success (when emacs-mcp-melpazoid--last-results
                                       (plist-get emacs-mcp-melpazoid--last-results :success))
                       :last-errors (when emacs-mcp-melpazoid--last-results
@@ -306,7 +306,7 @@ If RECIPE is nil, attempts to auto-detect from recipes/ directory."
                (or (plist-get status :last-warnings) 0)))
     status))
 
-;;;; Transient Menu
+;;;; Transient Menu:
 
 ;;;###autoload
 (defun emacs-mcp-melpazoid-transient ()
@@ -329,7 +329,7 @@ If RECIPE is nil, attempts to auto-detect from recipes/ directory."
         (emacs-mcp-melpazoid--transient-menu))
     (message "Transient package not available. Use M-x emacs-mcp-melpazoid-run-current-project")))
 
-;;;; Minor Mode
+;;;; Minor Mode:
 
 ;;;###autoload
 (define-minor-mode emacs-mcp-melpazoid-mode
@@ -347,11 +347,11 @@ Provides Docker-based MELPA submission testing with:
   (if emacs-mcp-melpazoid-mode
       (progn
         (require 'emacs-mcp-api nil t)
-        (message "emacs-mcp-melpazoid enabled"))
+        (message "Emacs-mcp-melpazoid enabled"))
     (emacs-mcp-melpazoid-stop)
-    (message "emacs-mcp-melpazoid disabled")))
+    (message "Emacs-mcp-melpazoid disabled")))
 
-;;;; Addon Registration
+;;;; Addon Registration:
 
 (with-eval-after-load 'emacs-mcp-addons
   (emacs-mcp-addon-register

--- a/elisp/addons/emacs-mcp-org-ai.el
+++ b/elisp/addons/emacs-mcp-org-ai.el
@@ -168,7 +168,7 @@ This enables persistent conversation history per project."
   (when (emacs-mcp-org-ai--available-p)
     (let ((ctx (emacs-mcp-api-get-context)))
       (pcase emacs-mcp-org-ai-context-format
-        ('compact (claude-code-mcp--format-context-compact ctx))
+        ('compact (emacs-mcp-claude-code--format-context-compact ctx))
         ('full (format "```json\n%s\n```" (json-encode ctx)))
         ('smart (emacs-mcp-org-ai--format-context-smart ctx))))))
 

--- a/elisp/addons/emacs-mcp-org-ai.el
+++ b/elisp/addons/emacs-mcp-org-ai.el
@@ -41,7 +41,7 @@
 (declare-function org-ai-switch-chat-model "org-ai")
 (declare-function org-ai-stream-text "org-ai")
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-org-ai nil
   "Integration between org-ai and emacs-mcp."
@@ -76,7 +76,7 @@ This enables persistent conversation history per project."
   :type 'boolean
   :group 'emacs-mcp-org-ai)
 
-;;;; Internal State
+;;;; Internal State:
 
 (defvar emacs-mcp-org-ai--available nil
   "Cached check for whether emacs-mcp-api is available.")
@@ -84,7 +84,7 @@ This enables persistent conversation history per project."
 (defvar emacs-mcp-org-ai--last-conversation nil
   "Last org-ai conversation for potential saving.")
 
-;;;; Utility Functions
+;;;; Utility Functions:
 
 (defun emacs-mcp-org-ai--available-p ()
   "Check if emacs-mcp-api is available."
@@ -97,7 +97,7 @@ This enables persistent conversation history per project."
   (unless (emacs-mcp-org-ai--available-p)
     (if (require 'emacs-mcp-api nil t)
         (setq emacs-mcp-org-ai--available t)
-      (error "emacs-mcp-api not available. Load emacs-mcp first"))))
+      (error "Emacs-mcp-api not available.  Load emacs-mcp first"))))
 
 (defun emacs-mcp-org-ai--format-context-compact (ctx)
   "Format CTX as compact one-line summary."
@@ -172,7 +172,7 @@ This enables persistent conversation history per project."
         ('full (format "```json\n%s\n```" (json-encode ctx)))
         ('smart (emacs-mcp-org-ai--format-context-smart ctx))))))
 
-;;;; Integration Commands
+;;;; Integration Commands:
 
 ;;;###autoload
 (defun emacs-mcp-org-ai-insert-context ()
@@ -306,7 +306,7 @@ This enables persistent conversation history per project."
       (goto-char (point-min)))
     (display-buffer buf)))
 
-;;;; Transient Menu
+;;;; Transient Menu:
 
 ;;;###autoload (autoload 'emacs-mcp-org-ai-transient "emacs-mcp-org-ai" nil t)
 (transient-define-prefix emacs-mcp-org-ai-transient ()
@@ -327,7 +327,7 @@ This enables persistent conversation history per project."
     ("L" "Toggle logging" emacs-mcp-org-ai-toggle-logging)
     ("M" "Toggle memory inclusion" emacs-mcp-org-ai-toggle-memory)]])
 
-;;;; Toggle Commands
+;;;; Toggle Commands:
 
 (defun emacs-mcp-org-ai-toggle-auto-context ()
   "Toggle automatic context injection."
@@ -349,7 +349,7 @@ This enables persistent conversation history per project."
   (message "Memory inclusion %s"
            (if emacs-mcp-org-ai-include-memory "enabled" "disabled")))
 
-;;;; Hooks and Advice
+;;;; Hooks and Advice:
 
 (defun emacs-mcp-org-ai--maybe-add-context (text)
   "Maybe add context to TEXT if auto-context is enabled."
@@ -370,7 +370,7 @@ This enables persistent conversation history per project."
         (setq emacs-mcp-org-ai--last-conversation content)
         (emacs-mcp-api-conversation-log "org-ai" content)))))
 
-;;;; Keymap for org-ai blocks
+;;;; Keymap for org-ai blocks:
 
 (defvar emacs-mcp-org-ai-block-map
   (let ((map (make-sparse-keymap)))
@@ -383,7 +383,7 @@ This enables persistent conversation history per project."
     map)
   "Keymap for org-ai blocks with MCP integration.")
 
-;;;; Minor Mode
+;;;; Minor Mode:
 
 ;;;###autoload
 (define-minor-mode emacs-mcp-org-ai-mode
@@ -395,11 +395,11 @@ When enabled, provides:
 - Conversation history
 - Workflow access
 
-Key bindings in org-ai blocks:
-  C-c C-c m - Insert context
-  C-c C-c s - Save conversation
-  C-c C-c q - Query memory
-  C-c C-c M - Open transient menu"
+Key bindings in org-ai blocks (see `emacs-mcp-org-ai-block-map'):
+  \\[emacs-mcp-org-ai-insert-context] - Insert context
+  \\[emacs-mcp-org-ai-save-conversation] - Save conversation
+  \\[emacs-mcp-org-ai-query-memory] - Query memory
+  \\[emacs-mcp-org-ai-transient] - Open transient menu"
   :init-value nil
   :lighter " MCP-AI"
   :global t
@@ -411,10 +411,10 @@ Key bindings in org-ai blocks:
         ;; Add keybindings to org-ai-mode if available
         (when (boundp 'org-ai-mode-map)
           (set-keymap-parent org-ai-mode-map emacs-mcp-org-ai-block-map))
-        (message "emacs-mcp-org-ai enabled"))
-    (message "emacs-mcp-org-ai disabled")))
+        (message "Emacs-mcp-org-ai enabled"))
+    (message "Emacs-mcp-org-ai disabled")))
 
-;;;; Addon Registration
+;;;; Addon Registration:
 
 (with-eval-after-load 'emacs-mcp-addons
   (emacs-mcp-addon-register

--- a/elisp/addons/emacs-mcp-org-kanban.el
+++ b/elisp/addons/emacs-mcp-org-kanban.el
@@ -579,6 +579,29 @@ For standalone backend, PROJECT-ID can be nil."
   (setq-local line-spacing 0.2)
   (hl-line-mode 1))
 
+;; Evil-mode integration
+(with-eval-after-load 'evil
+  (evil-set-initial-state 'emacs-mcp-kanban-board-mode 'emacs)
+  ;; Also define keys in normal state for users who prefer staying in normal
+  (evil-define-key 'normal emacs-mcp-kanban-board-mode-map
+    "n" #'emacs-mcp-kanban-board-next-task
+    "p" #'emacs-mcp-kanban-board-prev-task
+    "j" #'emacs-mcp-kanban-board-next-task
+    "k" #'emacs-mcp-kanban-board-prev-task
+    "l" #'emacs-mcp-kanban-board-next-column
+    "h" #'emacs-mcp-kanban-board-prev-column
+    (kbd "RET") #'emacs-mcp-kanban-board-open-task
+    "m" #'emacs-mcp-kanban-board-move-task
+    ">" #'emacs-mcp-kanban-board-move-right
+    "<" #'emacs-mcp-kanban-board-move-left
+    "c" #'emacs-mcp-kanban-board-create-task
+    "d" #'emacs-mcp-kanban-board-delete-task
+    "e" #'emacs-mcp-kanban-board-edit-task
+    "g" #'emacs-mcp-kanban-board-refresh
+    "o" #'emacs-mcp-kanban-open-org-file
+    "q" #'quit-window
+    "?" #'emacs-mcp-kanban-board-help))
+
 (defun emacs-mcp-kanban-board--render ()
   "Render the kanban board in the current buffer."
   (let* ((inhibit-read-only t)
@@ -988,9 +1011,9 @@ Used when CIDER is not connected."
       (dolist (status emacs-mcp-kanban-statuses)
         (insert (format "* %s\n" status))
         (let ((status-tasks (cl-remove-if-not
-                             (lambda (t)
+                             (lambda (tsk)
                                (equal (emacs-mcp-kanban--vibe-to-org-status
-                                      (alist-get 'status t))
+                                      (alist-get 'status tsk))
                                      status))
                              tasks)))
           (dolist (task status-tasks)
@@ -1022,10 +1045,10 @@ Used when CIDER is not connected."
   "Update status of a task interactively."
   (interactive)
   (let* ((tasks (emacs-mcp-kanban-list-tasks))
-         (task-names (mapcar (lambda (t)
+         (task-names (mapcar (lambda (tsk)
                               (format "%s [%s]"
-                                      (alist-get 'title t)
-                                      (alist-get 'status t)))
+                                      (alist-get 'title tsk)
+                                      (alist-get 'status tsk)))
                             tasks))
          (selection (completing-read "Task: " task-names nil t))
          (task (nth (cl-position selection task-names :test #'equal) tasks))

--- a/elisp/addons/emacs-mcp-package-lint.el
+++ b/elisp/addons/emacs-mcp-package-lint.el
@@ -39,7 +39,7 @@
 (declare-function transient-define-prefix "transient")
 (declare-function emacs-mcp-addon-register "emacs-mcp-addons")
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-package-lint nil
   "MELPA submission tools for emacs-mcp."
@@ -61,7 +61,7 @@
   :type '(repeat string)
   :group 'emacs-mcp-package-lint)
 
-;;;; Internal Variables
+;;;; Internal Variables:
 
 (defvar emacs-mcp-package-lint--last-results nil
   "Last lint results for reference.")
@@ -69,12 +69,12 @@
 (defvar emacs-mcp-package-lint--buffer-name "*MCP Package Lint*"
   "Buffer name for lint output.")
 
-;;;; Utility Functions
+;;;; Utility Functions:
 
 (defun emacs-mcp-package-lint--ensure-package-lint ()
   "Ensure package-lint is available."
   (unless (require 'package-lint nil t)
-    (error "package-lint not installed. Install with: M-x package-install RET package-lint RET")))
+    (error "Package-lint not installed.  Install with: M-x package-install RET package-lint RET")))
 
 (defun emacs-mcp-package-lint--find-elisp-files (directory)
   "Find all elisp files in DIRECTORY, excluding unwanted patterns."
@@ -111,7 +111,7 @@
       "\n")
      "\n")))
 
-;;;; Package-Lint Functions
+;;;; Package-Lint Functions:
 
 ;;;###autoload
 (defun emacs-mcp-package-lint-check-file (file)
@@ -139,11 +139,11 @@
                 :results results
                 :type 'package-lint))
     (if results
-        (message "package-lint: %d issue(s) found" (length results))
-      (message "package-lint: OK"))
+        (message "Package-lint: %d issue(s) found" (length results))
+      (message "Package-lint: OK"))
     results))
 
-;;;; Byte-Compile Functions
+;;;; Byte-Compile Functions:
 
 ;;;###autoload
 (defun emacs-mcp-package-lint-byte-compile-file (file)
@@ -167,8 +167,8 @@
     (setq emacs-mcp-package-lint--last-results
           (list :file file :results warnings :type 'byte-compile))
     (if (string-empty-p (string-trim warnings))
-        (message "byte-compile: OK")
-      (message "byte-compile warnings:\n%s" warnings))
+        (message "Byte-compile: OK")
+      (message "Byte-compile warnings:\n%s" warnings))
     warnings))
 
 ;;;###autoload
@@ -179,7 +179,7 @@
       (emacs-mcp-package-lint-byte-compile-file buffer-file-name)
     (error "Buffer is not visiting a file")))
 
-;;;; Checkdoc Functions
+;;;; Checkdoc Functions:
 
 ;;;###autoload
 (defun emacs-mcp-package-lint-checkdoc-file (file)
@@ -201,8 +201,8 @@
     (setq emacs-mcp-package-lint--last-results
           (list :file file :results issues :type 'checkdoc))
     (if (or (null issues) (string-empty-p (string-trim issues)))
-        (message "checkdoc: OK")
-      (message "checkdoc issues:\n%s" issues))
+        (message "Checkdoc: OK")
+      (message "Checkdoc issues:\n%s" issues))
     issues))
 
 ;;;###autoload
@@ -213,7 +213,7 @@
       (emacs-mcp-package-lint-checkdoc-file buffer-file-name)
     (checkdoc-current-buffer t)))
 
-;;;; Full MELPA Compliance Check
+;;;; Full MELPA Compliance Check:
 
 ;;;###autoload
 (defun emacs-mcp-package-lint-check-all (directory)
@@ -314,7 +314,7 @@ Runs package-lint, byte-compile, and checkdoc on each file."
                   default-directory)))
     (emacs-mcp-package-lint-check-all root)))
 
-;;;; Save Results to Memory
+;;;; Save Results to Memory:
 
 ;;;###autoload
 (defun emacs-mcp-package-lint-save-results ()
@@ -336,7 +336,7 @@ Runs package-lint, byte-compile, and checkdoc on each file."
         (message "Saved lint results to memory"))
     (message "No lint results to save")))
 
-;;;; MCP Tool API Functions
+;;;; MCP Tool API Functions:
 
 ;;;###autoload
 (defun emacs-mcp-package-lint-run (file-or-dir)
@@ -349,13 +349,13 @@ Runs package-lint, byte-compile, and checkdoc on each file."
 ;;;###autoload
 (defun emacs-mcp-package-lint-status ()
   "Return last lint status as JSON-compatible plist."
-  (list :has-results (not (null emacs-mcp-package-lint--last-results))
+  (list :has-results (and emacs-mcp-package-lint--last-results t)
         :last-type (when emacs-mcp-package-lint--last-results
                      (plist-get emacs-mcp-package-lint--last-results :type))
         :last-file (when emacs-mcp-package-lint--last-results
                      (plist-get emacs-mcp-package-lint--last-results :file))))
 
-;;;; Transient Menu
+;;;; Transient Menu:
 
 ;;;###autoload (autoload 'emacs-mcp-package-lint-transient "emacs-mcp-package-lint" nil t)
 (transient-define-prefix emacs-mcp-package-lint-transient ()
@@ -371,7 +371,7 @@ Runs package-lint, byte-compile, and checkdoc on each file."
    ["Memory"
     ("s" "Save results to memory" emacs-mcp-package-lint-save-results)]])
 
-;;;; Minor Mode
+;;;; Minor Mode:
 
 ;;;###autoload
 (define-minor-mode emacs-mcp-package-lint-mode
@@ -389,10 +389,10 @@ Provides:
   (if emacs-mcp-package-lint-mode
       (progn
         (require 'emacs-mcp-api nil t)
-        (message "emacs-mcp-package-lint enabled"))
-    (message "emacs-mcp-package-lint disabled")))
+        (message "Emacs-mcp-package-lint enabled"))
+    (message "Emacs-mcp-package-lint disabled")))
 
-;;;; Addon Registration
+;;;; Addon Registration:
 
 (with-eval-after-load 'emacs-mcp-addons
   (emacs-mcp-addon-register

--- a/elisp/addons/emacs-mcp-vibe-kanban.el
+++ b/elisp/addons/emacs-mcp-vibe-kanban.el
@@ -36,7 +36,7 @@
 
 (require 'emacs-mcp-api)
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-vibe-kanban nil
   "Vibe Kanban integration for emacs-mcp."
@@ -71,7 +71,7 @@ If nil, uses current project root or `default-directory'."
   :type '(choice (const nil) directory)
   :group 'emacs-mcp-vibe-kanban)
 
-;;;; Internal Variables
+;;;; Internal Variables:
 
 (defvar emacs-mcp-vibe-kanban--process nil
   "Process object for the vibe-kanban server.")
@@ -79,7 +79,7 @@ If nil, uses current project root or `default-directory'."
 (defvar emacs-mcp-vibe-kanban--buffer-name "*vibe-kanban*"
   "Buffer name for vibe-kanban output.")
 
-;;;; Helper Functions
+;;;; Helper Functions:
 
 (defun emacs-mcp-vibe-kanban--project-dir ()
   "Get the project directory for vibe-kanban."
@@ -94,7 +94,7 @@ If nil, uses current project root or `default-directory'."
   (and emacs-mcp-vibe-kanban--process
        (process-live-p emacs-mcp-vibe-kanban--process)))
 
-;;;; Server Control
+;;;; Server Control:
 
 (defun emacs-mcp-vibe-kanban--start-async ()
   "Start vibe-kanban server asynchronously.
@@ -123,7 +123,7 @@ Returns the process object."
     (setq emacs-mcp-vibe-kanban--process nil)
     (message "emacs-mcp-vibe-kanban: Server stopped")))
 
-;;;; Interactive Commands
+;;;; Interactive Commands:
 
 ;;;###autoload
 (defun emacs-mcp-vibe-kanban-start ()
@@ -164,7 +164,7 @@ Returns the process object."
       (display-buffer buf)
     (message "emacs-mcp-vibe-kanban: No output buffer")))
 
-;;;; Addon Lifecycle Functions
+;;;; Addon Lifecycle Functions:
 
 (defun emacs-mcp-vibe-kanban--addon-init ()
   "Synchronous init for vibe-kanban addon."
@@ -183,7 +183,7 @@ Returns the process object for lifecycle tracking."
   (emacs-mcp-vibe-kanban--stop)
   (message "emacs-mcp-vibe-kanban: shutdown complete"))
 
-;;;; Transient Menu
+;;;; Transient Menu:
 
 ;;;###autoload (autoload 'emacs-mcp-vibe-kanban-transient "emacs-mcp-vibe-kanban" nil t)
 (transient-define-prefix emacs-mcp-vibe-kanban-transient ()
@@ -197,7 +197,7 @@ Returns the process object for lifecycle tracking."
    ["View"
     ("b" "Show buffer" emacs-mcp-vibe-kanban-show-buffer)]])
 
-;;;; Addon Registration
+;;;; Addon Registration:
 
 (with-eval-after-load 'emacs-mcp-addons
   (emacs-mcp-addon-register

--- a/elisp/emacs-mcp-addons.el
+++ b/elisp/emacs-mcp-addons.el
@@ -261,7 +261,9 @@ Returns t if loaded successfully, nil otherwise."
 ;;;###autoload
 (defun emacs-mcp-addons-auto-load ()
   "Enable auto-loading of addons when their trigger packages load.
-Uses `emacs-mcp-addon-auto-load-list' to determine mappings."
+Uses `emacs-mcp-addon-auto-load-list' to determine mappings.
+This function is called during initialization; for manual setup,
+users can also configure auto-loading in their init file."
   (interactive)
   (dolist (entry emacs-mcp-addon-auto-load-list)
     (let ((addon (car entry))
@@ -269,9 +271,10 @@ Uses `emacs-mcp-addon-auto-load-list' to determine mappings."
       ;; If trigger already loaded, load addon now
       (if (featurep trigger)
           (emacs-mcp-addon-load addon)
-        ;; Otherwise, set up deferred loading
-        (with-eval-after-load trigger
-          (emacs-mcp-addon-load addon))))))
+        ;; Set up deferred loading via eval-after-load
+        ;; Note: eval-after-load is appropriate here as this runs during init
+        (eval-after-load trigger
+          `(emacs-mcp-addon-load ',addon))))))
 
 ;;;###autoload
 (defun emacs-mcp-addons-load-always ()

--- a/elisp/emacs-mcp-addons.el
+++ b/elisp/emacs-mcp-addons.el
@@ -29,7 +29,7 @@
 
 (require 'cl-lib)
 
-;;;; Customization
+;;;; Customization:
 
 (defgroup emacs-mcp-addons nil
   "Addon system for emacs-mcp."
@@ -63,7 +63,7 @@ Example: \\='(cider org-kanban package-lint)"
   :type '(repeat symbol)
   :group 'emacs-mcp-addons)
 
-;;;; Registry
+;;;; Registry:
 
 (defvar emacs-mcp-addon--registry (make-hash-table :test 'eq)
   "Hash table of registered addons.
@@ -81,7 +81,7 @@ Keys are addon symbols, values are process objects.")
   "Hash table tracking timers started by addons.
 Keys are addon symbols, values are lists of timer objects.")
 
-;;;; Core Functions
+;;;; Core Functions:
 
 (defun emacs-mcp-addon--find-file (addon)
   "Find the file for ADDON in addon directories."
@@ -106,7 +106,7 @@ Keys are addon symbols, values are lists of timer objects.")
       (when-let* ((timers (gethash addon emacs-mcp-addon--timers)))
         (cl-some #'timerp timers))))
 
-;;;; Lifecycle Management
+;;;; Lifecycle Management:
 
 (defun emacs-mcp-addon--run-init (addon)
   "Run the :init function for ADDON if defined."
@@ -115,9 +115,9 @@ Keys are addon symbols, values are lists of timer objects.")
     (condition-case err
         (progn
           (funcall init-fn)
-          (message "emacs-mcp addon %s: init completed" addon))
+          (message "Emacs-mcp addon %s: init completed" addon))
       (error
-       (message "emacs-mcp addon %s: init failed: %s" addon (error-message-string err))))))
+       (message "Emacs-mcp addon %s: init failed: %s" addon (error-message-string err))))))
 
 (defun emacs-mcp-addon--run-async-init (addon)
   "Run the :async-init function for ADDON if defined.
@@ -129,9 +129,9 @@ The async-init function should return a process object or nil."
           ;; Track returned process if any
           (when (processp result)
             (puthash addon result emacs-mcp-addon--processes))
-          (message "emacs-mcp addon %s: async-init started" addon))
+          (message "Emacs-mcp addon %s: async-init started" addon))
       (error
-       (message "emacs-mcp addon %s: async-init failed: %s" addon (error-message-string err))))))
+       (message "Emacs-mcp addon %s: async-init failed: %s" addon (error-message-string err))))))
 
 (defun emacs-mcp-addon--run-shutdown (addon)
   "Run the :shutdown function for ADDON if defined."
@@ -140,9 +140,9 @@ The async-init function should return a process object or nil."
     (condition-case err
         (progn
           (funcall shutdown-fn)
-          (message "emacs-mcp addon %s: shutdown completed" addon))
+          (message "Emacs-mcp addon %s: shutdown completed" addon))
       (error
-       (message "emacs-mcp addon %s: shutdown failed: %s" addon (error-message-string err))))))
+       (message "Emacs-mcp addon %s: shutdown failed: %s" addon (error-message-string err))))))
 
 (defun emacs-mcp-addon--cleanup (addon)
   "Clean up processes and timers for ADDON."
@@ -172,7 +172,7 @@ The async-init function should return a process object or nil."
   (when-let* ((timers (gethash addon emacs-mcp-addon--timers)))
     (puthash addon (delq timer timers) emacs-mcp-addon--timers)))
 
-;;;; Load/Unload
+;;;; Load/Unload:
 
 ;;;###autoload
 (defun emacs-mcp-addon-load (addon)
@@ -250,7 +250,7 @@ Returns t if loaded successfully, nil otherwise."
              emacs-mcp-addon--registry)
     loaded))
 
-;;;; Auto-loading
+;;;; Auto-loading:
 
 (defun emacs-mcp-addon--after-load-hook (feature)
   "Hook function to auto-load addons when FEATURE is loaded."
@@ -294,7 +294,7 @@ This is the main entry point, called from `emacs-mcp-initialize'."
   ;; Then set up deferred auto-loading for feature-triggered addons
   (emacs-mcp-addons-auto-load))
 
-;;;; Registration (for addon authors)
+;;;; Registration (for addon authors):
 
 (defun emacs-mcp-addon-register (addon &rest props)
   "Register ADDON with PROPS.
@@ -328,7 +328,7 @@ Example:
    :shutdown #\\='my-addon-stop-server)"
   (puthash addon props emacs-mcp-addon--registry))
 
-;;;; Info command
+;;;; Info command:
 
 ;;;###autoload
 (defun emacs-mcp-addon-info ()

--- a/elisp/emacs-mcp-api.el
+++ b/elisp/emacs-mcp-api.el
@@ -100,7 +100,8 @@ Keyword keys become symbols, lists become vectors."
 
 (defun emacs-mcp-api-memory-query (type &optional tags limit)
   "Query project memory by TYPE with optional TAGS filter.
-TYPE is a string: \"note\", \"snippet\", \"convention\", \"decision\", \"conversation\".
+TYPE is a string: \"note\", \"snippet\", \"convention\", \"decision\",
+or \"conversation\".
 TAGS is a list of strings.
 LIMIT is max results (default 20).
 Returns a vector of alists suitable for JSON encoding."

--- a/elisp/emacs-mcp-api.el
+++ b/elisp/emacs-mcp-api.el
@@ -27,9 +27,7 @@
 (declare-function emacs-mcp-register-trigger "emacs-mcp-triggers")
 (declare-function emacs-mcp-list-triggers "emacs-mcp-triggers")
 
-;;; ============================================================================
-;;; Context API
-;;; ============================================================================
+;;;; Context API:
 
 (defun emacs-mcp-api-get-context ()
   "Return full context as JSON-compatible plist.
@@ -64,9 +62,7 @@ Includes buffer, region, defun, project, git, and memory."
 BEFORE and AFTER default to 5 lines each."
   (emacs-mcp-context-surrounding-lines before after))
 
-;;; ============================================================================
-;;; Memory API
-;;; ============================================================================
+;;;; Memory API:
 
 (defun emacs-mcp-api--plist-to-alist (plist)
   "Convert PLIST to alist for JSON serialization.
@@ -133,9 +129,7 @@ Returns the created entry as alist suitable for JSON encoding."
   "Return full project context including all memory."
   (emacs-mcp-memory-get-project-context))
 
-;;; ============================================================================
-;;; Conversation API
-;;; ============================================================================
+;;;; Conversation API:
 
 (defun emacs-mcp-api-conversation-log (role content)
   "Log conversation entry.
@@ -154,9 +148,7 @@ LIMIT defaults to 20 entries."
     (emacs-mcp-memory--set-data pid "conversation" '())
     t))
 
-;;; ============================================================================
-;;; Workflow API
-;;; ============================================================================
+;;;; Workflow API:
 
 (defun emacs-mcp-api-list-workflows ()
   "Return list of registered workflows."
@@ -178,9 +170,7 @@ SPEC is plist with :description, :steps, :params."
       (emacs-mcp-workflow-register name spec)
     (error "Workflows not available")))
 
-;;; ============================================================================
-;;; Trigger API
-;;; ============================================================================
+;;;; Trigger API:
 
 (defun emacs-mcp-api-register-trigger (name spec)
   "Register a trigger for automation.
@@ -196,9 +186,7 @@ SPEC is plist with :event, :condition, :action."
       (emacs-mcp-list-triggers)
     '()))
 
-;;; ============================================================================
-;;; Interaction API
-;;; ============================================================================
+;;;; Interaction API:
 
 (defun emacs-mcp-api-notify (message &optional type)
   "Show notification MESSAGE to user.
@@ -227,9 +215,7 @@ OPTIONS is a list of strings.
 Returns the selected option."
   (completing-read (concat prompt ": ") options nil t))
 
-;;; ============================================================================
-;;; Buffer/File Operations API
-;;; ============================================================================
+;;;; Buffer and File Operations API:
 
 (defun emacs-mcp-api-open-file (path &optional line)
   "Open file at PATH and optionally go to LINE."
@@ -258,9 +244,7 @@ Returns the selected option."
   (kill-buffer name)
   t)
 
-;;; ============================================================================
-;;; Navigation API
-;;; ============================================================================
+;;;; Navigation API:
 
 (defun emacs-mcp-api-goto-line (line)
   "Go to LINE number."
@@ -285,9 +269,7 @@ BOUND limits the search to that buffer position.
 Returns position if found, nil otherwise."
   (re-search-forward regexp bound t))
 
-;;; ============================================================================
-;;; Visual Feedback API
-;;; ============================================================================
+;;;; Visual Feedback API:
 
 (defun emacs-mcp-api-highlight-line (&optional line)
   "Highlight LINE (or current line) briefly."
@@ -317,9 +299,7 @@ Returns position if found, nil otherwise."
     (display-buffer buf)
     name))
 
-;;; ============================================================================
-;;; Version Info
-;;; ============================================================================
+;;;; Version Info:
 
 (defconst emacs-mcp-api-version "0.1.0"
   "Version of the emacs-mcp API.")

--- a/elisp/emacs-mcp-context.el
+++ b/elisp/emacs-mcp-context.el
@@ -232,7 +232,7 @@ Called with single argument: the context plist being built.")
 Includes buffer, region, defun, project, git, and custom providers."
   (let ((context
          (list
-          :timestamp (format-time-string "%Y-%m-%dT%H:%M:%S%z")
+          :timestamp (format-time-string "%FT%T%z")
           :buffer (emacs-mcp-context-buffer)
           :region (emacs-mcp-context-region)
           :defun (emacs-mcp-context-defun)

--- a/elisp/emacs-mcp-memory.el
+++ b/elisp/emacs-mcp-memory.el
@@ -61,7 +61,7 @@
 
 (defun emacs-mcp-memory--timestamp ()
   "Return current ISO 8601 timestamp."
-  (format-time-string "%Y-%m-%dT%H:%M:%S%z"))
+  (format-time-string "%FT%T%z"))
 
 (defun emacs-mcp-memory--project-id (&optional project-root)
   "Return unique ID for PROJECT-ROOT (defaults to current project).

--- a/elisp/emacs-mcp-triggers.el
+++ b/elisp/emacs-mcp-triggers.el
@@ -16,6 +16,9 @@
 (require 'emacs-mcp-memory)
 (require 'emacs-mcp-context)
 
+;; Forward declaration for byte-compiler
+(defvar emacs-mcp-mode-map)
+
 ;;; Customization
 
 (defgroup emacs-mcp-triggers nil
@@ -27,7 +30,7 @@
   "Prefix key for emacs-mcp commands.
 Set this in your init file before enabling `emacs-mcp-mode'.
 Example: (setq emacs-mcp-keymap-prefix (kbd \"C-c m\"))
-Note: C-c followed by a letter is reserved for user bindings per Emacs conventions."
+Note: C-c <letter> is reserved for user bindings."
   :type '(choice (const :tag "None" nil) key-sequence)
   :group 'emacs-mcp-triggers)
 

--- a/elisp/emacs-mcp-triggers.el
+++ b/elisp/emacs-mcp-triggers.el
@@ -23,9 +23,12 @@
   :group 'emacs-mcp
   :prefix "emacs-mcp-trigger-")
 
-(defcustom emacs-mcp-keymap-prefix (kbd "C-c m")
-  "Prefix key for emacs-mcp commands."
-  :type 'key-sequence
+(defcustom emacs-mcp-keymap-prefix nil
+  "Prefix key for emacs-mcp commands.
+Set this in your init file before enabling `emacs-mcp-mode'.
+Example: (setq emacs-mcp-keymap-prefix (kbd \"C-c m\"))
+Note: C-c followed by a letter is reserved for user bindings per Emacs conventions."
+  :type '(choice (const :tag "None" nil) key-sequence)
   :group 'emacs-mcp-triggers)
 
 (defcustom emacs-mcp-after-save-hook-enabled nil
@@ -104,8 +107,14 @@ Events: after-save, compilation-finish, diagnostics-error, custom."
 
 ;;;###autoload
 (defun emacs-mcp-setup-keybindings ()
-  "Set up emacs-mcp keybindings."
-  (global-set-key emacs-mcp-keymap-prefix emacs-mcp-command-map))
+  "Set up emacs-mcp keybindings.
+Only sets up keybindings if `emacs-mcp-keymap-prefix' is configured.
+Users should set this in their init file before enabling `emacs-mcp-mode'.
+Example configuration:
+  (setq emacs-mcp-keymap-prefix (kbd \"C-c m\"))
+  (emacs-mcp-mode 1)"
+  (when emacs-mcp-keymap-prefix
+    (define-key emacs-mcp-mode-map emacs-mcp-keymap-prefix emacs-mcp-command-map)))
 
 ;;; Interactive Commands
 
@@ -270,7 +279,7 @@ BUFFER is the compilation buffer, STATUS is the result string."
   "Run a workflow interactively."
   (interactive)
   (if (fboundp 'emacs-mcp-workflow-run-interactive)
-      (call-interactively 'emacs-mcp-workflow-run-interactive)
+      (call-interactively #'emacs-mcp-workflow-run-interactive)
     (message "Workflows not loaded yet")))
 
 (defun emacs-mcp-define-workflow-interactive ()

--- a/elisp/emacs-mcp-triggers.el
+++ b/elisp/emacs-mcp-triggers.el
@@ -30,7 +30,7 @@
   "Prefix key for emacs-mcp commands.
 Set this in your init file before enabling `emacs-mcp-mode'.
 Example: (setq emacs-mcp-keymap-prefix (kbd \"C-c m\"))
-Note: C-c <letter> is reserved for user bindings."
+Note: Control-c <letter> is reserved for user bindings per Emacs conventions."
   :type '(choice (const :tag "None" nil) key-sequence)
   :group 'emacs-mcp-triggers)
 

--- a/elisp/emacs-mcp.el
+++ b/elisp/emacs-mcp.el
@@ -159,31 +159,34 @@ keybindings for AI-assisted development.
 
 ;;; Convenience aliases for common operations
 
-(defalias 'emacs-mcp-note 'emacs-mcp-add-note-interactive
+(defalias 'emacs-mcp-note #'emacs-mcp-add-note-interactive
   "Add a note to project memory.")
 
-(defalias 'emacs-mcp-snippet 'emacs-mcp-add-snippet-interactive
+(defalias 'emacs-mcp-snippet #'emacs-mcp-add-snippet-interactive
   "Save region as a snippet.")
 
-(defalias 'emacs-mcp-context 'emacs-mcp-show-context
+(defalias 'emacs-mcp-context #'emacs-mcp-show-context
   "Show current context.")
 
-(defalias 'emacs-mcp-memory 'emacs-mcp-show-memory
+(defalias 'emacs-mcp-memory #'emacs-mcp-show-memory
   "Show project memory.")
 
-(defalias 'emacs-mcp-workflow 'emacs-mcp-workflow-run-interactive
+(defalias 'emacs-mcp-workflow #'emacs-mcp-workflow-run-interactive
   "Run a workflow.")
 
 ;;; Auto-load on init (optional)
+;; Users who want auto-enable should add to their init file:
+;;   (setq emacs-mcp-auto-enable t)
+;;   (add-hook 'after-init-hook #'emacs-mcp--maybe-auto-enable)
 
 (defun emacs-mcp--maybe-auto-enable ()
   "Maybe enable `emacs-mcp-mode' automatically.
-Controlled by `emacs-mcp-auto-enable'."
+Controlled by `emacs-mcp-auto-enable'.
+To use, add to your init file:
+  (setq emacs-mcp-auto-enable t)
+  (add-hook \\='after-init-hook #\\='emacs-mcp--maybe-auto-enable)"
   (when emacs-mcp-auto-enable
     (emacs-mcp-mode 1)))
-
-;; Set up auto-enable hook (runs if emacs-mcp-auto-enable is t)
-(add-hook 'after-init-hook #'emacs-mcp--maybe-auto-enable)
 
 (provide 'emacs-mcp)
 ;;; emacs-mcp.el ends here

--- a/elisp/emacs-mcp.el
+++ b/elisp/emacs-mcp.el
@@ -150,7 +150,8 @@ keybindings for AI-assisted development.
   :global t
   :lighter " MCP"
   :keymap (let ((map (make-sparse-keymap)))
-            (define-key map emacs-mcp-keymap-prefix emacs-mcp-command-map)
+            (when emacs-mcp-keymap-prefix
+              (define-key map emacs-mcp-keymap-prefix emacs-mcp-command-map))
             map)
   (if emacs-mcp-mode
       (when emacs-mcp-auto-initialize

--- a/elisp/emacs-mcp.el
+++ b/elisp/emacs-mcp.el
@@ -126,7 +126,7 @@ and enables auto-loading for feature-triggered addons."
       (emacs-mcp-addons-setup))
 
     (setq emacs-mcp--initialized t)
-    (message "emacs-mcp initialized (C-c m for menu)")))
+    (message "Emacs-mcp initialized (C-c m for menu)")))
 
 (defun emacs-mcp-reset ()
   "Reset emacs-mcp state (for debugging)."
@@ -135,7 +135,7 @@ and enables auto-loading for feature-triggered addons."
   (clrhash emacs-mcp-memory--cache)
   (clrhash emacs-mcp-workflow-registry)
   (clrhash emacs-mcp-trigger-registry)
-  (message "emacs-mcp reset"))
+  (message "Emacs-mcp reset"))
 
 ;;; Minor Mode
 
@@ -156,7 +156,7 @@ keybindings for AI-assisted development.
   (if emacs-mcp-mode
       (when emacs-mcp-auto-initialize
         (emacs-mcp-initialize))
-    (message "emacs-mcp mode disabled")))
+    (message "Emacs-mcp mode disabled")))
 
 ;;; Convenience aliases for common operations
 

--- a/kanban.org
+++ b/kanban.org
@@ -143,6 +143,292 @@
 :VIBE_ID:  6bcd672a-6f47-4af1-a630-9be012503da1
 :END:
 
+* org-clj: Native Clojure Org-Mode Parser
+:PROPERTIES:
+:ID: org-clj-epic-2025
+:EPIC: org-clj
+:DESCRIPTION: Native Clojure library for parsing, querying, and writing org-mode files
+:END:
+
+** Phase 1: Core Parser (Wave 1 - Parallelizable)
+*** TODO Define org-clj data schemas (spec/malli)
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: high
+:WAVE: 1
+:WORKER: A
+:END:
+Create core data structures for org documents:
+- Document schema with properties, content, headlines
+- Headline schema with level, keyword, tags, properties, planning
+- Property drawer schema
+- Validation functions
+
+*** TODO Implement headline text parser
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: high
+:WAVE: 1
+:WORKER: A
+:DEPENDS: schemas
+:END:
+Parse headline components:
+- TODO keywords (TODO, DONE, IN-PROGRESS, etc)
+- Priority markers ([#A], [#B], [#C])
+- Tags (:tag1:tag2:)
+- Title text
+
+*** TODO Implement property drawer parser
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: high
+:WAVE: 1
+:WORKER: B
+:END:
+Parse :PROPERTIES: ... :END: blocks:
+- Key-value extraction
+- Special properties (ID, CREATED, etc)
+- Custom property handling
+
+*** TODO Create test fixtures and sample org files
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: high
+:WAVE: 1
+:WORKER: C
+:END:
+Create test data:
+- Minimal org file
+- Complex nested headlines
+- Various TODO keywords
+- Property drawer variations
+- Edge cases (empty, special chars)
+
+** Phase 2: Document Parser & Writer (Wave 2)
+*** TODO Implement document-level parser
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: high
+:WAVE: 2
+:WORKER: A
+:DEPENDS: headline-parser
+:END:
+Parse file-level elements:
+- #+TITLE, #+AUTHOR, #+STARTUP
+- File-level properties
+- Comments and blank lines
+
+*** TODO Implement headline tree builder
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: high
+:WAVE: 2
+:WORKER: A
+:DEPENDS: headline-parser
+:END:
+Build nested structure from flat headlines:
+- Level-based nesting algorithm
+- Parent-child relationships
+- Sibling ordering
+
+*** TODO Implement headline writer/serializer
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: high
+:WAVE: 2
+:WORKER: B
+:DEPENDS: schemas
+:END:
+Serialize headline back to org format:
+- Stars based on level
+- TODO keyword formatting
+- Priority and tags
+- Property drawer formatting
+
+*** TODO Implement document writer
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: high
+:WAVE: 2
+:WORKER: B
+:DEPENDS: headline-writer
+:END:
+Full document serialization:
+- File-level properties
+- Headline tree traversal
+- Whitespace preservation
+
+*** TODO Add round-trip parser tests
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: high
+:WAVE: 2
+:WORKER: C
+:DEPENDS: parser, writer
+:END:
+Verify idempotent round-trips:
+- parse → write → parse = same structure
+- Test with real kanban.org
+- Property preservation
+
+** Phase 3: Query & Transform (Wave 3 - Parallelizable)
+*** TODO Implement find-by-id query
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 3
+:WORKER: A
+:DEPENDS: parser
+:END:
+Find headline by :ID property.
+
+*** TODO Implement find-by-status query
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 3
+:WORKER: A
+:DEPENDS: parser
+:END:
+Filter headlines by TODO keyword.
+
+*** TODO Implement find-by-property query
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 3
+:WORKER: A
+:DEPENDS: parser
+:END:
+Generic property-based queries.
+
+*** TODO Implement update-headline transform
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: medium
+:WAVE: 3
+:WORKER: B
+:DEPENDS: query
+:END:
+Update headline by ID with new values.
+
+*** TODO Implement set-status transform
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 3
+:WORKER: B
+:DEPENDS: query
+:END:
+Change TODO keyword on headline.
+
+*** TODO Implement set-property transform
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 3
+:WORKER: B
+:DEPENDS: query
+:END:
+Add/update property on headline.
+
+*** TODO Create kanban-specific operations
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: medium
+:WAVE: 3
+:WORKER: C
+:DEPENDS: parser
+:END:
+Kanban helpers:
+- kanban-tasks: Extract level-2 as tasks
+- kanban-move-task: Change status column
+- kanban-create-task: Add new task
+
+** Phase 4: MCP Integration (Wave 4)
+*** TODO Implement org_clj_parse MCP tool
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 4
+:WORKER: A
+:DEPENDS: parser
+:END:
+Parse org file to EDN/JSON.
+
+*** TODO Implement org_clj_write MCP tool
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 4
+:WORKER: A
+:DEPENDS: writer
+:END:
+Write EDN back to org file.
+
+*** TODO Implement org_clj_query MCP tool
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: medium
+:WAVE: 4
+:WORKER: A
+:DEPENDS: query
+:END:
+Query headlines via MCP.
+
+*** TODO Implement org_kanban_native_status MCP tool
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: medium
+:WAVE: 4
+:WORKER: B
+:DEPENDS: kanban-ops
+:END:
+Native kanban status (replaces elisp).
+
+*** TODO Implement org_kanban_native_move MCP tool
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: medium
+:WAVE: 4
+:WORKER: B
+:DEPENDS: kanban-ops
+:END:
+Native task move operation.
+
+** Phase 5: Polish (Wave 5)
+*** TODO Add document caching layer
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: low
+:WAVE: 5
+:END:
+Cache by file path + mtime.
+
+*** TODO Add telemetry for org-clj operations
+:PROPERTIES:
+:EFFORT: S
+:PRIORITY: low
+:WAVE: 5
+:END:
+Parse time, query performance metrics.
+
+*** TODO Update org-kanban.el for native backend
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: low
+:WAVE: 5
+:END:
+Add option to use Clojure backend with elisp fallback.
+
+*** TODO Write org-clj API documentation
+:PROPERTIES:
+:EFFORT: M
+:PRIORITY: low
+:WAVE: 5
+:END:
+API reference, usage examples, integration guide.
+
 
 
 

--- a/recipes/emacs-mcp
+++ b/recipes/emacs-mcp
@@ -1,3 +1,3 @@
 (emacs-mcp :fetcher github
            :repo "BuddhiLW/emacs-mcp"
-           :files ("elisp/*.el" "elisp/addons/*.el"))
+           :files ("elisp/emacs-mcp*.el" "elisp/addons/emacs-mcp*.el"))

--- a/src/emacs_mcp/org_clj/parser.clj
+++ b/src/emacs_mcp/org_clj/parser.clj
@@ -1,0 +1,603 @@
+(ns emacs-mcp.org-clj.parser
+  "Parser for org-mode files including headlines, property drawers, and planning lines.
+   
+   Property drawers look like:
+   :PROPERTIES:
+   :ID: some-uuid-value
+   :CREATED: 2025-01-01
+   :END:
+   
+   Planning lines look like:
+   CLOSED: [2025-01-01 Wed 14:30] SCHEDULED: <2025-01-02 Thu>
+   
+   Headlines look like:
+   ** TODO [#A] Task title :tag1:tag2:"
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing run-tests]]
+            [malli.core :as m]
+            [malli.error :as me]))
+
+;; =============================================================================
+;; Data Schemas (Malli)
+;; =============================================================================
+
+(def TodoKeyword
+  "Valid TODO keywords"
+  [:enum "TODO" "DONE" "IN-PROGRESS" "IN-REVIEW" "CANCELLED" nil])
+
+(def Priority
+  "Priority markers"
+  [:enum "A" "B" "C" nil])
+
+(def Headline
+  "Schema for an org headline"
+  [:map
+   [:type [:= :headline]]
+   [:level :int]
+   [:keyword {:optional true} [:maybe :string]]
+   [:priority {:optional true} [:maybe :string]]
+   [:title :string]
+   [:tags {:optional true} [:vector :string]]
+   [:properties {:optional true} [:map-of :keyword :string]]
+   [:planning {:optional true} [:map
+                                [:closed {:optional true} [:maybe :string]]
+                                [:scheduled {:optional true} [:maybe :string]]
+                                [:deadline {:optional true} [:maybe :string]]]]
+   [:content {:optional true} [:vector :any]]
+   [:children {:optional true} [:vector [:ref #'Headline]]]])
+
+(def Document
+  "Schema for an org document"
+  [:map
+   [:type [:= :document]]
+   [:properties {:optional true} [:map-of :keyword :string]]
+   [:headlines [:vector Headline]]])
+
+(defn validate-headline
+  "Validate a headline map against the schema"
+  [headline]
+  (if (m/validate Headline headline)
+    {:valid true :data headline}
+    {:valid false :errors (me/humanize (m/explain Headline headline))}))
+
+(defn validate-document
+  "Validate a document map against the schema"
+  [doc]
+  (if (m/validate Document doc)
+    {:valid true :data doc}
+    {:valid false :errors (me/humanize (m/explain Document doc))}))
+
+;; =============================================================================
+;; Headline Text Parsing
+;; =============================================================================
+
+(def ^:private todo-keywords
+  "Set of recognized TODO keywords"
+  #{"TODO" "DONE" "IN-PROGRESS" "IN-REVIEW" "CANCELLED"})
+
+(defn parse-headline-text
+  "Parse an org headline text into its components.
+   
+   Input: string like '** TODO [#A] Task title :tag1:tag2:'
+   Output: map with :level, :keyword, :priority, :title, :tags
+   
+   Example:
+     (parse-headline-text \"** TODO [#A] My task :work:urgent:\")
+     => {:level 2, :keyword \"TODO\", :priority \"A\", 
+         :title \"My task\", :tags [\"work\" \"urgent\"]}"
+  [line]
+  (when (and line (str/starts-with? (str/trim line) "*"))
+    (let [trimmed (str/trim line)
+          ;; Count stars for level
+          stars (re-find #"^\*+" trimmed)
+          level (count stars)
+          rest-line (str/trim (subs trimmed level))
+
+          ;; Extract TODO keyword
+          first-word (first (str/split rest-line #"\s+" 2))
+          has-keyword? (contains? todo-keywords first-word)
+          keyword (when has-keyword? first-word)
+          after-keyword (if has-keyword?
+                          (str/trim (subs rest-line (count first-word)))
+                          rest-line)
+
+          ;; Extract priority [#A]
+          priority-match (re-find #"^\[#([A-C])\]\s*" after-keyword)
+          priority (when priority-match (second priority-match))
+          after-priority (if priority-match
+                           (str/trim (subs after-keyword (count (first priority-match))))
+                           after-keyword)
+
+          ;; Extract tags :tag1:tag2: at end of line
+          tags-match (re-find #"\s+:([\w:]+):$" after-priority)
+          tags (when tags-match
+                 (vec (filter (complement str/blank?)
+                              (str/split (second tags-match) #":"))))
+          title (if tags-match
+                  (str/trim (subs after-priority 0 (- (count after-priority)
+                                                      (count (first tags-match)))))
+                  (str/trim after-priority))]
+
+      {:type :headline
+       :level level
+       :keyword keyword
+       :priority priority
+       :title title
+       :tags (or tags [])})))
+
+(defn headline?
+  "Check if a line is a headline"
+  [line]
+  (and line (re-matches #"^\*+\s+.*" (str/trim line))))
+
+(defn headline-level
+  "Get the level of a headline (number of stars)"
+  [line]
+  (when (headline? line)
+    (count (re-find #"^\*+" (str/trim line)))))
+
+;; =============================================================================
+;; Property Drawer Parsing
+;; =============================================================================
+
+(defn- parse-property-line
+  "Parse a single property line like ':KEY: value'.
+   Returns [key value] or nil if the line doesn't match."
+  [line]
+  (when-let [[_ key value] (re-matches #"^\s*:([^:]+):\s*(.*)$" (str/trim line))]
+    [(keyword key) (str/trim value)]))
+
+(defn parse-property-drawer
+  "Parse property drawer lines (between :PROPERTIES: and :END:).
+   
+   Input: vector of strings representing lines inside the drawer
+   Output: map of keyword keys to string values
+   
+   Example:
+     (parse-property-drawer [\":ID: abc-123\" \":CREATED: 2025-01-01\"])
+     => {:ID \"abc-123\", :CREATED \"2025-01-01\"}"
+  [lines]
+  (if (or (nil? lines) (empty? lines))
+    {}
+    (->> lines
+         (map str/trim)
+         (filter (complement str/blank?))
+         (map parse-property-line)
+         (filter some?)
+         (into {}))))
+
+;; =============================================================================
+;; Planning Line Parsing
+;; =============================================================================
+
+(defn- extract-timestamp
+  "Extract timestamp from org timestamp format.
+   Handles both active <...> and inactive [...] timestamps.
+   Returns the inner content without brackets."
+  [s]
+  (when s
+    (let [s (str/trim s)]
+      (cond
+        (and (str/starts-with? s "[") (str/ends-with? s "]"))
+        (subs s 1 (dec (count s)))
+
+        (and (str/starts-with? s "<") (str/ends-with? s ">"))
+        (subs s 1 (dec (count s)))
+
+        :else s))))
+
+(defn- parse-planning-keyword
+  "Parse a single planning keyword and its timestamp.
+   Returns [keyword timestamp-string] or nil."
+  [text keyword-name]
+  (let [pattern (re-pattern (str "(?i)" keyword-name ":\\s*([<\\[][^>\\]]+[>\\]])"))
+        match (re-find pattern text)]
+    (when match
+      [(keyword (str/lower-case keyword-name))
+       (extract-timestamp (second match))])))
+
+(defn parse-planning-line
+  "Parse org-mode planning line containing CLOSED, SCHEDULED, DEADLINE.
+   
+   Input: string like 'CLOSED: [2025-01-01 Wed] SCHEDULED: <2025-01-02>'
+   Output: map with :closed, :scheduled, :deadline keys (only present if found)
+   
+   Example:
+     (parse-planning-line \"CLOSED: [2025-01-01 Wed 14:30] SCHEDULED: <2025-01-02 Thu>\")
+     => {:closed \"2025-01-01 Wed 14:30\", :scheduled \"2025-01-02 Thu\"}"
+  [line]
+  (if (or (nil? line) (str/blank? line))
+    {}
+    (let [keywords ["CLOSED" "SCHEDULED" "DEADLINE"]
+          parsed (keep #(parse-planning-keyword line %) keywords)]
+      (into {} parsed))))
+
+;; =============================================================================
+;; Utility Functions
+;; =============================================================================
+
+(defn extract-property-drawer
+  "Extract property drawer from a sequence of org lines.
+   Returns {:properties map, :remaining-lines lines-after-drawer}
+   or {:properties nil, :remaining-lines all-lines} if no drawer found."
+  [lines]
+  (let [lines-vec (vec lines)
+        start-idx (some (fn [[idx line]]
+                          (when (re-matches #"^\s*:PROPERTIES:\s*$" (str/trim line))
+                            idx))
+                        (map-indexed vector lines-vec))]
+    (if start-idx
+      (let [end-idx (some (fn [[idx line]]
+                            (when (and (> idx start-idx)
+                                       (re-matches #"^\s*:END:\s*$" (str/trim line)))
+                              idx))
+                          (map-indexed vector lines-vec))]
+        (if end-idx
+          {:properties (parse-property-drawer (subvec lines-vec (inc start-idx) end-idx))
+           :remaining-lines (vec (concat (subvec lines-vec 0 start-idx)
+                                         (subvec lines-vec (inc end-idx))))}
+          {:properties nil
+           :remaining-lines lines-vec}))
+      {:properties nil
+       :remaining-lines lines-vec})))
+
+(defn parse-headline-metadata
+  "Parse metadata from lines immediately following a headline.
+   Extracts planning info and property drawer.
+   
+   Input: vector of lines after the headline
+   Output: {:planning {...}, :properties {...}, :remaining-lines [...]}"
+  [lines]
+  (if (empty? lines)
+    {:planning {} :properties {} :remaining-lines []}
+    (let [first-line (str/trim (first lines))
+          ;; Check if first line is a planning line
+          has-planning? (re-find #"(?i)^(CLOSED|SCHEDULED|DEADLINE):" first-line)
+          planning (if has-planning?
+                     (parse-planning-line first-line)
+                     {})
+          remaining-after-planning (if has-planning?
+                                     (rest lines)
+                                     lines)
+          ;; Now check for property drawer
+          {:keys [properties remaining-lines]} (extract-property-drawer remaining-after-planning)]
+      {:planning planning
+       :properties (or properties {})
+       :remaining-lines remaining-lines})))
+
+;; =============================================================================
+;; Document-Level Parsing
+;; =============================================================================
+
+(defn- parse-file-property
+  "Parse a file-level property like #+TITLE: value"
+  [line]
+  (when-let [[_ key value] (re-matches #"^\s*#\+([A-Za-z_]+):\s*(.*)$" line)]
+    [(keyword (str/upper-case key)) (str/trim value)]))
+
+(defn parse-file-properties
+  "Extract file-level properties (#+KEY: value) from org lines.
+   Returns {:properties map, :remaining-lines lines-without-properties}"
+  [lines]
+  (loop [remaining lines
+         props {}]
+    (if (empty? remaining)
+      {:properties props :remaining-lines []}
+      (let [line (first remaining)
+            trimmed (str/trim line)]
+        (if (or (str/blank? trimmed)
+                (str/starts-with? trimmed "#"))
+          (if-let [[k v] (parse-file-property trimmed)]
+            (recur (rest remaining) (assoc props k v))
+            (if (str/blank? trimmed)
+              (recur (rest remaining) props)
+              {:properties props :remaining-lines remaining}))
+          {:properties props :remaining-lines remaining})))))
+
+(defn- collect-headline-content
+  "Collect content lines until the next headline or end of input.
+   Returns {:content lines, :rest remaining-lines}"
+  [lines]
+  (loop [content []
+         remaining lines]
+    (if (empty? remaining)
+      {:content content :rest []}
+      (let [line (first remaining)]
+        (if (headline? line)
+          {:content content :rest remaining}
+          (recur (conj content line) (rest remaining)))))))
+
+(defn- parse-single-headline
+  "Parse a single headline and its immediate content (not children).
+   Returns headline map with :content but empty :children"
+  [headline-line following-lines]
+  (let [base (parse-headline-text headline-line)
+        {:keys [planning properties remaining-lines]} (parse-headline-metadata following-lines)
+        {:keys [content rest]} (collect-headline-content remaining-lines)]
+    (-> base
+        (assoc :planning planning)
+        (assoc :properties properties)
+        (assoc :content (vec (filter (complement str/blank?) content)))
+        (assoc :children [])
+        (with-meta {:remaining-lines rest}))))
+
+(defn- build-headline-tree
+  "Build a tree of headlines from a flat sequence.
+   Headlines are nested based on their level."
+  [headlines]
+  (when (seq headlines)
+    (let [first-hl (first headlines)
+          first-level (:level first-hl)
+          rest-hls (rest headlines)]
+      (loop [result [(dissoc first-hl :children)]
+             remaining rest-hls]
+        (if (empty? remaining)
+          result
+          (let [current (first remaining)
+                current-level (:level current)]
+            (cond
+              ;; Same level - add as sibling
+              (= current-level first-level)
+              (recur (conj result (dissoc current :children))
+                     (rest remaining))
+
+              ;; Higher level (more stars) - this is a child of the last item
+              (> current-level first-level)
+              (let [;; Find all consecutive items at higher levels (children subtree)
+                    child-items (take-while #(> (:level %) first-level) remaining)
+                    rest-after-children (drop (count child-items) remaining)
+                    ;; Recursively build children
+                    children (build-headline-tree child-items)
+                    ;; Update last item with children
+                    updated-last (update (peek result) :children
+                                         (fnil into []) children)]
+                (recur (conj (pop result) updated-last)
+                       rest-after-children))
+
+              ;; Lower level - we're done with this subtree
+              :else
+              result)))))))
+
+(defn parse-headlines
+  "Parse all headlines from org lines into a flat sequence.
+   Each headline includes its metadata and content."
+  [lines]
+  (loop [remaining lines
+         headlines []]
+    (if (empty? remaining)
+      headlines
+      (let [line (first remaining)]
+        (if (headline? line)
+          (let [hl (parse-single-headline line (rest remaining))
+                rest-lines (:remaining-lines (meta hl))]
+            (recur rest-lines (conj headlines (vary-meta hl dissoc :remaining-lines))))
+          (recur (rest remaining) headlines))))))
+
+(defn parse-document
+  "Parse a complete org document from text or lines.
+   
+   Input: string (full file content) or vector of lines
+   Output: {:type :document, :properties {...}, :headlines [...]}
+   
+   Example:
+     (parse-document \"#+TITLE: My Doc\\n* Heading 1\\n** TODO Task\")
+     => {:type :document
+         :properties {:TITLE \"My Doc\"}
+         :headlines [{:type :headline :level 1 :title \"Heading 1\"
+                      :children [{:type :headline :level 2 :keyword \"TODO\" ...}]}]}"
+  [input]
+  (let [lines (if (string? input)
+                (str/split-lines input)
+                (vec input))
+        {:keys [properties remaining-lines]} (parse-file-properties lines)
+        flat-headlines (parse-headlines remaining-lines)
+        nested-headlines (build-headline-tree flat-headlines)]
+    {:type :document
+     :properties properties
+     :headlines (or nested-headlines [])}))
+
+;; =============================================================================
+;; Tests
+;; =============================================================================
+
+(deftest test-parse-property-line
+  (testing "Basic property parsing"
+    (is (= [:ID "abc-123"] (parse-property-line ":ID: abc-123")))
+    (is (= [:CREATED "2025-01-01"] (parse-property-line ":CREATED: 2025-01-01"))))
+
+  (testing "Property with spaces in value"
+    (is (= [:TITLE "My Important Task"] (parse-property-line ":TITLE: My Important Task"))))
+
+  (testing "Property with special characters"
+    (is (= [:URL "https://example.com/path?q=1&r=2"]
+           (parse-property-line ":URL: https://example.com/path?q=1&r=2"))))
+
+  (testing "Property with leading/trailing whitespace"
+    (is (= [:ID "trimmed"] (parse-property-line "  :ID:   trimmed  "))))
+
+  (testing "Empty value"
+    (is (= [:EMPTY ""] (parse-property-line ":EMPTY:"))))
+
+  (testing "Invalid lines return nil"
+    (is (nil? (parse-property-line "not a property")))
+    (is (nil? (parse-property-line "")))))
+
+(deftest test-parse-property-drawer
+  (testing "Normal property drawer"
+    (is (= {:ID "abc-123" :CREATED "2025-01-01"}
+           (parse-property-drawer [":ID: abc-123" ":CREATED: 2025-01-01"]))))
+
+  (testing "Empty drawer"
+    (is (= {} (parse-property-drawer [])))
+    (is (= {} (parse-property-drawer nil))))
+
+  (testing "Drawer with blank lines"
+    (is (= {:ID "abc"} (parse-property-drawer [":ID: abc" "" "  "]))))
+
+  (testing "Multi-word values preserved"
+    (is (= {:DESCRIPTION "This is a long description with spaces"}
+           (parse-property-drawer [":DESCRIPTION: This is a long description with spaces"]))))
+
+  (testing "Special characters in values"
+    (is (= {:EXPR "(+ 1 2)" :PATH "/home/user/file.org"}
+           (parse-property-drawer [":EXPR: (+ 1 2)" ":PATH: /home/user/file.org"])))))
+
+(deftest test-parse-planning-line
+  (testing "CLOSED only"
+    (is (= {:closed "2025-01-01 Wed"}
+           (parse-planning-line "CLOSED: [2025-01-01 Wed]"))))
+
+  (testing "SCHEDULED only"
+    (is (= {:scheduled "2025-01-02 Thu"}
+           (parse-planning-line "SCHEDULED: <2025-01-02 Thu>"))))
+
+  (testing "DEADLINE only"
+    (is (= {:deadline "2025-01-03 Fri 10:00"}
+           (parse-planning-line "DEADLINE: <2025-01-03 Fri 10:00>"))))
+
+  (testing "Multiple planning keywords"
+    (is (= {:closed "2025-01-01 Wed 14:30" :scheduled "2025-01-02 Thu"}
+           (parse-planning-line "CLOSED: [2025-01-01 Wed 14:30] SCHEDULED: <2025-01-02 Thu>"))))
+
+  (testing "All three keywords"
+    (is (= {:closed "2025-01-01" :scheduled "2025-01-02" :deadline "2025-01-03"}
+           (parse-planning-line "CLOSED: [2025-01-01] SCHEDULED: <2025-01-02> DEADLINE: <2025-01-03>"))))
+
+  (testing "Empty and nil input"
+    (is (= {} (parse-planning-line "")))
+    (is (= {} (parse-planning-line nil)))
+    (is (= {} (parse-planning-line "   ")))))
+
+(deftest test-extract-property-drawer
+  (testing "Extract drawer from lines"
+    (let [lines [":PROPERTIES:" ":ID: test-id" ":END:" "Content here"]
+          result (extract-property-drawer lines)]
+      (is (= {:ID "test-id"} (:properties result)))
+      (is (= ["Content here"] (:remaining-lines result)))))
+
+  (testing "No drawer present"
+    (let [lines ["Just some content" "More content"]
+          result (extract-property-drawer lines)]
+      (is (nil? (:properties result)))
+      (is (= lines (:remaining-lines result)))))
+
+  (testing "Unclosed drawer"
+    (let [lines [":PROPERTIES:" ":ID: test-id" "Missing END"]
+          result (extract-property-drawer lines)]
+      (is (nil? (:properties result))))))
+
+(deftest test-parse-headline-metadata
+  (testing "Planning and properties"
+    (let [lines ["CLOSED: [2025-01-01]"
+                 ":PROPERTIES:"
+                 ":ID: headline-1"
+                 ":END:"
+                 "Body content"]
+          result (parse-headline-metadata lines)]
+      (is (= {:closed "2025-01-01"} (:planning result)))
+      (is (= {:ID "headline-1"} (:properties result)))
+      (is (= ["Body content"] (:remaining-lines result)))))
+
+  (testing "Properties only (no planning)"
+    (let [lines [":PROPERTIES:"
+                 ":ID: headline-2"
+                 ":END:"
+                 "Body"]
+          result (parse-headline-metadata lines)]
+      (is (= {} (:planning result)))
+      (is (= {:ID "headline-2"} (:properties result)))))
+
+  (testing "Planning only (no properties)"
+    (let [lines ["SCHEDULED: <2025-01-02>"
+                 "Body content"]
+          result (parse-headline-metadata lines)]
+      (is (= {:scheduled "2025-01-02"} (:planning result)))
+      (is (= {} (:properties result)))))
+
+  (testing "Empty input"
+    (let [result (parse-headline-metadata [])]
+      (is (= {} (:planning result)))
+      (is (= {} (:properties result)))
+      (is (= [] (:remaining-lines result))))))
+
+(deftest test-parse-headline-text
+  (testing "Basic headline with TODO"
+    (is (= {:type :headline
+            :level 2
+            :keyword "TODO"
+            :priority nil
+            :title "Task title"
+            :tags []}
+           (parse-headline-text "** TODO Task title"))))
+
+  (testing "Headline with priority"
+    (is (= {:type :headline
+            :level 1
+            :keyword "TODO"
+            :priority "A"
+            :title "Important task"
+            :tags []}
+           (parse-headline-text "* TODO [#A] Important task"))))
+
+  (testing "Headline with tags"
+    (is (= {:type :headline
+            :level 2
+            :keyword "DONE"
+            :priority nil
+            :title "Completed task"
+            :tags ["work" "urgent"]}
+           (parse-headline-text "** DONE Completed task :work:urgent:"))))
+
+  (testing "Full headline with everything"
+    (is (= {:type :headline
+            :level 3
+            :keyword "IN-PROGRESS"
+            :priority "B"
+            :title "Complex task"
+            :tags ["project" "dev"]}
+           (parse-headline-text "*** IN-PROGRESS [#B] Complex task :project:dev:"))))
+
+  (testing "Headline without TODO keyword"
+    (is (= {:type :headline
+            :level 1
+            :keyword nil
+            :priority nil
+            :title "Just a heading"
+            :tags []}
+           (parse-headline-text "* Just a heading"))))
+
+  (testing "Headline with only tags"
+    (is (= {:type :headline
+            :level 2
+            :keyword nil
+            :priority nil
+            :title "Tagged heading"
+            :tags ["tag1" "tag2" "tag3"]}
+           (parse-headline-text "** Tagged heading :tag1:tag2:tag3:"))))
+
+  (testing "Non-headline returns nil"
+    (is (nil? (parse-headline-text "Not a headline")))
+    (is (nil? (parse-headline-text "")))
+    (is (nil? (parse-headline-text nil)))))
+
+(comment
+  ;; Run tests
+  (run-tests)
+
+  ;; Example usage
+  (parse-property-drawer [":ID: abc-123" ":CREATED: 2025-01-01"])
+  ;; => {:ID "abc-123", :CREATED "2025-01-01"}
+
+  (parse-planning-line "CLOSED: [2025-01-01 Wed 14:30] SCHEDULED: <2025-01-02 Thu>")
+  ;; => {:closed "2025-01-01 Wed 14:30", :scheduled "2025-01-02 Thu"}
+
+  (parse-headline-metadata ["CLOSED: [2025-01-01]"
+                            ":PROPERTIES:"
+                            ":ID: task-1"
+                            ":CATEGORY: work"
+                            ":END:"
+                            "This is the body"])
+  ;; => {:planning {:closed "2025-01-01"},
+  ;;     :properties {:ID "task-1", :CATEGORY "work"},
+  ;;     :remaining-lines ["This is the body"]}
+  )

--- a/src/emacs_mcp/org_clj/query.clj
+++ b/src/emacs_mcp/org_clj/query.clj
@@ -1,0 +1,187 @@
+(ns emacs-mcp.org-clj.query
+  "Query functions for finding and filtering org headlines."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;; =============================================================================
+;; Tree Traversal
+;; =============================================================================
+
+(defn flatten-headlines
+  "Flatten a nested headline tree into a sequence.
+   Visits all headlines depth-first."
+  [headlines]
+  (mapcat (fn [hl]
+            (cons hl (flatten-headlines (:children hl))))
+          headlines))
+
+(defn all-headlines
+  "Get all headlines from a document as a flat sequence."
+  [doc]
+  (flatten-headlines (:headlines doc)))
+
+;; =============================================================================
+;; Query by ID
+;; =============================================================================
+
+(defn find-by-id
+  "Find a headline by its :ID property.
+   Searches the entire document tree."
+  [doc id]
+  (first (filter #(= (get-in % [:properties :ID]) id)
+                 (all-headlines doc))))
+
+(defn find-by-vibe-id
+  "Find a headline by its :VIBE_ID property."
+  [doc vibe-id]
+  (first (filter #(= (get-in % [:properties :VIBE_ID]) vibe-id)
+                 (all-headlines doc))))
+
+;; =============================================================================
+;; Query by Status
+;; =============================================================================
+
+(defn find-by-status
+  "Find all headlines with a specific TODO keyword.
+   Pass nil to find headlines without any keyword."
+  [doc status]
+  (filter #(= (:keyword %) status)
+          (all-headlines doc)))
+
+(defn find-todo
+  "Find all TODO items (headlines with keyword TODO)."
+  [doc]
+  (find-by-status doc "TODO"))
+
+(defn find-done
+  "Find all DONE items."
+  [doc]
+  (find-by-status doc "DONE"))
+
+(defn find-in-progress
+  "Find all IN-PROGRESS items."
+  [doc]
+  (find-by-status doc "IN-PROGRESS"))
+
+;; =============================================================================
+;; Query by Property
+;; =============================================================================
+
+(defn find-by-property
+  "Find headlines where a property matches a value.
+   
+   Examples:
+     (find-by-property doc :EFFORT \"M\")
+     (find-by-property doc :PRIORITY \"high\")"
+  [doc prop-key prop-value]
+  (filter #(= (get-in % [:properties prop-key]) prop-value)
+          (all-headlines doc)))
+
+(defn find-by-property-exists
+  "Find headlines that have a specific property (any value)."
+  [doc prop-key]
+  (filter #(contains? (:properties %) prop-key)
+          (all-headlines doc)))
+
+;; =============================================================================
+;; Query by Level
+;; =============================================================================
+
+(defn find-by-level
+  "Find all headlines at a specific level."
+  [doc level]
+  (filter #(= (:level %) level)
+          (all-headlines doc)))
+
+(defn find-tasks
+  "Find all task-level headlines (level 2 by default).
+   These are typically the actionable items in a kanban."
+  ([doc] (find-tasks doc 2))
+  ([doc level] (find-by-level doc level)))
+
+;; =============================================================================
+;; Query by Tags
+;; =============================================================================
+
+(defn find-by-tag
+  "Find all headlines with a specific tag."
+  [doc tag]
+  (filter #(some #{tag} (:tags %))
+          (all-headlines doc)))
+
+(defn find-by-tags
+  "Find headlines that have ALL specified tags."
+  [doc tags]
+  (filter #(every? (set (:tags %)) tags)
+          (all-headlines doc)))
+
+;; =============================================================================
+;; Predicate-based Query
+;; =============================================================================
+
+(defn find-where
+  "Find all headlines matching a predicate function.
+   
+   Example:
+     (find-where doc #(and (= (:keyword %) \"TODO\")
+                           (= (:level %) 2)))"
+  [doc pred]
+  (filter pred (all-headlines doc)))
+
+;; =============================================================================
+;; Statistics
+;; =============================================================================
+
+(defn status-counts
+  "Get count of headlines by TODO keyword."
+  [doc]
+  (frequencies (map :keyword (all-headlines doc))))
+
+(defn task-stats
+  "Get task statistics for kanban-style reporting."
+  [doc]
+  (let [tasks (find-tasks doc)
+        by-status (group-by :keyword tasks)]
+    {:total (count tasks)
+     :todo (count (get by-status "TODO" []))
+     :in-progress (count (get by-status "IN-PROGRESS" []))
+     :in-review (count (get by-status "IN-REVIEW" []))
+     :done (count (get by-status "DONE" []))
+     :cancelled (count (get by-status "CANCELLED" []))}))
+
+;; =============================================================================
+;; Tests
+;; =============================================================================
+
+(deftest test-flatten-headlines
+  (testing "Flattens nested headlines"
+    (let [headlines [{:title "A" :children [{:title "A1" :children []}
+                                            {:title "A2" :children []}]}
+                     {:title "B" :children []}]]
+      (is (= ["A" "A1" "A2" "B"]
+             (map :title (flatten-headlines headlines)))))))
+
+(deftest test-find-by-status
+  (testing "Finds by TODO keyword"
+    (let [doc {:headlines [{:keyword "TODO" :title "Task 1" :children []}
+                           {:keyword "DONE" :title "Task 2" :children []}
+                           {:keyword "TODO" :title "Task 3" :children []}]}]
+      (is (= 2 (count (find-by-status doc "TODO"))))
+      (is (= 1 (count (find-by-status doc "DONE")))))))
+
+(deftest test-find-by-property
+  (testing "Finds by property value"
+    (let [doc {:headlines [{:properties {:ID "a"} :children []}
+                           {:properties {:ID "b"} :children []}]}]
+      (is (= "a" (get-in (first (find-by-property doc :ID "a")) [:properties :ID]))))))
+
+(comment
+  ;; Example usage with kanban.org
+  (require '[emacs-mcp.org-clj.parser :as parser])
+  (def doc (parser/parse-document (slurp "kanban.org")))
+
+  (count (all-headlines doc))
+  (find-todo doc)
+  (find-done doc)
+  (task-stats doc)
+  (find-by-property doc :EFFORT "M"))

--- a/src/emacs_mcp/org_clj/render.clj
+++ b/src/emacs_mcp/org_clj/render.clj
@@ -1,0 +1,193 @@
+(ns emacs-mcp.org-clj.render
+  "Kanban board rendering with pluggable adapters (OCP).
+   
+   Architecture:
+   - `KanbanRenderer` protocol defines the port
+   - Each adapter (terminal, emacs, html, web) implements the protocol
+   - `render-board` is the main entry point
+   
+   To add a new renderer:
+   1. Create a new record implementing KanbanRenderer
+   2. Implement render-board, render-column, render-card methods
+   3. No changes needed to existing code (OCP)"
+  (:require [clojure.string :as str]
+            [emacs-mcp.org-clj.parser :as parser]
+            [emacs-mcp.org-clj.query :as query]))
+
+;; =============================================================================
+;; Protocol (Port)
+;; =============================================================================
+
+(defprotocol KanbanRenderer
+  "Protocol for rendering kanban boards. Implement this to add new output formats."
+  (render-board [this board-data]
+    "Render the complete kanban board. Returns renderer-specific output.")
+  (render-column [this column-name tasks]
+    "Render a single column with its tasks.")
+  (render-card [this task]
+    "Render a single task card."))
+
+;; =============================================================================
+;; Board Data Extraction
+;; =============================================================================
+
+(defn extract-board-data
+  "Extract kanban board data from a parsed org document.
+   Returns {:columns [...] :stats {...} :title ...}"
+  [doc]
+  (let [stats (query/task-stats doc)
+        todos (query/find-todo doc)
+        in-progress (query/find-in-progress doc)
+        in-review (query/find-by-status doc "IN-REVIEW")
+        done (query/find-done doc)]
+    {:title (get-in doc [:properties :TITLE] "Kanban Board")
+     :stats stats
+     :columns [{:name "TODO" :tasks todos :emoji "📋"}
+               {:name "IN-PROGRESS" :tasks in-progress :emoji "🔄"}
+               {:name "IN-REVIEW" :tasks in-review :emoji "👀"}
+               {:name "DONE" :tasks done :emoji "✅"}]}))
+
+(defn load-board
+  "Load kanban board data from an org file path."
+  [file-path]
+  (let [content (slurp file-path)
+        doc (parser/parse-document content)]
+    (extract-board-data doc)))
+
+;; =============================================================================
+;; Terminal ASCII Adapter
+;; =============================================================================
+
+(defrecord TerminalRenderer [width column-width max-cards]
+  KanbanRenderer
+
+  (render-card [_ task]
+    (let [title (or (:title task) "Untitled")
+          id (get-in task [:properties :ID] "")
+          short-id (if (> (count id) 8) (subs id 0 8) id)
+          truncated (if (> (count title) (- column-width 4))
+                      (str (subs title 0 (- column-width 7)) "...")
+                      title)]
+      (str "│ " truncated (apply str (repeat (- column-width (count truncated) 3) " ")) "│")))
+
+  (render-column [this column-name tasks]
+    (let [col-w column-width
+          header (str "┌" (apply str (repeat (- col-w 2) "─")) "┐")
+          title-line (let [padded (str " " column-name " (" (count tasks) ") ")]
+                       (str "│" padded (apply str (repeat (- col-w (count padded) 2) " ")) "│"))
+          separator (str "├" (apply str (repeat (- col-w 2) "─")) "┤")
+          footer (str "└" (apply str (repeat (- col-w 2) "─")) "┘")
+          task-cards (take max-cards (map #(render-card this %) tasks))
+          more-indicator (when (> (count tasks) max-cards)
+                           (str "│ ..." (- (count tasks) max-cards) " more"
+                                (apply str (repeat (- col-w 12) " ")) "│"))]
+      (str/join "\n" (concat [header title-line separator]
+                             task-cards
+                             (when more-indicator [more-indicator])
+                             [footer]))))
+
+  (render-board [this {:keys [title stats columns]}]
+    (let [col-outputs (map #(render-column this (:name %) (:tasks %)) columns)
+          col-lines (map str/split-lines col-outputs)
+          max-height (apply max (map count col-lines))
+          padded-cols (map (fn [lines]
+                             (concat lines (repeat (- max-height (count lines))
+                                                   (str "│" (apply str (repeat (- column-width 2) " ")) "│"))))
+                           col-lines)
+          merged-lines (apply map (fn [& rows] (str/join "  " rows)) padded-cols)
+          header (str "\n  " title "\n"
+                      "  Stats: " (:total stats) " total | "
+                      (:todo stats) " todo | "
+                      (:in-progress stats) " in-progress | "
+                      (:done stats) " done\n")]
+      (str header "\n" (str/join "\n" merged-lines) "\n"))))
+
+(defn terminal-renderer
+  "Create a terminal ASCII renderer.
+   Options:
+   - :width - total width (default 120)
+   - :column-width - width per column (default 28)
+   - :max-cards - max cards per column (default 10)"
+  ([] (terminal-renderer {}))
+  ([{:keys [width column-width max-cards]
+     :or {width 120 column-width 28 max-cards 10}}]
+   (->TerminalRenderer width column-width max-cards)))
+
+;; =============================================================================
+;; Emacs Buffer Adapter
+;; =============================================================================
+
+(defrecord EmacsRenderer [buffer-name use-colors]
+  KanbanRenderer
+
+  (render-card [_ task]
+    (let [title (or (:title task) "Untitled")
+          id (get-in task [:properties :ID] "")
+          priority (get-in task [:properties :PRIORITY])]
+      (str "  • " title
+           (when priority (str " [" priority "]"))
+           "\n")))
+
+  (render-column [this column-name tasks]
+    (let [header (str "** " column-name " (" (count tasks) ")\n")
+          cards (str/join "" (map #(render-card this %) tasks))]
+      (str header cards)))
+
+  (render-board [this {:keys [title stats columns]}]
+    (let [org-header (str "#+TITLE: " title " - Kanban View\n"
+                          "#+STARTUP: showall\n\n"
+                          "* Overview\n"
+                          "  - Total: " (:total stats) "\n"
+                          "  - TODO: " (:todo stats) "\n"
+                          "  - In Progress: " (:in-progress stats) "\n"
+                          "  - Done: " (:done stats) "\n\n"
+                          "* Board\n")
+          col-outputs (map #(render-column this (:name %) (:tasks %)) columns)]
+      (str org-header (str/join "\n" col-outputs)))))
+
+(defn emacs-renderer
+  "Create an Emacs buffer renderer.
+   Options:
+   - :buffer-name - name of the buffer (default *kanban*)
+   - :use-colors - use org-mode faces (default true)"
+  ([] (emacs-renderer {}))
+  ([{:keys [buffer-name use-colors]
+     :or {buffer-name "*kanban*" use-colors true}}]
+   (->EmacsRenderer buffer-name use-colors)))
+
+;; =============================================================================
+;; Convenience Functions
+;; =============================================================================
+
+(defn render-file
+  "Render a kanban board from an org file.
+   renderer - a KanbanRenderer implementation
+   file-path - path to the org file"
+  [renderer file-path]
+  (let [board-data (load-board file-path)]
+    (render-board renderer board-data)))
+
+(defn render-to-terminal
+  "Quick function to render org file to terminal."
+  [file-path]
+  (render-file (terminal-renderer) file-path))
+
+(defn render-to-emacs
+  "Quick function to render org file for Emacs buffer."
+  [file-path]
+  (render-file (emacs-renderer) file-path))
+
+;; =============================================================================
+;; REPL Testing
+;; =============================================================================
+
+(comment
+  ;; Terminal rendering
+  (println (render-to-terminal "/home/lages/dotfiles/gitthings/emacs-mcp/kanban.org"))
+
+  ;; Emacs rendering
+  (println (render-to-emacs "/home/lages/dotfiles/gitthings/emacs-mcp/kanban.org"))
+
+  ;; Custom renderer
+  (println (render-file (terminal-renderer {:column-width 35 :max-cards 5})
+                        "/home/lages/dotfiles/gitthings/emacs-mcp/kanban.org")))

--- a/src/emacs_mcp/org_clj/transform.clj
+++ b/src/emacs_mcp/org_clj/transform.clj
@@ -1,0 +1,250 @@
+(ns emacs-mcp.org-clj.transform
+  "Transform functions for modifying org documents immutably."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [emacs-mcp.org-clj.query :as query]))
+
+;; =============================================================================
+;; Headline Tree Updates
+;; =============================================================================
+
+(defn update-headline-in-tree
+  "Update a headline in a tree by applying f to matching headlines.
+   pred is a function that returns true for headlines to update.
+   f is applied to each matching headline."
+  [headlines pred f]
+  (mapv (fn [hl]
+          (let [updated (if (pred hl) (f hl) hl)
+                children (:children updated)]
+            (if (seq children)
+              (assoc updated :children (update-headline-in-tree children pred f))
+              updated)))
+        headlines))
+
+(defn update-in-document
+  "Update headlines in a document matching pred by applying f."
+  [doc pred f]
+  (update doc :headlines update-headline-in-tree pred f))
+
+;; =============================================================================
+;; Update by ID
+;; =============================================================================
+
+(defn update-by-id
+  "Update a headline by its :ID property.
+   
+   Example:
+     (update-by-id doc \"task-123\" assoc :keyword \"DONE\")"
+  [doc id f & args]
+  (update-in-document doc
+                      #(= (get-in % [:properties :ID]) id)
+                      #(apply f % args)))
+
+(defn update-by-vibe-id
+  "Update a headline by its :VIBE_ID property."
+  [doc vibe-id f & args]
+  (update-in-document doc
+                      #(= (get-in % [:properties :VIBE_ID]) vibe-id)
+                      #(apply f % args)))
+
+;; =============================================================================
+;; Status Changes
+;; =============================================================================
+
+(defn set-status
+  "Set the TODO keyword of a headline by ID.
+   
+   Example:
+     (set-status doc \"task-123\" \"DONE\")"
+  [doc id new-status]
+  (update-by-id doc id assoc :keyword new-status))
+
+(defn set-status-by-vibe-id
+  "Set the TODO keyword of a headline by VIBE_ID."
+  [doc vibe-id new-status]
+  (update-by-vibe-id doc vibe-id assoc :keyword new-status))
+
+(defn mark-done
+  "Mark a task as DONE by ID."
+  [doc id]
+  (set-status doc id "DONE"))
+
+(defn mark-todo
+  "Mark a task as TODO by ID."
+  [doc id]
+  (set-status doc id "TODO"))
+
+(defn mark-in-progress
+  "Mark a task as IN-PROGRESS by ID."
+  [doc id]
+  (set-status doc id "IN-PROGRESS"))
+
+;; =============================================================================
+;; Property Updates
+;; =============================================================================
+
+(defn set-property
+  "Set or update a property on a headline by ID.
+   
+   Example:
+     (set-property doc \"task-123\" :EFFORT \"L\")"
+  [doc id prop-key prop-value]
+  (update-by-id doc id assoc-in [:properties prop-key] prop-value))
+
+(defn remove-property
+  "Remove a property from a headline by ID."
+  [doc id prop-key]
+  (update-by-id doc id update :properties dissoc prop-key))
+
+;; =============================================================================
+;; Title and Content Updates
+;; =============================================================================
+
+(defn set-title
+  "Set the title of a headline by ID."
+  [doc id new-title]
+  (update-by-id doc id assoc :title new-title))
+
+(defn append-content
+  "Append content lines to a headline by ID."
+  [doc id new-content]
+  (update-by-id doc id update :content
+                (fnil into [])
+                (if (string? new-content) [new-content] new-content)))
+
+;; =============================================================================
+;; Tag Operations
+;; =============================================================================
+
+(defn add-tag
+  "Add a tag to a headline by ID."
+  [doc id tag]
+  (update-by-id doc id update :tags (fnil conj []) tag))
+
+(defn remove-tag
+  "Remove a tag from a headline by ID."
+  [doc id tag]
+  (update-by-id doc id update :tags #(vec (remove #{tag} %))))
+
+(defn set-tags
+  "Replace all tags on a headline by ID."
+  [doc id tags]
+  (update-by-id doc id assoc :tags (vec tags)))
+
+;; =============================================================================
+;; Planning Updates
+;; =============================================================================
+
+(defn set-closed
+  "Set the CLOSED timestamp on a headline by ID."
+  [doc id timestamp]
+  (update-by-id doc id assoc-in [:planning :closed] timestamp))
+
+(defn set-scheduled
+  "Set the SCHEDULED timestamp on a headline by ID."
+  [doc id timestamp]
+  (update-by-id doc id assoc-in [:planning :scheduled] timestamp))
+
+(defn set-deadline
+  "Set the DEADLINE timestamp on a headline by ID."
+  [doc id timestamp]
+  (update-by-id doc id assoc-in [:planning :deadline] timestamp))
+
+;; =============================================================================
+;; Bulk Operations
+;; =============================================================================
+
+(defn mark-all-done
+  "Mark all headlines matching a predicate as DONE."
+  [doc pred]
+  (update-in-document doc pred #(assoc % :keyword "DONE")))
+
+(defn update-all-matching
+  "Apply an update function to all headlines matching a predicate."
+  [doc pred f]
+  (update-in-document doc pred f))
+
+;; =============================================================================
+;; Create/Delete Headlines
+;; =============================================================================
+
+(defn add-headline
+  "Add a new headline to the document at the top level."
+  [doc headline]
+  (update doc :headlines conj
+          (merge {:type :headline
+                  :level 1
+                  :keyword nil
+                  :priority nil
+                  :tags []
+                  :properties {}
+                  :planning {}
+                  :content []
+                  :children []}
+                 headline)))
+
+(defn add-child-headline
+  "Add a child headline under a parent identified by ID."
+  [doc parent-id child-headline]
+  (let [parent (query/find-by-id doc parent-id)
+        child-level (inc (:level parent 1))]
+    (update-by-id doc parent-id
+                  update :children conj
+                  (merge {:type :headline
+                          :level child-level
+                          :keyword nil
+                          :priority nil
+                          :tags []
+                          :properties {}
+                          :planning {}
+                          :content []
+                          :children []}
+                         (assoc child-headline :level child-level)))))
+
+(defn remove-headline
+  "Remove a headline by ID from the document."
+  [doc id]
+  (letfn [(remove-from-tree [headlines]
+            (reduce (fn [acc hl]
+                      (if (= (get-in hl [:properties :ID]) id)
+                        acc
+                        (conj acc (update hl :children remove-from-tree))))
+                    []
+                    headlines))]
+    (update doc :headlines remove-from-tree)))
+
+;; =============================================================================
+;; Tests
+;; =============================================================================
+
+(deftest test-set-status
+  (testing "Changes TODO keyword"
+    (let [doc {:headlines [{:properties {:ID "a"} :keyword "TODO" :children []}]}
+          updated (set-status doc "a" "DONE")]
+      (is (= "DONE" (get-in updated [:headlines 0 :keyword]))))))
+
+(deftest test-set-property
+  (testing "Sets property value"
+    (let [doc {:headlines [{:properties {:ID "a"} :children []}]}
+          updated (set-property doc "a" :EFFORT "M")]
+      (is (= "M" (get-in updated [:headlines 0 :properties :EFFORT]))))))
+
+(deftest test-add-tag
+  (testing "Adds tag to headline"
+    (let [doc {:headlines [{:properties {:ID "a"} :tags ["work"] :children []}]}
+          updated (add-tag doc "a" "urgent")]
+      (is (= ["work" "urgent"] (get-in updated [:headlines 0 :tags]))))))
+
+(comment
+  ;; Example usage
+  (require '[emacs-mcp.org-clj.parser :as parser])
+  (def doc (parser/parse-document (slurp "kanban.org")))
+
+  ;; Mark a task done
+  (def updated (mark-done doc "some-task-id"))
+
+  ;; Add a property
+  (def updated (set-property doc "task-id" :EFFORT "L"))
+
+  ;; Add a new headline
+  (def updated (add-headline doc {:title "New Task" :keyword "TODO"})))

--- a/src/emacs_mcp/org_clj/writer.clj
+++ b/src/emacs_mcp/org_clj/writer.clj
@@ -1,0 +1,207 @@
+(ns emacs-mcp.org-clj.writer
+  "Serializer for org-mode documents - converts EDN back to org text.
+   
+   Handles:
+   - File properties (#+TITLE, etc)
+   - Headlines with TODO keywords, priorities, tags
+   - Property drawers
+   - Planning lines (CLOSED, SCHEDULED, DEADLINE)
+   - Nested headline structure"
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;; =============================================================================
+;; Property Drawer Writing
+;; =============================================================================
+
+(defn write-property-drawer
+  "Convert a properties map to org property drawer lines.
+   
+   Input: {:ID \"abc-123\", :CREATED \"2025-01-01\"}
+   Output: [\":PROPERTIES:\" \":ID: abc-123\" \":CREATED: 2025-01-01\" \":END:\"]"
+  [properties]
+  (when (and properties (seq properties))
+    (concat [":PROPERTIES:"]
+            (map (fn [[k v]] (str ":" (name k) ": " v)) properties)
+            [":END:"])))
+
+;; =============================================================================
+;; Planning Line Writing
+;; =============================================================================
+
+(defn write-planning-line
+  "Convert planning map to org planning line.
+   
+   Input: {:closed \"2025-01-01\", :scheduled \"2025-01-02\"}
+   Output: \"CLOSED: [2025-01-01] SCHEDULED: <2025-01-02>\""
+  [planning]
+  (when (and planning (seq planning))
+    (let [parts (keep (fn [[k v]]
+                        (when v
+                          (case k
+                            :closed (str "CLOSED: [" v "]")
+                            :scheduled (str "SCHEDULED: <" v ">")
+                            :deadline (str "DEADLINE: <" v ">")
+                            nil)))
+                      planning)]
+      (when (seq parts)
+        (str/join " " parts)))))
+
+;; =============================================================================
+;; Headline Writing
+;; =============================================================================
+
+(defn write-headline-text
+  "Convert headline map to headline text line.
+   
+   Input: {:level 2, :keyword \"TODO\", :priority \"A\", :title \"Task\", :tags [\"work\"]}
+   Output: \"** TODO [#A] Task :work:\""
+  [{:keys [level keyword priority title tags]}]
+  (let [stars (apply str (repeat level "*"))
+        parts (filter some?
+                      [stars
+                       keyword
+                       (when priority (str "[#" priority "]"))
+                       title
+                       (when (seq tags)
+                         (str ":" (str/join ":" tags) ":"))])]
+    (str/join " " parts)))
+
+(defn write-headline
+  "Convert a headline map to org lines (including properties, planning, content).
+   Does NOT include children - use write-headline-tree for nested output."
+  [{:keys [planning properties content] :as headline}]
+  (let [headline-line (write-headline-text headline)
+        planning-line (write-planning-line planning)
+        drawer-lines (write-property-drawer properties)
+        content-lines (or content [])]
+    (filter some?
+            (concat [headline-line]
+                    (when planning-line [planning-line])
+                    drawer-lines
+                    content-lines))))
+
+(defn write-headline-tree
+  "Recursively write a headline and all its children to org lines."
+  [{:keys [children] :as headline}]
+  (concat (write-headline headline)
+          (when (seq children)
+            (mapcat write-headline-tree children))))
+
+;; =============================================================================
+;; File Properties Writing
+;; =============================================================================
+
+(defn write-file-properties
+  "Convert file properties map to org file property lines.
+   
+   Input: {:TITLE \"My Doc\", :STARTUP \"overview\"}
+   Output: [\"#+TITLE: My Doc\" \"#+STARTUP: overview\"]"
+  [properties]
+  (when (and properties (seq properties))
+    (map (fn [[k v]] (str "#+" (name k) ": " v)) properties)))
+
+;; =============================================================================
+;; Document Writing
+;; =============================================================================
+
+(defn write-document
+  "Convert a document map to org text.
+   
+   Input: {:type :document, :properties {...}, :headlines [...]}
+   Output: string of complete org file content"
+  [{:keys [properties headlines]}]
+  (let [file-props (write-file-properties properties)
+        headline-lines (mapcat write-headline-tree headlines)
+        all-lines (concat file-props
+                          (when (seq file-props) [""]) ; blank line after props
+                          headline-lines)]
+    (str/join "\n" all-lines)))
+
+(defn write-document-to-file
+  "Write a document to a file."
+  [doc file-path]
+  (spit file-path (write-document doc)))
+
+;; =============================================================================
+;; Tests
+;; =============================================================================
+
+(deftest test-write-property-drawer
+  (testing "Basic property drawer"
+    (is (= [":PROPERTIES:" ":ID: abc-123" ":END:"]
+           (write-property-drawer {:ID "abc-123"}))))
+
+  (testing "Multiple properties"
+    (is (= [":PROPERTIES:" ":ID: abc" ":CREATED: 2025" ":END:"]
+           (write-property-drawer {:ID "abc" :CREATED "2025"}))))
+
+  (testing "Empty properties"
+    (is (nil? (write-property-drawer {})))
+    (is (nil? (write-property-drawer nil)))))
+
+(deftest test-write-planning-line
+  (testing "CLOSED only"
+    (is (= "CLOSED: [2025-01-01]"
+           (write-planning-line {:closed "2025-01-01"}))))
+
+  (testing "Multiple planning keywords"
+    (is (= "CLOSED: [2025-01-01] SCHEDULED: <2025-01-02>"
+           (write-planning-line {:closed "2025-01-01" :scheduled "2025-01-02"}))))
+
+  (testing "Empty planning"
+    (is (nil? (write-planning-line {})))
+    (is (nil? (write-planning-line nil)))))
+
+(deftest test-write-headline-text
+  (testing "Simple headline"
+    (is (= "* Heading"
+           (write-headline-text {:level 1 :title "Heading" :tags []}))))
+
+  (testing "With TODO keyword"
+    (is (= "** TODO Task"
+           (write-headline-text {:level 2 :keyword "TODO" :title "Task" :tags []}))))
+
+  (testing "With priority"
+    (is (= "** TODO [#A] Important"
+           (write-headline-text {:level 2 :keyword "TODO" :priority "A" :title "Important" :tags []}))))
+
+  (testing "With tags"
+    (is (= "** DONE Task :work:urgent:"
+           (write-headline-text {:level 2 :keyword "DONE" :title "Task" :tags ["work" "urgent"]}))))
+
+  (testing "Full headline"
+    (is (= "*** IN-PROGRESS [#B] Complex :project:dev:"
+           (write-headline-text {:level 3 :keyword "IN-PROGRESS" :priority "B"
+                                 :title "Complex" :tags ["project" "dev"]})))))
+
+(deftest test-write-document
+  (testing "Simple document"
+    (let [doc {:type :document
+               :properties {:TITLE "Test"}
+               :headlines [{:type :headline
+                            :level 1
+                            :keyword nil
+                            :priority nil
+                            :title "Heading"
+                            :tags []
+                            :properties {}
+                            :planning {}
+                            :content []
+                            :children []}]}
+          result (write-document doc)]
+      (is (str/includes? result "#+TITLE: Test"))
+      (is (str/includes? result "* Heading")))))
+
+(comment
+  ;; Run tests
+  (require '[clojure.test :refer [run-tests]])
+  (run-tests)
+
+  ;; Example usage
+  (write-headline-text {:level 2 :keyword "TODO" :priority "A" :title "My task" :tags ["work"]})
+  ;; => "** TODO [#A] My task :work:"
+
+  (write-property-drawer {:ID "abc-123" :CREATED "2025-01-01"})
+  ;; => [":PROPERTIES:" ":ID: abc-123" ":CREATED: 2025-01-01" ":END:"]
+  )


### PR DESCRIPTION
## Summary

- **org-clj library**: Native Clojure parser for org-mode files with 4 modules:
  - `parser.clj` - Parse org files (headlines, properties, planning lines)
  - `writer.clj` - Serialize org documents back to text  
  - `query.clj` - Find/filter headlines (by-id, by-status, by-property)
  - `transform.clj` - Immutable updates (set-status, set-property, add-tag)

- **5 new MCP tools** (Phase 4):
  - `org_clj_parse` - Parse org file to JSON
  - `org_clj_write` - Write JSON document to org file
  - `org_clj_query` - Query headlines via MCP
  - `org_kanban_native_status` - Native kanban status (no elisp)
  - `org_kanban_native_move` - Native task move (no elisp)

- **Elisp fixes**: Make keybindings opt-in per Emacs conventions

## Test plan

- [x] 16 unit tests with 68 assertions pass
- [x] Round-trip parsing verified (parse → transform → write → parse)
- [x] MCP tools tested in REPL
- [ ] Integration test with emacs-mcp server

🤖 Generated with [Claude Code](https://claude.com/claude-code)