### PR TITLE
feat: CI-friendly test infrastructure + BUG #10 fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -49,4 +49,22 @@
   {:extra-paths ["test"]
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-   :main-opts ["-m" "cognitect.test-runner"]}}}
+   :main-opts ["-m" "cognitect.test-runner"]}
+
+  ;; CI-friendly: Run only unit tests (excludes tests requiring Emacs)
+  :test-unit
+  {:extra-paths ["test"]
+   :extra-deps {io.github.cognitect-labs/test-runner
+                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts ["-m" "cognitect.test-runner" "-e" ":integration"]
+   :exec-fn cognitect.test-runner.api/test
+   :exec-args {:excludes [:integration]}}
+
+  ;; Run only integration tests (requires Emacs with emacs-mcp loaded)
+  :test-integration
+  {:extra-paths ["test"]
+   :extra-deps {io.github.cognitect-labs/test-runner
+                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts ["-m" "cognitect.test-runner" "-i" ":integration"]
+   :exec-fn cognitect.test-runner.api/test
+   :exec-args {:includes [:integration]}}}}

--- a/src/emacs_mcp/tools.clj
+++ b/src/emacs_mcp/tools.clj
@@ -1432,24 +1432,9 @@
       (mcp-error (str "Error querying org file: " (.getMessage e))))))
 
 (defn handle-org-kanban-native-status
-  "Get kanban status using native Clojure parser (no elisp dependency)."
-  [{:keys [file_path]}]
-  (try
-    (let [content (slurp file_path)
-          doc (org-parser/parse-document content)
-          stats (org-query/task-stats doc)
-          todos (org-query/find-todo doc)
-          in-progress (org-query/find-in-progress doc)
-          done (org-query/find-done doc)
-          result {:stats stats
-                  :by_status {:todo (mapv #(select-keys % [:title :properties]) todos)
-                              :in_progress (mapv #(select-keys % [:title :properties]) in-progress)
-                              :done (mapv #(select-keys % [:title :properties]) done)}
-                  :file file_path
-                  :backend "org-clj-native"}]
-      {:type "text" :text (json/write-str result)})
-    (catch Exception e
-      {:type "text" :text (str "Error getting kanban status: " (.getMessage e)) :isError true})))
+  "Delegate to org namespace for native kanban status."
+  [params]
+  (org/handle-org-kanban-native-status params))
 
 (defn handle-org-kanban-native-move
   "Move a task to a new status using native Clojure parser."

--- a/test/emacs_mcp/resilience_test.clj
+++ b/test/emacs_mcp/resilience_test.clj
@@ -30,19 +30,6 @@
     (connected? [_] true)
     (get-status [_] {:connected true})))
 
-(defn make-mode-specific-evaluator
-  "Creates an evaluator that returns different results based on code content.
-   Simulates mode-specific behavior without opts parameter."
-  [explicit-error silent-result]
-  (reify evaluator/ReplEvaluator
-    (eval-code [_ code]
-      ;; Use code content to determine behavior (simulating mode)
-      (if (str/includes? (str code) "silent")
-        {:success true :result silent-result}
-        {:success false :error explicit-error}))
-    (connected? [_] true)
-    (get-status [_] {:connected true})))
-
 (defn make-flaky-evaluator
   "Creates an evaluator that fails N times before succeeding.
    Useful for testing retry logic."
@@ -62,40 +49,38 @@
 ;; ============================================================================
 
 (deftest eval-with-fallback-test
-  (testing "Fallback succeeds when primary mode fails"
-    (let [evaluator (make-mode-specific-evaluator
-                     "REPL buffer not available"
-                     "42")
-          result (resilience/eval-with-fallback
-                  evaluator
-                  "(+ 40 2)"
-                  {:mode :explicit :fallback-mode :silent})]
+  (testing "Fallback succeeds when primary fails"
+    (let [primary (make-failing-evaluator "REPL buffer not available")
+          fallback (make-succeeding-evaluator "42")
+          result (resilience/eval-with-fallback primary fallback "(+ 40 2)")]
       (is (= true (:success result)))
       (is (= "42" (:result result)))
-      (is (= :silent (:mode-used result)))
+      (is (= :fallback (:evaluator-used result)))
       (is (= true (:fallback-used result)))
       (is (some? (:primary-error result)))))
 
   (testing "Primary mode succeeds, no fallback needed"
-    (let [evaluator (make-succeeding-evaluator "123")
-          result (resilience/eval-with-fallback
-                  evaluator
-                  "(* 41 3)"
-                  {:mode :silent})]
+    (let [primary (make-succeeding-evaluator "123")
+          fallback (make-succeeding-evaluator "999")
+          result (resilience/eval-with-fallback primary fallback "(* 41 3)")]
       (is (= true (:success result)))
       (is (= "123" (:result result)))
-      (is (= :silent (:mode-used result)))
+      (is (= :primary (:evaluator-used result)))
       (is (nil? (:fallback-used result)))))
 
   (testing "Both modes fail"
-    (let [evaluator (make-failing-evaluator "Connection lost")
-          result (resilience/eval-with-fallback
-                  evaluator
-                  "(+ 1 1)"
-                  {:mode :explicit :fallback-mode :silent})]
+    (let [primary (make-failing-evaluator "Primary connection lost")
+          fallback (make-failing-evaluator "Fallback connection lost")
+          result (resilience/eval-with-fallback primary fallback "(+ 1 1)")]
       (is (= false (:success result)))
       (is (= true (:fallback-used result)))
-      (is (some? (:primary-error result))))))
+      (is (some? (:primary-error result)))))
+
+  (testing "No fallback evaluator provided"
+    (let [primary (make-failing-evaluator "No connection")
+          result (resilience/eval-with-fallback primary nil "(+ 1 1)")]
+      (is (= false (:success result)))
+      (is (= :primary (:evaluator-used result))))))
 
 ;; ============================================================================
 ;; Retry Tests
@@ -107,9 +92,7 @@
           result (resilience/eval-with-retry
                   evaluator
                   "(+ 1 2)"
-                  {:silent? true}
-                  :max-retries 5
-                  :delay-ms 10)]
+                  {:max-retries 5 :delay-ms 10})]
       (is (= true (:success result)))
       (is (= "success" (:result result)))
       (is (= 3 (:attempts result)))))
@@ -119,8 +102,7 @@
           result (resilience/eval-with-retry
                   evaluator
                   "(+ 1 1)"
-                  {:silent? true}
-                  :max-retries 3)]
+                  {:max-retries 3})]
       (is (= true (:success result)))
       (is (= "42" (:result result)))
       (is (= 1 (:attempts result)))))
@@ -130,9 +112,7 @@
           result (resilience/eval-with-retry
                   evaluator
                   "(+ 1 1)"
-                  {:silent? true}
-                  :max-retries 3
-                  :delay-ms 10)]
+                  {:max-retries 3 :delay-ms 10})]
       (is (= false (:success result)))
       (is (= 3 (:attempts result)))
       (is (some? (:error result))))))
@@ -144,14 +124,14 @@
 (deftest safe-eval-test
   (testing "Returns :ok on success"
     (let [evaluator (make-succeeding-evaluator "42")
-          result (resilience/safe-eval evaluator "(+ 1 2)" {:silent? true})]
+          result (resilience/safe-eval evaluator "(+ 1 2)")]
       (is (contains? result :ok))
       (is (= "42" (:ok result)))
       (is (nil? (:error result)))))
 
   (testing "Returns :error on failure, never throws"
     (let [evaluator (make-failing-evaluator "Division by zero")
-          result (resilience/safe-eval evaluator "(/ 1 0)" {:silent? true})]
+          result (resilience/safe-eval evaluator "(/ 1 0)")]
       (is (contains? result :error))
       (is (= "Division by zero" (:error result)))
       (is (= "EvaluationFailure" (:type result)))
@@ -163,7 +143,7 @@
                              (throw (ex-info "Boom!" {:cause :evil})))
                            (connected? [_] true)
                            (get-status [_] {:connected true}))
-          result (resilience/safe-eval evil-evaluator "(+ 1 1)" {:silent? true})]
+          result (resilience/safe-eval evil-evaluator "(+ 1 1)")]
       (is (contains? result :error))
       (is (some? (:type result)))
       (is (some? (:error result))))))
@@ -202,25 +182,21 @@
 ;; ============================================================================
 
 (deftest integration-test
-  (testing "Realistic failure scenario with mode-specific evaluator"
-    (let [evaluator (make-mode-specific-evaluator
-                     "CIDER REPL not ready"
-                     "evaluation-successful")]
+  (testing "Realistic failure scenario with fallback"
+    (let [failing-primary (make-failing-evaluator "CIDER REPL not ready")
+          working-fallback (make-succeeding-evaluator "evaluation-successful")]
 
       ;; Try with fallback
       (let [result (resilience/eval-with-fallback
-                    evaluator
-                    "(require 'my.namespace)"
-                    {:mode :explicit :fallback-mode :silent})]
+                    failing-primary
+                    working-fallback
+                    "(require 'my.namespace)")]
         (is (resilience/success? result))
-        (is (= :silent (:mode-used result)))
+        (is (= :fallback (:evaluator-used result)))
         (is (:fallback-used result)))
 
       ;; Use safe-eval wrapper
-      (let [result (resilience/safe-eval
-                    evaluator
-                    "(+ 1 2)"
-                    {:silent? true})]
+      (let [result (resilience/safe-eval working-fallback "(+ 1 2)")]
         (is (contains? result :ok))
         (is (= "evaluation-successful" (resilience/get-value result))))))
 
@@ -231,9 +207,7 @@
       (let [result (resilience/eval-with-retry
                     evaluator
                     "(load-data)"
-                    {:silent? true}
-                    :max-retries 5
-                    :delay-ms 50)]
+                    {:max-retries 5 :delay-ms 50})]
         (is (resilience/success? result))
         (is (= 3 (:attempts result)))
         (is (= "data-loaded" (resilience/get-value result)))))))


### PR DESCRIPTION
## Summary

- Add CI-friendly test aliases (`:test-unit` excludes Emacs-dependent tests)
- Add `^:integration` metadata to tests requiring Emacs
- Fix `resilience_test.clj` to match current API signatures
- Fix BUG #10: `org_kanban_native_status` stats mismatch

## Test Infrastructure

| Command | Purpose |
|---------|---------|
| `clojure -M:test-unit` | CI-safe - excludes `:integration` tests |
| `clojure -M:test-integration` | Local - only Emacs-dependent tests |
| `clojure -M:test` | All tests |

### Integration-tagged tests (4):
- `test-cider-eval-returns-result`
- `test-kanban-status-performance`
- `test-swarm-status-clean-json`
- `test-cider-eval-does-not-hang`

## BUG #10 Fix

**Problem**: `stats.todo` showed 5 but `by_status.todo` had 54 items.

**Root cause**: Inconsistent data sources
- `task-stats` used `find-tasks` (level 2 only)
- `find-todo` used `all-headlines` (all levels)

**Fix**: Use `find-tasks` consistently for both stats and arrays.

## Test plan

- [x] Unit tests pass: `clojure -M:test-unit -n emacs-mcp.resilience-test` (0 failures)
- [x] Unit tests pass: `clojure -M:test-unit -n emacs-mcp.bug-regression-test` (7 tests, 0 failures)
- [x] Integration tests pass: `clojure -M:test-integration -n emacs-mcp.bug-regression-test` (4 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)