### PR TITLE
feat(swarm): Async timeout wrapper + Milvus infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ test-output/
 # Generated diagrams
 overarch/
 melpa/
+
+# Vector index backups
+backups/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   chroma:
     image: chromadb/chroma:latest
@@ -12,13 +10,81 @@ services:
       - IS_PERSISTENT=TRUE
       - ANONYMIZED_TELEMETRY=FALSE
     restart: unless-stopped
+    # Chroma image lacks curl/nc, disable healthcheck
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      disable: true
+
+  etcd:
+    container_name: emacs-mcp-milvus-etcd
+    image: quay.io/coreos/etcd:v3.5.5
+    environment:
+      - ETCD_AUTO_COMPACTION_MODE=revision
+      - ETCD_AUTO_COMPACTION_RETENTION=1000
+      - ETCD_QUOTA_BACKEND_BYTES=4294967296
+      - ETCD_SNAPSHOT_COUNT=50000
+    volumes:
+      - milvus-etcd:/etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
       interval: 30s
-      timeout: 10s
+      timeout: 20s
       retries: 3
-      start_period: 10s
+    restart: unless-stopped
+
+  minio:
+    container_name: emacs-mcp-milvus-minio
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9001:9001"
+      - "9000:9000"
+    volumes:
+      - milvus-minio:/minio_data
+    command: minio server /minio_data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    restart: unless-stopped
+
+  milvus:
+    container_name: emacs-mcp-milvus
+    image: milvusdb/milvus:v2.4.4
+    command: ["milvus", "run", "standalone"]
+    security_opt:
+      - seccomp:unconfined
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    volumes:
+      - milvus-data:/var/lib/milvus
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      interval: 30s
+      start_period: 90s
+      timeout: 20s
+      retries: 3
+    ports:
+      - "19530:19530"
+      - "9091:9091"
+    depends_on:
+      - etcd
+      - minio
+    restart: unless-stopped
 
 volumes:
   chroma-data:
     driver: local
+  milvus-etcd:
+    name: emacs-mcp_milvus-etcd
+    external: true
+  milvus-minio:
+    name: emacs-mcp_milvus-minio
+    external: true
+  milvus-data:
+    name: emacs-mcp_milvus-data
+    external: true

--- a/kanban.org
+++ b/kanban.org
@@ -214,6 +214,68 @@ PR #15 + #23 merged. Beamer and Reveal.js support with C4 diagram integration.
 :AGENT: emacs-1664516
 :SESSION: 20251231-164648
 :END:
+** DONE Swarm: Async timeout wrapper for MCP calls
+:PROPERTIES:
+:ID: 79f2252f-ef64-4b83-9b77-b1075ca3152c
+:CREATED: 2026-01-01 18:26
+:DESCRIPTION: Implement timeout wrapper on Clojure side to prevent Emacs blocking from freezing MCP server. Default 5s timeout, return error on timeout.
+:AGENT: emacs-1035819
+:SESSION: 20260101-182630
+:END:
+** DONE Swarm: Force-kill without prompts
+:PROPERTIES:
+:ID: 47417376-f06b-427c-ac31-e878d021d89a
+:CREATED: 2026-01-01 18:26
+:DESCRIPTION: Kill swarm slave buffers without confirmation prompts (kill-buffer-query-functions nil). Prevents blocking on "Buffer has running process".
+:AGENT: emacs-1035819
+:SESSION: 20260101-182631
+:END:
+** TODO [EPIC] Swarm: Dedicated daemon architecture
+:PROPERTIES:
+:ID: aed3402b-31bb-4fed-985f-fc1b8e6ab549
+:CREATED: 2026-01-01 18:26
+:DESCRIPTION: Long-term architectural improvement: Run swarm slaves in separate emacs --daemon=swarm. Benefits: Main Emacs never blocks, dashboard view possible, bb-mcp integration for lighter JVM. Requires architectural review.
+:AGENT: emacs-1035819
+:SESSION: 20260101-182631
+:END:
+** TODO Swarm: Dashboard panel for slave monitoring
+:PROPERTIES:
+:ID: 05fa9283-6b12-47dc-b2ec-6ceb5c3c6202
+:CREATED: 2026-01-01 18:26
+:DESCRIPTION: Create a dashboard view showing all swarm slaves with live status updates. Part of dedicated daemon epic. Could use tabulated-list-mode or custom buffer.
+:AGENT: emacs-1035819
+:SESSION: 20260101-182631
+:END:
+** TODO Swarm: bb-mcp integration for lighter JVM
+:PROPERTIES:
+:ID: 7948f020-5333-4c1f-8e10-6a7770b7567f
+:CREATED: 2026-01-01 18:26
+:DESCRIPTION: Explore using bb-mcp (Babashka) for swarm operations instead of full JVM. Faster startup, lower memory. Could complement dedicated daemon architecture.
+:AGENT: emacs-1035819
+:SESSION: 20260101-182632
+:END:
+** DONE BUG #7: swarm_collect double JSON parse issue (FIXED)
+:PROPERTIES:
+:ID:       58716982-4db7-4591-ad7b-5eeb66442117
+:CREATED:  2026-01-01 21:30
+:DESCRIPTION: FIXED - emacsclient returns quoted JSON, json-encode adds another layer. Solution: Double parse - first unwraps quotes, second gets map. Fixed in src/emacs_mcp/tools/swarm.clj handle-swarm-collect
+:AGENT:    emacs-126582
+:SESSION:  20260101-213013
+:UPDATED:  2026-01-01 21:30
+:LAST_AGENT: emacs-126582
+:END:
+** DONE BUG #10: org_kanban_native_status stats mismatch
+:PROPERTIES:
+:ID:       95bb1f33-5a1e-48ce-adc3-51c4ac6b14f4
+:CREATED:  2026-01-01 21:30
+:DESCRIPTION: MEDIUM - stats.todo shows 4 but by_status.todo array contains 54 items. The stats calculation is incorrect or filtering differently than the array population.
+:AGENT:    emacs-126582
+:SESSION:  20260101-213013
+:UPDATED:  2026-01-01 21:33
+:LAST_AGENT: emacs-126582
+:END:
+
+
 * MCP-Native Documentation Tools (Emacs RAG)
 :PROPERTIES:
 :ID: emacs-docs-rag-epic-2025

--- a/kanban.org
+++ b/kanban.org
@@ -274,6 +274,96 @@ PR #15 + #23 merged. Beamer and Reveal.js support with C4 diagram integration.
 :UPDATED:  2026-01-01 21:33
 :LAST_AGENT: emacs-126582
 :END:
+** TODO [EPIC] SOLID+CLARITY+DDD Refactor for elisp
+:PROPERTIES:
+:ID:       7d2a5b68-1e11-45ba-a336-f0058f74581e
+:CREATED:  2026-01-01 21:52
+:DESCRIPTION: Apply CLARITY framework to emacs-mcp elisp codebase. Goals: SRP compliance, layer purity, domain entities, input guards, telemetry. Major targets: swarm.el (1180 lines), memory.el (617 lines), api.el (420 lines).
+:AGENT:    emacs-126582
+:SESSION:  20260101-215247
+:END:
+** TODO CLARITY-C: Extract terminal-backend protocol (OCP)
+:PROPERTIES:
+:ID:       a8b0bb42-a24d-41cf-8891-d3e48d08666f
+:CREATED:  2026-01-01 21:52
+:DESCRIPTION: Replace pcase vterm/eat dispatching with composable protocol. Create terminal-backend abstraction with send-string, send-return methods. Enable adding new terminals without modifying swarm.el core.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215247
+:END:
+** TODO CLARITY-L: Separate API transformation from domain logic
+:PROPERTIES:
+:ID:       fcbe08f0-1a6f-4a02-8afe-52f0997ed1b6
+:CREATED:  2026-01-01 21:52
+:DESCRIPTION: emacs-mcp-api.el mixes plist-to-alist conversion with business logic. Extract data transformation layer. Create pure domain functions that API layer calls.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215248
+:END:
+** TODO CLARITY-R: Define domain entities with cl-defstruct
+:PROPERTIES:
+:ID:       562a72b8-49af-4dcf-a220-15eda41d429b
+:CREATED:  2026-01-01 21:52
+:DESCRIPTION: Replace raw plists with typed structures: (cl-defstruct swarm-slave id name status buffer), (cl-defstruct swarm-task id prompt status result), (cl-defstruct memory-entry id type content tags). Enables compile-time safety.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215248
+:END:
+** TODO CLARITY-I: Add input validation at API boundaries
+:PROPERTIES:
+:ID:       48cad8ea-254d-4657-a00f-e783ae6a5360
+:CREATED:  2026-01-01 21:53
+:DESCRIPTION: API functions accept any input without validation. Add guards: validate slave-id format, sanitize prompt strings, check timeout ranges, validate memory entry types. Fail fast with clear errors.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215300
+:END:
+** TODO CLARITY-T: Add structured logging infrastructure
+:PROPERTIES:
+:ID:       58e924c0-6a48-48b9-99c6-d37ec11d98fe
+:CREATED:  2026-01-01 21:53
+:DESCRIPTION: Replace (message ...) with structured logging. Create emacs-mcp-log with levels (debug, info, warn, error). Add timing instrumentation for MCP calls. Enable log filtering by component.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215301
+:END:
+** TODO CLARITY-Y: Graceful degradation for missing backends
+:PROPERTIES:
+:ID:       b3b100e7-c0be-410c-8c5b-d6650f0f498f
+:CREATED:  2026-01-01 21:53
+:DESCRIPTION: Swarm fails hard if vterm/eat missing. Memory fails if file unwritable. Add fallback strategies: swarm could use shell-mode, memory could use temp storage. Feature flags for optional features.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215301
+:END:
+** TODO SRP: Split swarm.el into focused modules
+:PROPERTIES:
+:ID:       81aa470e-3400-4b3d-9aa8-4cb772bec2f5
+:CREATED:  2026-01-01 21:53
+:DESCRIPTION: swarm.el (1180 lines) does too much. Split into: swarm-core.el (spawn/kill), swarm-dispatch.el (send/collect), swarm-presets.el (preset loading), swarm-auto-approve.el (approval watcher). Each module single responsibility.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215301
+:END:
+** TODO DDD: Create Value Objects for domain primitives
+:PROPERTIES:
+:ID:       a17d098d-a06f-420c-ba36-67c80469921c
+:CREATED:  2026-01-01 21:53
+:DESCRIPTION: Replace magic strings with Value Objects: SlaveStatus (idle/working/error), TaskStatus (pending/dispatched/completed), MemoryDuration (ephemeral/short/medium/long/permanent). Encapsulate validation in constructors.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215310
+:END:
+** TODO DIP: Extract memory storage interface
+:PROPERTIES:
+:ID:       d095fe75-403d-42d6-9696-a16cd7d7c880
+:CREATED:  2026-01-01 21:53
+:DESCRIPTION: Memory layer couples to file storage. Define storage protocol with save/load/query. Implement file-storage, add option for sqlite-storage or chroma-storage. Enables testing with mock storage.
+:AGENT:    emacs-126582
+:SESSION:  20260101-215310
+:END:
+
+
+
+
+
+
+
+
+
+
 
 
 * MCP-Native Documentation Tools (Emacs RAG)


### PR DESCRIPTION
## Summary

- **Async timeout wrapper**: All swarm MCP handlers now use timeout-wrapped elisp calls to prevent blocking
- **Force-kill improvements**: Better vterm process cleanup without confirmation dialogs  
- **BUG #7 fix**: Double JSON parse issue in swarm_collect resolved
- **Milvus infrastructure**: Added docker-compose services for vector search

## Changes

### Swarm Timeouts (prevents MCP blocking)
| Operation | Timeout |
|-----------|---------|
| spawn | 10s |
| dispatch/status/broadcast | 5s |
| kill | 3s |
| collect | 10s per call |

### Files Modified
- `src/emacs_mcp/emacsclient.clj` - Added `eval-elisp-with-timeout`
- `src/emacs_mcp/tools/swarm.clj` - All handlers use timeouts + JSON parse fix
- `elisp/addons/emacs-mcp-swarm.el` - Improved force-kill
- `docker-compose.yml` - Added Milvus stack
- `.gitignore` - Added backups/

## Test plan
- [x] Spawn slave with timeout verification
- [x] Kill slave without confirmation prompts
- [x] swarm_collect returns proper JSON (not double-quoted)
- [ ] Docker compose up for Milvus services

🤖 Generated with [Claude Code](https://claude.com/claude-code)