### PR TITLE
feat(swarm): Add human-in-the-loop decision system for permission prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,50 @@ Or directly with clojure:
 
 **No nREPL needed!** The MCP server runs standalone via `clojure -X:mcp`.
 
+### Alternative: Lightweight Mode (bb-mcp)
+
+For memory-constrained environments, use **bb-mcp** - a Babashka-based MCP server:
+
+| Metric | JVM (start-mcp.sh) | bb-mcp (start-bb-mcp.sh) |
+|--------|-------------------|--------------------------|
+| Memory | ~500 MB | ~50 MB |
+| Startup | ~2-3s | ~5ms |
+| Tools | 50+ (full Emacs) | 6 (basic file ops) |
+
+**bb-mcp tools:** `bash`, `read_file`, `file_write`, `glob_files`, `grep`, `clojure_eval`
+
+**Setup:**
+
+1. Clone bb-mcp:
+   ```bash
+   git clone https://github.com/BuddhiLW/bb-mcp.git ~/bb-mcp
+   ```
+
+2. Configure Claude Code:
+   ```json
+   {
+     "mcpServers": {
+       "emacs-mcp": {
+         "command": "/path/to/emacs-mcp/start-bb-mcp.sh"
+       }
+     }
+   }
+   ```
+
+3. (Optional) Start shared nREPL for `clojure_eval`:
+   ```bash
+   cd /your/project && clojure -M:nrepl -p 7910
+   ```
+
+**When to use bb-mcp:**
+- Multiple Claude sessions (saves ~450MB per session)
+- Fast startup needed
+- Only need basic file/bash operations
+
+**When to use full JVM:**
+- Need Emacs integration (eval_elisp, buffers, kanban)
+- Need memory, workflows, magit, projectile tools
+
 ## Development
 
 ### Start nREPL for development

--- a/presets/hive-master.md
+++ b/presets/hive-master.md
@@ -1,0 +1,50 @@
+# Hive Master - Swarm Prompt Handler
+
+You are the **Hive Master** coordinating a swarm of Claude slave instances.
+
+## Prompt Handling Protocol
+
+When you receive a desktop notification or the user mentions a swarm prompt:
+
+1. **Check pending prompts** using `swarm_pending_prompts` tool
+2. **Present each prompt** to the user clearly:
+   ```
+   [Slave: {slave_id}] asks:
+   {prompt_text}
+
+   How should I respond? (y/n/custom)
+   ```
+3. **Send the user's response** using `swarm_respond_prompt` tool
+4. **Confirm** the response was sent
+
+## Quick Commands
+
+When the user says:
+- "y" or "yes" or "approve" → Send "y" to the first pending prompt
+- "n" or "no" or "deny" → Send "n" to the first pending prompt
+- "approve all" → Approve all pending prompts with "y"
+- "deny all" → Deny all pending prompts with "n"
+- "check prompts" → List all pending prompts
+
+## Example Interaction
+
+User: "I got a swarm notification"
+
+You: *calls swarm_pending_prompts*
+"There's 1 pending prompt:
+
+[Slave: swarm-worker-12345] asks:
+Allow Bash tool to run `npm test`? (y/n)
+
+How should I respond?"
+
+User: "y"
+
+You: *calls swarm_respond_prompt with slave_id and "y"*
+"Approved. The worker will continue."
+
+## Important
+
+- **React immediately** to notifications - slaves are blocked waiting
+- **Be concise** - just show the prompt and ask for response
+- If the user seems busy, you can mention there are pending prompts without interrupting their flow

--- a/start-bb-mcp.sh
+++ b/start-bb-mcp.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Start bb-mcp - Lightweight MCP server using Babashka
+#
+# This is an alternative to start-mcp.sh (JVM) for environments
+# where memory is constrained or fast startup is needed.
+#
+# Memory: ~50MB vs ~500MB (JVM)
+# Startup: ~5ms vs ~2-3s (JVM)
+#
+# Tools provided:
+#   - bash: Execute shell commands
+#   - read_file: Read file contents
+#   - file_write: Write files
+#   - glob_files: Find files by pattern
+#   - grep: Search content with ripgrep
+#   - clojure_eval: Evaluate Clojure (requires shared nREPL)
+#
+# For full Emacs integration (eval_elisp, buffers, memory, kanban),
+# use start-mcp.sh instead.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Ensure babashka is available
+if ! command -v bb &> /dev/null; then
+    echo "Error: babashka (bb) not found in PATH" >&2
+    echo "Install from: https://babashka.org/" >&2
+    exit 1
+fi
+
+# bb-mcp location - can be overridden via BB_MCP_DIR
+BB_MCP_DIR="${BB_MCP_DIR:-$HOME/PP/bb-mcp}"
+
+if [[ ! -d "$BB_MCP_DIR" ]]; then
+    echo "Error: bb-mcp not found at $BB_MCP_DIR" >&2
+    echo "Clone from: https://github.com/your-user/bb-mcp" >&2
+    echo "Or set BB_MCP_DIR environment variable" >&2
+    exit 1
+fi
+
+# nREPL configuration for clojure_eval
+# Port resolution: BB_MCP_NREPL_PORT > .nrepl-port file > 7888
+export BB_MCP_NREPL_PORT="${BB_MCP_NREPL_PORT:-7910}"
+
+# Project directory for .nrepl-port lookup
+export BB_MCP_PROJECT_DIR="${BB_MCP_PROJECT_DIR:-$SCRIPT_DIR}"
+
+cd "$BB_MCP_DIR"
+
+# Run bb-mcp
+exec bb -m bb-mcp.core


### PR DESCRIPTION
## Summary

- Implements swarm hooks that forward slave permission prompts to the master for human decision
- When a slave encounters a permission prompt, it's queued and a desktop notification is sent via `notify-send`
- Master Claude can query pending prompts and respond using MCP tools

## New Features

- **`emacs-mcp-swarm-prompt-mode`**: Choose between `'bypass`, `'auto`, or `'human` mode
- **`emacs-mcp-swarm-desktop-notify`**: Send `notify-send` alerts when prompts are queued
- **`swarm_pending_prompts` MCP tool**: Query pending prompts from master Claude
- **`swarm_respond_prompt` MCP tool**: Send response (y/n/custom) back to slave
- **`hive-master` preset**: Instructions for master Claude to handle prompts

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│ Master Terminal (Human)                                      │
│  ┌───────────────────────────────────────────────────────┐  │
│  │ [Pending Prompts Queue]                               │  │
│  │  • slave-1: "Allow Bash tool? (y/n)"                  │  │
│  └───────────────────────────────────────────────────────┘  │
│                           │                                  │
│                    Human responds                            │
│                           ↓                                  │
└─────────────────────────────────────────────────────────────┘
                            │
           ┌────────────────┴────────────────┐
           ↓                                 ↓
    ┌─────────────┐                   ┌─────────────┐
    │ Slave-1     │                   │ Slave-3     │
    │ (vterm)     │                   │ (vterm)     │
    │ ← 'y' sent  │                   │ ← 'n' sent  │
    └─────────────┘                   └─────────────┘
```

## Bug Fix

Changed `let` to `let*` in `--do-spawn-async` so `permission-flag` is available when building `claude-cmd`.

## Test Plan

- [x] Set `emacs-mcp-swarm-prompt-mode` to `'human`
- [x] Spawn a slave without bypass permissions
- [x] Dispatch a task that triggers a permission prompt
- [x] Verify desktop notification appears via `notify-send`
- [x] Verify prompt appears in `swarm_pending_prompts`
- [x] Use `swarm_respond_prompt` to approve
- [x] Verify slave receives response and continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)