### PR TITLE
fix(mcp): Add async handler fix via submodule + stderr logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "clojure-chroma-client"]
 	path = clojure-chroma-client
 	url = https://github.com/BuddhiLW/clojure-chroma-client.git
+[submodule "mcp-clojure-sdk"]
+	path = mcp-clojure-sdk
+	url = https://github.com/BuddhiLW/mcp-clojure-sdk.git

--- a/deps.edn
+++ b/deps.edn
@@ -4,10 +4,11 @@
         org.clojure/data.json {:mvn/version "2.5.1"}
         org.clojure/core.async {:mvn/version "1.7.701"}
 
-        ;; MCP SDK from unravel-team
+        ;; MCP SDK - using local fork with async handler fix
+        ;; Original: https://github.com/unravel-team/mcp-clojure-sdk.git
+        ;; Fix: p/promise → p/future + discarding-stdout in jsonrpc4clj
         io.modelcontextprotocol/mcp-clojure-sdk
-        {:git/url "https://github.com/unravel-team/mcp-clojure-sdk.git"
-         :git/sha "039cf220ac6bb3858f71e823016035e257a5380d"}
+        {:local/root "mcp-clojure-sdk"}
 
         ;; nREPL client support
         nrepl/bencode {:mvn/version "1.2.0"}

--- a/src/emacs_mcp/server.clj
+++ b/src/emacs_mcp/server.clj
@@ -5,6 +5,17 @@
             [taoensso.timbre :as log])
   (:gen-class))
 
+;; Configure Timbre to write to stderr instead of stdout
+;; This is CRITICAL for MCP servers - stdout is the JSON-RPC channel
+(log/merge-config!
+ {:appenders
+  {:println {:enabled? true
+             :async? false
+             :fn (fn [data]
+                   (let [{:keys [output_]} data]
+                     (binding [*out* *err*]
+                       (println (force output_)))))}}})
+
 ;; Convert our tool definitions to the SDK format
 (defn make-tool
   "Convert a tool definition with :handler to SDK format."


### PR DESCRIPTION
## Summary
- Root cause of MCP tool timeouts identified and fixed
- jsonrpc4clj `p/promise` ran handlers synchronously, blocking main loop
- Timbre logging wrote to stdout, corrupting JSON-RPC channel

## Changes
- Add `mcp-clojure-sdk` as submodule (BuddhiLW fork)
- Fork uses `BuddhiLW/jsonrpc4clj` with `p/future` + `discarding-stdout`
- Configure Timbre appender to write to stderr instead of stdout
- Update deps.edn to use local/root submodule

## Test plan
- [ ] Restart Claude Code to reload MCP server
- [ ] Test `org_kanban_native_status` tool
- [ ] Verify no timeouts on pure Clojure MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)