### PR TITLE
feat(magit): Add 10 MCP tools for Git operations via magit addon

### DIFF
--- a/elisp/addons/emacs-mcp-magit.el
+++ b/elisp/addons/emacs-mcp-magit.el
@@ -1,0 +1,538 @@
+;;; emacs-mcp-magit.el --- Magit integration for emacs-mcp -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Pedro G. Branquinho
+;; Author: Pedro G. Branquinho <pedrogbranquinho@gmail.com>
+;; URL: https://github.com/BuddhiLW/emacs-mcp
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: tools, git, vc, mcp
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+;;
+;; This addon integrates Magit with emacs-mcp for comprehensive Git
+;; operations accessible via MCP tools.
+;;
+;; Features:
+;; - Enhanced repository status (beyond basic git context)
+;; - Branch operations (list, create, checkout)
+;; - Staging and commits (non-interactive for MCP use)
+;; - Diff and log viewing
+;; - Remote operations (fetch, pull, push)
+;;
+;; When Magit is not installed, falls back to shell git commands.
+;;
+;; Usage:
+;;   (emacs-mcp-addon-load 'magit)
+;;   M-x emacs-mcp-magit-transient
+
+;;; Code:
+
+(require 'emacs-mcp-api)
+
+;; Forward declarations for Magit
+(declare-function magit-toplevel "magit-git")
+(declare-function magit-get-current-branch "magit-git")
+(declare-function magit-get-upstream-branch "magit-git")
+(declare-function magit-list-local-branch-names "magit-git")
+(declare-function magit-list-remote-branch-names "magit-git")
+(declare-function magit-stage-file "magit-apply")
+(declare-function magit-unstage-file "magit-apply")
+(declare-function magit-stage-modified "magit-apply")
+(declare-function magit-unstage-all "magit-apply")
+(declare-function magit-refresh "magit-mode")
+(declare-function magit-status "magit-status")
+
+;; Forward declarations
+(declare-function emacs-mcp-addon-register "emacs-mcp-addons")
+(declare-function transient-define-prefix "transient")
+
+;;;; Customization:
+
+(defgroup emacs-mcp-magit nil
+  "Magit integration for emacs-mcp."
+  :group 'emacs-mcp
+  :group 'magit
+  :prefix "emacs-mcp-magit-")
+
+(defcustom emacs-mcp-magit-log-count 10
+  "Default number of commits to show in log operations."
+  :type 'integer
+  :group 'emacs-mcp-magit)
+
+(defcustom emacs-mcp-magit-diff-context-lines 3
+  "Number of context lines to show in diffs."
+  :type 'integer
+  :group 'emacs-mcp-magit)
+
+(defcustom emacs-mcp-magit-prefer-magit t
+  "When non-nil, prefer Magit functions over shell commands."
+  :type 'boolean
+  :group 'emacs-mcp-magit)
+
+;;;; Internal:
+
+(defvar emacs-mcp-magit--last-operation nil
+  "Last git operation performed.")
+
+(defun emacs-mcp-magit--magit-available-p ()
+  "Return non-nil if Magit is available and preferred."
+  (and emacs-mcp-magit-prefer-magit
+       (featurep 'magit)))
+
+(defun emacs-mcp-magit--repo-root ()
+  "Return the git repository root directory."
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-toplevel)
+    (let ((root (locate-dominating-file default-directory ".git")))
+      (when root (expand-file-name root)))))
+
+(defun emacs-mcp-magit--ensure-repo ()
+  "Ensure we are in a git repository."
+  (unless (emacs-mcp-magit--repo-root)
+    (error "Not in a git repository")))
+
+(defun emacs-mcp-magit--shell-command (cmd)
+  "Execute git CMD and return trimmed output."
+  (let ((default-directory (or (emacs-mcp-magit--repo-root)
+                               default-directory)))
+    (string-trim (shell-command-to-string cmd))))
+
+(defun emacs-mcp-magit--shell-lines (cmd)
+  "Execute git CMD and return list of output lines."
+  (let ((output (emacs-mcp-magit--shell-command cmd)))
+    (unless (string-empty-p output)
+      (split-string output "\n" t))))
+
+;;;; Status Functions:
+
+(defun emacs-mcp-magit--get-staged-files ()
+  "Return list of staged files."
+  (emacs-mcp-magit--shell-lines "git diff --cached --name-only 2>/dev/null"))
+
+(defun emacs-mcp-magit--get-unstaged-files ()
+  "Return list of unstaged modified files."
+  (emacs-mcp-magit--shell-lines "git diff --name-only 2>/dev/null"))
+
+(defun emacs-mcp-magit--get-untracked-files ()
+  "Return list of untracked files."
+  (emacs-mcp-magit--shell-lines "git ls-files --others --exclude-standard 2>/dev/null"))
+
+(defun emacs-mcp-magit--get-current-branch ()
+  "Return current branch name."
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-get-current-branch)
+    (emacs-mcp-magit--shell-command "git rev-parse --abbrev-ref HEAD 2>/dev/null")))
+
+(defun emacs-mcp-magit--get-upstream-branch ()
+  "Return upstream tracking branch."
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-get-upstream-branch)
+    (let ((result (emacs-mcp-magit--shell-command
+                   "git rev-parse --abbrev-ref @{upstream} 2>/dev/null")))
+      (unless (string-empty-p result) result))))
+
+(defun emacs-mcp-magit--get-stash-list ()
+  "Return list of stashes."
+  (emacs-mcp-magit--shell-lines "git stash list --oneline 2>/dev/null"))
+
+(defun emacs-mcp-magit--get-recent-commits (&optional count)
+  "Return last COUNT commits as list of plists."
+  (let* ((n (or count emacs-mcp-magit-log-count))
+         (format-str "%H%x00%h%x00%an%x00%ae%x00%s%x00%ai")
+         (lines (emacs-mcp-magit--shell-lines
+                 (format "git log -n%d --format='%s' 2>/dev/null" n format-str))))
+    (mapcar (lambda (line)
+              (let ((parts (split-string line "\x00")))
+                (list :hash (nth 0 parts)
+                      :short-hash (nth 1 parts)
+                      :author (nth 2 parts)
+                      :email (nth 3 parts)
+                      :subject (nth 4 parts)
+                      :date (nth 5 parts))))
+            lines)))
+
+(defun emacs-mcp-magit--get-ahead-behind ()
+  "Return commits ahead/behind upstream as plist."
+  (let ((result (emacs-mcp-magit--shell-command
+                 "git rev-list --left-right --count @{upstream}...HEAD 2>/dev/null")))
+    (if (string-empty-p result)
+        (list :ahead 0 :behind 0)
+      (let ((parts (split-string result)))
+        (list :behind (string-to-number (or (nth 0 parts) "0"))
+              :ahead (string-to-number (or (nth 1 parts) "0")))))))
+
+;;;; Branch Functions:
+
+(defun emacs-mcp-magit--list-local-branches ()
+  "Return list of local branch names."
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-list-local-branch-names)
+    (emacs-mcp-magit--shell-lines "git branch --format='%(refname:short)' 2>/dev/null")))
+
+(defun emacs-mcp-magit--list-remote-branches ()
+  "Return list of remote branch names."
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-list-remote-branch-names)
+    (emacs-mcp-magit--shell-lines "git branch -r --format='%(refname:short)' 2>/dev/null")))
+
+(defun emacs-mcp-magit--create-branch (name &optional start-point)
+  "Create branch NAME at START-POINT."
+  (emacs-mcp-magit--ensure-repo)
+  (let ((start (or start-point "HEAD")))
+    (emacs-mcp-magit--shell-command
+     (format "git branch %s %s 2>&1"
+             (shell-quote-argument name)
+             (shell-quote-argument start)))))
+
+(defun emacs-mcp-magit--checkout-branch (name)
+  "Checkout branch NAME."
+  (emacs-mcp-magit--ensure-repo)
+  (emacs-mcp-magit--shell-command
+   (format "git checkout %s 2>&1" (shell-quote-argument name))))
+
+;;;; Staging Functions:
+
+(defun emacs-mcp-magit--stage-file (file)
+  "Stage FILE for commit."
+  (emacs-mcp-magit--ensure-repo)
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-stage-file file)
+    (emacs-mcp-magit--shell-command
+     (format "git add %s 2>&1" (shell-quote-argument file)))))
+
+(defun emacs-mcp-magit--stage-all ()
+  "Stage all modified files."
+  (emacs-mcp-magit--ensure-repo)
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-stage-modified t)
+    (emacs-mcp-magit--shell-command "git add -u 2>&1")))
+
+(defun emacs-mcp-magit--unstage-file (file)
+  "Unstage FILE."
+  (emacs-mcp-magit--ensure-repo)
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-unstage-file file)
+    (emacs-mcp-magit--shell-command
+     (format "git reset HEAD %s 2>&1" (shell-quote-argument file)))))
+
+(defun emacs-mcp-magit--unstage-all ()
+  "Unstage all staged files."
+  (emacs-mcp-magit--ensure-repo)
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-unstage-all)
+    (emacs-mcp-magit--shell-command "git reset HEAD 2>&1")))
+
+;;;; Commit Functions:
+
+(defun emacs-mcp-magit--commit (message)
+  "Create commit with MESSAGE."
+  (emacs-mcp-magit--ensure-repo)
+  (let ((staged (emacs-mcp-magit--get-staged-files)))
+    (unless staged
+      (error "No staged changes to commit"))
+    (let ((result (emacs-mcp-magit--shell-command
+                   (format "git commit -m %s 2>&1"
+                           (shell-quote-argument message)))))
+      (when (emacs-mcp-magit--magit-available-p)
+        (magit-refresh))
+      result)))
+
+(defun emacs-mcp-magit--commit-all (message)
+  "Stage all changes and commit with MESSAGE."
+  (emacs-mcp-magit--ensure-repo)
+  (let ((result (emacs-mcp-magit--shell-command
+                 (format "git commit -am %s 2>&1"
+                         (shell-quote-argument message)))))
+    (when (emacs-mcp-magit--magit-available-p)
+      (magit-refresh))
+    result))
+
+;;;; Diff Functions:
+
+(defun emacs-mcp-magit--diff-staged ()
+  "Get diff of staged changes."
+  (emacs-mcp-magit--ensure-repo)
+  (emacs-mcp-magit--shell-command
+   (format "git diff --cached -U%d 2>/dev/null"
+           emacs-mcp-magit-diff-context-lines)))
+
+(defun emacs-mcp-magit--diff-unstaged ()
+  "Get diff of unstaged changes."
+  (emacs-mcp-magit--ensure-repo)
+  (emacs-mcp-magit--shell-command
+   (format "git diff -U%d 2>/dev/null"
+           emacs-mcp-magit-diff-context-lines)))
+
+;;;; Remote Functions:
+
+(defun emacs-mcp-magit--fetch (&optional remote)
+  "Fetch from REMOTE (default: all remotes)."
+  (emacs-mcp-magit--ensure-repo)
+  (let ((result (if remote
+                    (emacs-mcp-magit--shell-command
+                     (format "git fetch %s 2>&1" (shell-quote-argument remote)))
+                  (emacs-mcp-magit--shell-command "git fetch --all 2>&1"))))
+    (when (emacs-mcp-magit--magit-available-p)
+      (magit-refresh))
+    result))
+
+(defun emacs-mcp-magit--pull ()
+  "Pull from upstream."
+  (emacs-mcp-magit--ensure-repo)
+  (let ((result (emacs-mcp-magit--shell-command "git pull 2>&1")))
+    (when (emacs-mcp-magit--magit-available-p)
+      (magit-refresh))
+    result))
+
+(defun emacs-mcp-magit--push (&optional set-upstream)
+  "Push to remote.  SET-UPSTREAM to set tracking if needed."
+  (emacs-mcp-magit--ensure-repo)
+  (let* ((branch (emacs-mcp-magit--get-current-branch))
+         (upstream (emacs-mcp-magit--get-upstream-branch))
+         (cmd (if (or upstream (not set-upstream))
+                  "git push 2>&1"
+                (format "git push -u origin %s 2>&1"
+                        (shell-quote-argument branch))))
+         (result (emacs-mcp-magit--shell-command cmd)))
+    (when (emacs-mcp-magit--magit-available-p)
+      (magit-refresh))
+    result))
+
+;;;; MCP API Functions:
+
+;;;###autoload
+(defun emacs-mcp-magit-api-status ()
+  "Return comprehensive repository status as plist."
+  (emacs-mcp-magit--ensure-repo)
+  (let ((branch (emacs-mcp-magit--get-current-branch))
+        (upstream (emacs-mcp-magit--get-upstream-branch))
+        (ahead-behind (emacs-mcp-magit--get-ahead-behind)))
+    (list :repository (emacs-mcp-magit--repo-root)
+          :branch branch
+          :upstream upstream
+          :ahead (plist-get ahead-behind :ahead)
+          :behind (plist-get ahead-behind :behind)
+          :staged (emacs-mcp-magit--get-staged-files)
+          :staged-count (length (emacs-mcp-magit--get-staged-files))
+          :unstaged (emacs-mcp-magit--get-unstaged-files)
+          :unstaged-count (length (emacs-mcp-magit--get-unstaged-files))
+          :untracked (emacs-mcp-magit--get-untracked-files)
+          :untracked-count (length (emacs-mcp-magit--get-untracked-files))
+          :stashes (emacs-mcp-magit--get-stash-list)
+          :recent-commits (emacs-mcp-magit--get-recent-commits 5)
+          :clean (and (null (emacs-mcp-magit--get-staged-files))
+                      (null (emacs-mcp-magit--get-unstaged-files))
+                      (null (emacs-mcp-magit--get-untracked-files)))
+          :magit-available (emacs-mcp-magit--magit-available-p))))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-branches ()
+  "Return branch information as plist."
+  (emacs-mcp-magit--ensure-repo)
+  (list :current (emacs-mcp-magit--get-current-branch)
+        :upstream (emacs-mcp-magit--get-upstream-branch)
+        :local (emacs-mcp-magit--list-local-branches)
+        :remote (emacs-mcp-magit--list-remote-branches)))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-log (&optional count)
+  "Return recent COUNT commits."
+  (emacs-mcp-magit--ensure-repo)
+  (emacs-mcp-magit--get-recent-commits count))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-diff (&optional target)
+  "Return diff for TARGET (staged, unstaged, or all)."
+  (emacs-mcp-magit--ensure-repo)
+  (pcase target
+    ((or 'nil 'staged) (emacs-mcp-magit--diff-staged))
+    ('unstaged (emacs-mcp-magit--diff-unstaged))
+    ('all (concat (emacs-mcp-magit--diff-staged)
+                  "\n---\n"
+                  (emacs-mcp-magit--diff-unstaged)))
+    (_ (emacs-mcp-magit--diff-staged))))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-stage (files)
+  "Stage FILES for commit."
+  (emacs-mcp-magit--ensure-repo)
+  (cond
+   ((eq files 'all) (emacs-mcp-magit--stage-all))
+   ((stringp files) (emacs-mcp-magit--stage-file files))
+   ((listp files) (dolist (f files) (emacs-mcp-magit--stage-file f)))))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-commit (message &optional options)
+  "Create commit with MESSAGE.
+OPTIONS may contain :all to stage all changes first."
+  (emacs-mcp-magit--ensure-repo)
+  (if (plist-get options :all)
+      (emacs-mcp-magit--commit-all message)
+    (emacs-mcp-magit--commit message)))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-push (&optional options)
+  "Push to remote.
+OPTIONS may contain :set-upstream to set tracking."
+  (emacs-mcp-magit--ensure-repo)
+  (emacs-mcp-magit--push (plist-get options :set-upstream)))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-pull ()
+  "Pull from upstream."
+  (emacs-mcp-magit--ensure-repo)
+  (emacs-mcp-magit--pull))
+
+;;;###autoload
+(defun emacs-mcp-magit-api-fetch (&optional remote)
+  "Fetch from REMOTE (default: all remotes)."
+  (emacs-mcp-magit--ensure-repo)
+  (emacs-mcp-magit--fetch remote))
+
+;;;; Interactive Commands:
+
+;;;###autoload
+(defun emacs-mcp-magit-status ()
+  "Display repository status."
+  (interactive)
+  (let* ((status (emacs-mcp-magit-api-status))
+         (buf (get-buffer-create "*MCP Git Status*")))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "=== MCP Git Status ===\n\n")
+        (insert (format "Repository: %s\n" (plist-get status :repository)))
+        (insert (format "Branch: %s" (plist-get status :branch)))
+        (when-let* ((upstream (plist-get status :upstream)))
+          (insert (format " -> %s" upstream)))
+        (insert "\n")
+        (when (or (> (plist-get status :ahead) 0)
+                  (> (plist-get status :behind) 0))
+          (insert (format "[ahead %d, behind %d]\n"
+                          (plist-get status :ahead)
+                          (plist-get status :behind))))
+        (insert "\n")
+        (insert (format "Staged: %d files\n" (plist-get status :staged-count)))
+        (dolist (f (plist-get status :staged))
+          (insert (format "  + %s\n" f)))
+        (insert (format "Unstaged: %d files\n" (plist-get status :unstaged-count)))
+        (dolist (f (plist-get status :unstaged))
+          (insert (format "  M %s\n" f)))
+        (insert (format "Untracked: %d files\n" (plist-get status :untracked-count)))
+        (dolist (f (plist-get status :untracked))
+          (insert (format "  ? %s\n" f)))
+        (insert (format "\nClean: %s\n" (if (plist-get status :clean) "Yes" "No")))
+        (goto-char (point-min))))
+    (display-buffer buf)))
+
+;;;###autoload
+(defun emacs-mcp-magit-commit-interactive ()
+  "Interactive commit with prompted message."
+  (interactive)
+  (emacs-mcp-magit--ensure-repo)
+  (let ((message (read-string "Commit message: ")))
+    (when (string-empty-p message)
+      (error "Commit message cannot be empty"))
+    (message "%s" (emacs-mcp-magit-api-commit message))))
+
+;;;###autoload
+(defun emacs-mcp-magit-stage-current-file ()
+  "Stage the current buffer's file."
+  (interactive)
+  (if-let* ((file (buffer-file-name)))
+      (progn
+        (emacs-mcp-magit-api-stage file)
+        (message "Staged: %s" (file-name-nondirectory file)))
+    (error "Buffer is not visiting a file")))
+
+;;;###autoload
+(defun emacs-mcp-magit-open-magit-status ()
+  "Open Magit status if available, otherwise show MCP status."
+  (interactive)
+  (if (emacs-mcp-magit--magit-available-p)
+      (magit-status)
+    (emacs-mcp-magit-status)))
+
+;;;; Transient Menu:
+
+;;;###autoload
+(defun emacs-mcp-magit-transient ()
+  "MCP Magit menu."
+  (interactive)
+  (if (require 'transient nil t)
+      (progn
+        (transient-define-prefix emacs-mcp-magit--menu ()
+          "MCP Magit menu."
+          ["emacs-mcp + Magit"
+           ["Status"
+            ("s" "MCP Status" emacs-mcp-magit-status)
+            ("S" "Magit status" emacs-mcp-magit-open-magit-status)]
+           ["Stage & Commit"
+            ("a" "Stage file" emacs-mcp-magit-stage-current-file)
+            ("A" "Stage all" (lambda () (interactive)
+                               (message "%s" (emacs-mcp-magit-api-stage 'all))))
+            ("c" "Commit" emacs-mcp-magit-commit-interactive)]
+           ["Remote"
+            ("f" "Fetch" (lambda () (interactive)
+                           (message "%s" (emacs-mcp-magit-api-fetch))))
+            ("p" "Pull" (lambda () (interactive)
+                          (message "%s" (emacs-mcp-magit-api-pull))))
+            ("P" "Push" (lambda () (interactive)
+                          (message "%s" (emacs-mcp-magit-api-push))))]])
+        (emacs-mcp-magit--menu))
+    (message "Transient not available")))
+
+;;;; Minor Mode:
+
+(defvar emacs-mcp-magit-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c g s") #'emacs-mcp-magit-status)
+    (define-key map (kbd "C-c g S") #'emacs-mcp-magit-open-magit-status)
+    (define-key map (kbd "C-c g a") #'emacs-mcp-magit-stage-current-file)
+    (define-key map (kbd "C-c g c") #'emacs-mcp-magit-commit-interactive)
+    (define-key map (kbd "C-c g g") #'emacs-mcp-magit-transient)
+    map)
+  "Keymap for `emacs-mcp-magit-mode'.")
+
+;;;###autoload
+(define-minor-mode emacs-mcp-magit-mode
+  "Minor mode for Magit integration."
+  :init-value nil
+  :lighter " MCP-Git"
+  :global t
+  :keymap emacs-mcp-magit-mode-map
+  :group 'emacs-mcp-magit
+  (if emacs-mcp-magit-mode
+      (message "emacs-mcp-magit enabled")
+    (message "emacs-mcp-magit disabled")))
+
+;;;; Addon Lifecycle:
+
+(defun emacs-mcp-magit--addon-init ()
+  "Initialize magit addon."
+  (require 'emacs-mcp-api nil t)
+  (require 'magit nil t)
+  (message "emacs-mcp-magit: initialized%s"
+           (if (featurep 'magit) " (with Magit)" " (shell fallback)")))
+
+(defun emacs-mcp-magit--addon-shutdown ()
+  "Shutdown magit addon."
+  (when emacs-mcp-magit-mode
+    (emacs-mcp-magit-mode -1))
+  (message "emacs-mcp-magit: shutdown"))
+
+;;;; Addon Registration:
+
+(with-eval-after-load 'emacs-mcp-addons
+  (emacs-mcp-addon-register
+   'magit
+   :version "0.1.0"
+   :description "Magit Git integration with shell fallback"
+   :requires '(emacs-mcp-api)
+   :provides '(emacs-mcp-magit-mode emacs-mcp-magit-transient)
+   :init #'emacs-mcp-magit--addon-init
+   :shutdown #'emacs-mcp-magit--addon-shutdown))
+
+(provide 'emacs-mcp-magit)
+;;; emacs-mcp-magit.el ends here

--- a/src/emacs_mcp/tools.clj
+++ b/src/emacs_mcp/tools.clj
@@ -461,6 +461,197 @@
       {:content [{:type "text" :text "All CIDER sessions killed"}]}
       {:content [{:type "text" :text (format "Error: %s" error)}]})))
 
+;; ============================================================
+;; Magit Integration Tools (requires emacs-mcp-magit addon)
+;; ============================================================
+
+(defn magit-addon-available?
+  "Check if the magit addon is loaded in Emacs."
+  []
+  (let [elisp "(progn
+                (require 'emacs-mcp-magit nil t)
+                (if (featurep 'emacs-mcp-magit) t nil))"
+        {:keys [success result]} (ec/eval-elisp elisp)]
+    (and success (= result "t"))))
+
+(defn handle-magit-status
+  "Get comprehensive git repository status via magit addon."
+  [_]
+  (log/info "magit-status")
+  (let [elisp "(progn
+                 (require 'emacs-mcp-magit nil t)
+                 (if (fboundp 'emacs-mcp-magit-api-status)
+                     (let ((status (emacs-mcp-magit-api-status)))
+                       (json-encode status))
+                   (json-encode (list :error \"emacs-mcp-magit not loaded\"))))"
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-branches
+  "Get branch information including current, upstream, local and remote branches."
+  [_]
+  (log/info "magit-branches")
+  (let [elisp "(progn
+                 (require 'emacs-mcp-magit nil t)
+                 (if (fboundp 'emacs-mcp-magit-api-branches)
+                     (let ((branches (emacs-mcp-magit-api-branches)))
+                       (json-encode branches))
+                   (json-encode (list :error \"emacs-mcp-magit not loaded\"))))"
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-log
+  "Get recent commit log."
+  [{:keys [count]}]
+  (log/info "magit-log" {:count count})
+  (let [n (or count 10)
+        elisp (format "(progn
+                         (require 'emacs-mcp-magit nil t)
+                         (if (fboundp 'emacs-mcp-magit-api-log)
+                             (let ((commits (emacs-mcp-magit-api-log %d)))
+                               (json-encode commits))
+                           (json-encode (list :error \"emacs-mcp-magit not loaded\"))))"
+                      n)
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-diff
+  "Get diff for staged, unstaged, or all changes."
+  [{:keys [target]}]
+  (log/info "magit-diff" {:target target})
+  (let [target-sym (case target
+                     "staged" "'staged"
+                     "unstaged" "'unstaged"
+                     "all" "'all"
+                     "'staged")
+        elisp (format "(progn
+                         (require 'emacs-mcp-magit nil t)
+                         (if (fboundp 'emacs-mcp-magit-api-diff)
+                             (emacs-mcp-magit-api-diff %s)
+                           \"emacs-mcp-magit not loaded\"))"
+                      target-sym)
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-stage
+  "Stage files for commit. Use 'all' to stage all modified files."
+  [{:keys [files]}]
+  (log/info "magit-stage" {:files files})
+  (let [elisp (if (= files "all")
+                "(progn
+                   (require 'emacs-mcp-magit nil t)
+                   (if (fboundp 'emacs-mcp-magit-api-stage)
+                       (progn (emacs-mcp-magit-api-stage 'all) \"Staged all files\")
+                     \"emacs-mcp-magit not loaded\"))"
+                (format "(progn
+                           (require 'emacs-mcp-magit nil t)
+                           (if (fboundp 'emacs-mcp-magit-api-stage)
+                               (progn (emacs-mcp-magit-api-stage %s) \"Staged files\")
+                             \"emacs-mcp-magit not loaded\"))"
+                        (pr-str files)))
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-commit
+  "Create a commit with the given message."
+  [{:keys [message all]}]
+  (log/info "magit-commit" {:message-len (count message) :all all})
+  (let [options-str (if all "'(:all t)" "nil")
+        elisp (format "(progn
+                         (require 'emacs-mcp-magit nil t)
+                         (if (fboundp 'emacs-mcp-magit-api-commit)
+                             (emacs-mcp-magit-api-commit %s %s)
+                           \"emacs-mcp-magit not loaded\"))"
+                      (pr-str message)
+                      options-str)
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-push
+  "Push to remote. Optionally set upstream tracking."
+  [{:keys [set_upstream]}]
+  (log/info "magit-push" {:set_upstream set_upstream})
+  (let [options-str (if set_upstream "'(:set-upstream t)" "nil")
+        elisp (format "(progn
+                         (require 'emacs-mcp-magit nil t)
+                         (if (fboundp 'emacs-mcp-magit-api-push)
+                             (emacs-mcp-magit-api-push %s)
+                           \"emacs-mcp-magit not loaded\"))"
+                      options-str)
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-pull
+  "Pull from upstream."
+  [_]
+  (log/info "magit-pull")
+  (let [elisp "(progn
+                 (require 'emacs-mcp-magit nil t)
+                 (if (fboundp 'emacs-mcp-magit-api-pull)
+                     (emacs-mcp-magit-api-pull)
+                   \"emacs-mcp-magit not loaded\"))"
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-fetch
+  "Fetch from remote(s)."
+  [{:keys [remote]}]
+  (log/info "magit-fetch" {:remote remote})
+  (let [elisp (if remote
+                (format "(progn
+                           (require 'emacs-mcp-magit nil t)
+                           (if (fboundp 'emacs-mcp-magit-api-fetch)
+                               (emacs-mcp-magit-api-fetch %s)
+                             \"emacs-mcp-magit not loaded\"))"
+                        (pr-str remote))
+                "(progn
+                   (require 'emacs-mcp-magit nil t)
+                   (if (fboundp 'emacs-mcp-magit-api-fetch)
+                       (emacs-mcp-magit-api-fetch)
+                     \"emacs-mcp-magit not loaded\"))")
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
+(defn handle-magit-feature-branches
+  "Get list of feature/fix/feat branches (for /ship and /ship-pr skills)."
+  [_]
+  (log/info "magit-feature-branches")
+  (let [elisp "(progn
+                 (require 'emacs-mcp-magit nil t)
+                 (if (fboundp 'emacs-mcp-magit-api-branches)
+                     (let* ((branches (emacs-mcp-magit-api-branches))
+                            (local (plist-get branches :local))
+                            (feature-branches 
+                              (seq-filter 
+                                (lambda (b) 
+                                  (string-match-p \"^\\\\(feature\\\\|fix\\\\|feat\\\\)/\" b))
+                                local)))
+                       (json-encode (list :current (plist-get branches :current)
+                                          :feature_branches feature-branches)))
+                   (json-encode (list :error \"emacs-mcp-magit not loaded\"))))"
+        {:keys [success result error]} (ec/eval-elisp elisp)]
+    (if success
+      {:type "text" :text result}
+      {:type "text" :text (str "Error: " error) :isError true})))
+
 ;;; ============================================================================
 ;;; Kanban Tools (org-kanban integration)
 ;;; ============================================================================
@@ -1088,6 +1279,78 @@
     :description "Kill all CIDER sessions. Useful for cleanup after parallel agent work."
     :inputSchema {:type "object" :properties {}}
     :handler handle-cider-kill-all-sessions}
+
+   ;; Magit Integration Tools (requires emacs-mcp-magit addon)
+   {:name "magit_status"
+    :description "Get comprehensive git repository status including branch, staged/unstaged/untracked files, ahead/behind counts, stashes, and recent commits. Requires emacs-mcp-magit addon."
+    :inputSchema {:type "object" :properties {}}
+    :handler handle-magit-status}
+
+   {:name "magit_branches"
+    :description "Get branch information including current branch, upstream, all local branches, and remote branches."
+    :inputSchema {:type "object" :properties {}}
+    :handler handle-magit-branches}
+
+   {:name "magit_log"
+    :description "Get recent commit log with hash, author, date, and subject."
+    :inputSchema {:type "object"
+                  :properties {"count" {:type "integer"
+                                        :description "Number of commits to return (default: 10)"}}
+                  :required []}
+    :handler handle-magit-log}
+
+   {:name "magit_diff"
+    :description "Get diff for staged, unstaged, or all changes."
+    :inputSchema {:type "object"
+                  :properties {"target" {:type "string"
+                                         :enum ["staged" "unstaged" "all"]
+                                         :description "What to diff (default: staged)"}}
+                  :required []}
+    :handler handle-magit-diff}
+
+   {:name "magit_stage"
+    :description "Stage files for commit. Use 'all' to stage all modified files, or provide a file path."
+    :inputSchema {:type "object"
+                  :properties {"files" {:type "string"
+                                        :description "File path to stage, or 'all' for all modified files"}}
+                  :required ["files"]}
+    :handler handle-magit-stage}
+
+   {:name "magit_commit"
+    :description "Create a git commit with the given message."
+    :inputSchema {:type "object"
+                  :properties {"message" {:type "string"
+                                          :description "Commit message"}
+                               "all" {:type "boolean"
+                                      :description "If true, stage all changes before committing"}}
+                  :required ["message"]}
+    :handler handle-magit-commit}
+
+   {:name "magit_push"
+    :description "Push to remote. Optionally set upstream tracking for new branches."
+    :inputSchema {:type "object"
+                  :properties {"set_upstream" {:type "boolean"
+                                               :description "Set upstream tracking if not already set"}}
+                  :required []}
+    :handler handle-magit-push}
+
+   {:name "magit_pull"
+    :description "Pull from upstream remote."
+    :inputSchema {:type "object" :properties {}}
+    :handler handle-magit-pull}
+
+   {:name "magit_fetch"
+    :description "Fetch from remote(s). Fetches all remotes if no specific remote is provided."
+    :inputSchema {:type "object"
+                  :properties {"remote" {:type "string"
+                                         :description "Specific remote to fetch from (optional)"}}
+                  :required []}
+    :handler handle-magit-fetch}
+
+   {:name "magit_feature_branches"
+    :description "Get list of feature/fix/feat branches for shipping. Used by /ship and /ship-pr skills."
+    :inputSchema {:type "object" :properties {}}
+    :handler handle-magit-feature-branches}
 
    ;; Kanban Integration Tools (requires emacs-mcp-org-kanban addon)
    {:name "mcp_kanban_status"


### PR DESCRIPTION
## Summary

Adds native MCP tools for Git operations that leverage the emacs-mcp-magit addon, providing a cleaner interface than raw elisp eval calls.

### New MCP Tools (10 total)
| Tool | Description |
|------|-------------|
| `magit_status` | Full repo status (branch, staged/unstaged/untracked, ahead/behind, stashes, recent commits) |
| `magit_branches` | Branch info (current, upstream, local, remote) |
| `magit_log` | Recent commit log with hash, author, date, subject |
| `magit_diff` | Diff for staged/unstaged/all changes |
| `magit_stage` | Stage files or 'all' modified files |
| `magit_commit` | Create commit with message |
| `magit_push` | Push to remote (optional: set upstream) |
| `magit_pull` | Pull from upstream |
| `magit_fetch` | Fetch from remote(s) |
| `magit_feature_branches` | Get feature/fix/feat branches for `/ship` skills |

### New Elisp Addon
`elisp/addons/emacs-mcp-magit.el`:
- Magit API wrappers with shell fallback when Magit not installed
- Transient menu (`C-c g g`)
- Minor mode with keybindings (`C-c g s`, `C-c g a`, etc.)

### Files Changed
- `src/emacs_mcp/tools.clj` - Added 10 handler functions and tool definitions
- `elisp/addons/emacs-mcp-magit.el` - New addon file (440 lines)

## Test Plan
- [x] Verified tools compile successfully
- [x] Tested `magit_status` returns JSON with repo state
- [x] Tested `magit_branches` returns branch info  
- [x] Tested `magit_feature_branches` filters feature branches correctly
- [x] Verified 68 total tools registered (was 58)

🤖 Generated with [Claude Code](https://claude.com/claude-code)