### PR TITLE
feat(chroma): Auto-initialize Ollama embedding provider at server startup

### DIFF
--- a/start-mcp.sh
+++ b/start-mcp.sh
@@ -19,5 +19,11 @@ fi
 
 cd "$SCRIPT_DIR"
 
+# Chroma configuration - override via environment or Emacs config
+# These can be set in your shell profile, Emacs config, or systemd unit
+export CHROMA_HOST="${CHROMA_HOST:-localhost}"
+export CHROMA_PORT="${CHROMA_PORT:-8000}"
+export OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
+
 # Run the MCP server
 exec clojure -X:mcp


### PR DESCRIPTION
## Summary
- Add `init-embedding-provider!` function to `server.clj`
- Auto-configure Ollama embeddings with `nomic-embed-text` model at startup
- Enable semantic memory search via `mcp_memory_search_semantic` tool
- Fail gracefully if Ollama or Chroma are not available

## Changes
- Add requires for `emacs-mcp.chroma` and `emacs-mcp.embeddings.ollama`
- Add `init-embedding-provider!` function with try/catch for graceful degradation
- Call initialization in `start!` before launching the server

## Test plan
- [x] Code compiles and loads in REPL
- [x] `init-embedding-provider!` returns true when Ollama/Chroma available
- [x] `chroma/status` shows `{:configured? true}` after init
- [ ] Restart MCP server and verify semantic search works

🤖 Generated with [Claude Code](https://claude.com/claude-code)