### PR TITLE
fix(overarch): Fix defonce syntax

### DIFF
--- a/src/emacs_mcp/diagrams/adapters/overarch.clj
+++ b/src/emacs_mcp/diagrams/adapters/overarch.clj
@@ -13,11 +13,9 @@
 
 ;;; Configuration
 
-(defonce ^:dynamic *overarch-path*
-  "Configurable path to overarch CLI or JAR.
-   Set via (set-overarch-path! \"/path/to/overarch\")
-   or bind dynamically."
-  (atom nil))
+;; Configurable path to overarch CLI or JAR.
+;; Set via (set-overarch-path! "/path/to/overarch")
+(defonce *overarch-path* (atom nil))
 
 (defn set-overarch-path!
   "Set the overarch executable/JAR path.


### PR DESCRIPTION
## Summary
- `defonce` doesn't support docstrings as a third argument
- Converted to comment-based documentation

## Test
```clojure
(require '[emacs-mcp.diagrams.adapters.overarch :as oa] :reload)
;; No more ArityException
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)