### PR TITLE
feat(swarm): Human-in-the-loop + BUG #7 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,50 @@ Or directly with clojure:
 
 **No nREPL needed!** The MCP server runs standalone via `clojure -X:mcp`.
 
+### Alternative: Lightweight Mode (bb-mcp)
+
+For memory-constrained environments, use **bb-mcp** - a Babashka-based MCP server:
+
+| Metric | JVM (start-mcp.sh) | bb-mcp (start-bb-mcp.sh) |
+|--------|-------------------|--------------------------|
+| Memory | ~500 MB | ~50 MB |
+| Startup | ~2-3s | ~5ms |
+| Tools | 50+ (full Emacs) | 6 (basic file ops) |
+
+**bb-mcp tools:** `bash`, `read_file`, `file_write`, `glob_files`, `grep`, `clojure_eval`
+
+**Setup:**
+
+1. Clone bb-mcp:
+   ```bash
+   git clone https://github.com/BuddhiLW/bb-mcp.git ~/bb-mcp
+   ```
+
+2. Configure Claude Code:
+   ```json
+   {
+     "mcpServers": {
+       "emacs-mcp": {
+         "command": "/path/to/emacs-mcp/start-bb-mcp.sh"
+       }
+     }
+   }
+   ```
+
+3. (Optional) Start shared nREPL for `clojure_eval`:
+   ```bash
+   cd /your/project && clojure -M:nrepl -p 7910
+   ```
+
+**When to use bb-mcp:**
+- Multiple Claude sessions (saves ~450MB per session)
+- Fast startup needed
+- Only need basic file/bash operations
+
+**When to use full JVM:**
+- Need Emacs integration (eval_elisp, buffers, kanban)
+- Need memory, workflows, magit, projectile tools
+
 ## Development
 
 ### Start nREPL for development

--- a/presets/hive-master.md
+++ b/presets/hive-master.md
@@ -1,0 +1,50 @@
+# Hive Master - Swarm Prompt Handler
+
+You are the **Hive Master** coordinating a swarm of Claude slave instances.
+
+## Prompt Handling Protocol
+
+When you receive a desktop notification or the user mentions a swarm prompt:
+
+1. **Check pending prompts** using `swarm_pending_prompts` tool
+2. **Present each prompt** to the user clearly:
+   ```
+   [Slave: {slave_id}] asks:
+   {prompt_text}
+
+   How should I respond? (y/n/custom)
+   ```
+3. **Send the user's response** using `swarm_respond_prompt` tool
+4. **Confirm** the response was sent
+
+## Quick Commands
+
+When the user says:
+- "y" or "yes" or "approve" → Send "y" to the first pending prompt
+- "n" or "no" or "deny" → Send "n" to the first pending prompt
+- "approve all" → Approve all pending prompts with "y"
+- "deny all" → Deny all pending prompts with "n"
+- "check prompts" → List all pending prompts
+
+## Example Interaction
+
+User: "I got a swarm notification"
+
+You: *calls swarm_pending_prompts*
+"There's 1 pending prompt:
+
+[Slave: swarm-worker-12345] asks:
+Allow Bash tool to run `npm test`? (y/n)
+
+How should I respond?"
+
+User: "y"
+
+You: *calls swarm_respond_prompt with slave_id and "y"*
+"Approved. The worker will continue."
+
+## Important
+
+- **React immediately** to notifications - slaves are blocked waiting
+- **Be concise** - just show the prompt and ask for response
+- If the user seems busy, you can mention there are pending prompts without interrupting their flow

--- a/src/emacs_mcp/tools/magit.clj
+++ b/src/emacs_mcp/tools/magit.clj
@@ -11,6 +11,21 @@
             [taoensso.timbre :as log]))
 
 ;; ============================================================
+;; Working Directory Resolution
+;; ============================================================
+;;
+;; When Claude CLI spawns in a project directory, magit tools should
+;; operate on that project by default - not on whatever buffer is
+;; active in Emacs. We use the MCP server's working directory as the
+;; default when no explicit directory is provided.
+
+(defn- resolve-directory
+  "Resolve the directory to use for git operations.
+   Uses provided directory or falls back to MCP server's working directory."
+  [directory]
+  (or directory (System/getProperty "user.dir")))
+
+;; ============================================================
 ;; Magit Integration Tools (requires emacs-mcp-magit addon)
 ;; ============================================================
 
@@ -25,211 +40,258 @@
 
 (defn handle-magit-status
   "Get comprehensive git repository status via magit addon."
-  [_]
-  (log/info "magit-status")
-  (let [elisp (el/require-and-call-json 'emacs-mcp-magit 'emacs-mcp-magit-api-status)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [directory]}]
+  (let [dir (resolve-directory directory)]
+    (log/info "magit-status" {:directory dir})
+    (let [elisp (el/require-and-call-json 'emacs-mcp-magit 'emacs-mcp-magit-api-status dir)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-branches
   "Get branch information including current, upstream, local and remote branches."
-  [_]
-  (log/info "magit-branches")
-  (let [elisp (el/require-and-call-json 'emacs-mcp-magit 'emacs-mcp-magit-api-branches)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [directory]}]
+  (let [dir (resolve-directory directory)]
+    (log/info "magit-branches" {:directory dir})
+    (let [elisp (el/require-and-call-json 'emacs-mcp-magit 'emacs-mcp-magit-api-branches dir)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-log
   "Get recent commit log."
-  [{:keys [count]}]
-  (log/info "magit-log" {:count count})
-  (let [n (or count 10)
-        elisp (el/require-and-call-json 'emacs-mcp-magit 'emacs-mcp-magit-api-log n)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [count directory]}]
+  (let [dir (resolve-directory directory)
+        n (or count 10)]
+    (log/info "magit-log" {:count n :directory dir})
+    (let [elisp (el/require-and-call-json 'emacs-mcp-magit 'emacs-mcp-magit-api-log n dir)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-diff
   "Get diff for staged, unstaged, or all changes."
-  [{:keys [target]}]
-  (log/info "magit-diff" {:target target})
-  (let [target-sym (case target
+  [{:keys [target directory]}]
+  (let [dir (resolve-directory directory)
+        target-sym (case target
                      "staged" 'staged
                      "unstaged" 'unstaged
                      "all" 'all
-                     'staged)
-        elisp (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-diff target-sym)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+                     'staged)]
+    (log/info "magit-diff" {:target target :directory dir})
+    (let [elisp (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-diff target-sym dir)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-stage
   "Stage files for commit. Use 'all' to stage all modified files."
-  [{:keys [files]}]
-  (log/info "magit-stage" {:files files})
-  (let [file-arg (if (= files "all") 'all files)
-        elisp (el/require-and-call 'emacs-mcp-magit 'emacs-mcp-magit-api-stage file-arg)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success (or result "Staged files"))
-      (mcp-error (str "Error: " error)))))
+  [{:keys [files directory]}]
+  (let [dir (resolve-directory directory)
+        file-arg (if (= files "all") 'all files)]
+    (log/info "magit-stage" {:files files :directory dir})
+    (let [elisp (el/require-and-call 'emacs-mcp-magit 'emacs-mcp-magit-api-stage file-arg dir)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success (or result "Staged files"))
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-commit
   "Create a commit with the given message."
-  [{:keys [message all]}]
-  (log/info "magit-commit" {:message-len (count message) :all all})
-  (let [options (if all "'(:all t)" "nil")
-        elisp (el/format-elisp
-               "(progn
-                  (require 'emacs-mcp-magit nil t)
-                  (if (fboundp 'emacs-mcp-magit-api-commit)
-                      (emacs-mcp-magit-api-commit %s %s)
-                    \"emacs-mcp-magit not loaded\"))"
-               (pr-str message) options)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [message all directory]}]
+  (let [dir (resolve-directory directory)]
+    (log/info "magit-commit" {:message-len (count message) :all all :directory dir})
+    (let [options (if all "'(:all t)" "nil")
+          dir-arg (pr-str dir)
+          elisp (el/format-elisp
+                 "(progn
+                    (require 'emacs-mcp-magit nil t)
+                    (if (fboundp 'emacs-mcp-magit-api-commit)
+                        (emacs-mcp-magit-api-commit %s %s %s)
+                      \"emacs-mcp-magit not loaded\"))"
+                 (pr-str message) options dir-arg)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-push
   "Push to remote. Optionally set upstream tracking."
-  [{:keys [set_upstream]}]
-  (log/info "magit-push" {:set_upstream set_upstream})
-  (let [options (if set_upstream "'(:set-upstream t)" "nil")
-        elisp (el/format-elisp
-               "(progn
-                  (require 'emacs-mcp-magit nil t)
-                  (if (fboundp 'emacs-mcp-magit-api-push)
-                      (emacs-mcp-magit-api-push %s)
-                    \"emacs-mcp-magit not loaded\"))"
-               options)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [set_upstream directory]}]
+  (let [dir (resolve-directory directory)]
+    (log/info "magit-push" {:set_upstream set_upstream :directory dir})
+    (let [options (if set_upstream "'(:set-upstream t)" "nil")
+          dir-arg (pr-str dir)
+          elisp (el/format-elisp
+                 "(progn
+                    (require 'emacs-mcp-magit nil t)
+                    (if (fboundp 'emacs-mcp-magit-api-push)
+                        (emacs-mcp-magit-api-push %s %s)
+                      \"emacs-mcp-magit not loaded\"))"
+                 options dir-arg)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-pull
   "Pull from upstream."
-  [_]
-  (log/info "magit-pull")
-  (let [elisp (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-pull)
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [directory]}]
+  (let [dir (resolve-directory directory)]
+    (log/info "magit-pull" {:directory dir})
+    (let [elisp (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-pull dir)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-fetch
   "Fetch from remote(s)."
-  [{:keys [remote]}]
-  (log/info "magit-fetch" {:remote remote})
-  (let [elisp (if remote
-                (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-fetch remote)
-                (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-fetch))
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [remote directory]}]
+  (let [dir (resolve-directory directory)]
+    (log/info "magit-fetch" {:remote remote :directory dir})
+    (let [elisp (if remote
+                  (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-fetch remote dir)
+                  (el/require-and-call-text 'emacs-mcp-magit 'emacs-mcp-magit-api-fetch nil dir))
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 (defn handle-magit-feature-branches
   "Get list of feature/fix/feat branches (for /ship and /ship-pr skills)."
-  [_]
-  (log/info "magit-feature-branches")
-  ;; Complex elisp with client-side filtering - use format-elisp
-  (let [elisp (el/format-elisp
-               "(progn
-                  (require 'emacs-mcp-magit nil t)
-                  (if (fboundp 'emacs-mcp-magit-api-branches)
-                      (let* ((branches (emacs-mcp-magit-api-branches))
-                             (local (plist-get branches :local))
-                             (feature-branches
-                               (seq-filter
-                                 (lambda (b)
-                                   (string-match-p \"^\\\\(feature\\\\|fix\\\\|feat\\\\)/\" b))
-                                 local)))
-                        (json-encode (list :current (plist-get branches :current)
-                                           :feature_branches feature-branches)))
-                    (json-encode (list :error \"emacs-mcp-magit not loaded\"))))")
-        {:keys [success result error]} (ec/eval-elisp elisp)]
-    (if success
-      (mcp-success result)
-      (mcp-error (str "Error: " error)))))
+  [{:keys [directory]}]
+  (let [dir (resolve-directory directory)]
+    (log/info "magit-feature-branches" {:directory dir})
+    ;; Complex elisp with client-side filtering - use format-elisp
+    (let [dir-arg (pr-str dir)
+          elisp (el/format-elisp
+                 "(progn
+                    (require 'emacs-mcp-magit nil t)
+                    (if (fboundp 'emacs-mcp-magit-api-branches)
+                        (let* ((default-directory %s)
+                               (branches (emacs-mcp-magit-api-branches default-directory))
+                               (local (plist-get branches :local))
+                               (feature-branches
+                                 (seq-filter
+                                   (lambda (b)
+                                     (string-match-p \"^\\\\(feature\\\\|fix\\\\|feat\\\\)/\" b))
+                                   local)))
+                          (json-encode (list :current (plist-get branches :current)
+                                             :feature_branches feature-branches)))
+                      (json-encode (list :error \"emacs-mcp-magit not loaded\"))))"
+                 dir-arg)
+          {:keys [success result error]} (ec/eval-elisp elisp)]
+      (if success
+        (mcp-success result)
+        (mcp-error (str "Error: " error))))))
 
 ;; Tool definitions for magit handlers
 
+;; IMPORTANT: When using a shared emacs-mcp server across multiple projects,
+;; Claude should ALWAYS pass its current working directory to these tools.
+;; The directory can be found in Claude's prompt (e.g., ~/PP/funeraria/sisf-web)
+;; or by running `pwd` in bash.
+
+(def ^:private dir-desc
+  "IMPORTANT: Pass your current working directory here to ensure git operations target YOUR project, not the MCP server's directory. Get it from your prompt path or run `pwd`.")
+
 (def tools
   [{:name "magit_status"
-    :description "Get comprehensive git repository status including branch, staged/unstaged/untracked files, ahead/behind counts, stashes, and recent commits. Requires emacs-mcp-magit addon."
-    :inputSchema {:type "object" :properties {}}
+    :description "Get comprehensive git repository status including branch, staged/unstaged/untracked files, ahead/behind counts, stashes, and recent commits. IMPORTANT: Pass your working directory to target your project."
+    :inputSchema {:type "object"
+                  :properties {"directory" {:type "string"
+                                            :description dir-desc}}
+                  :required []}
     :handler handle-magit-status}
 
    {:name "magit_branches"
-    :description "Get branch information including current branch, upstream, all local branches, and remote branches."
-    :inputSchema {:type "object" :properties {}}
+    :description "Get branch information including current branch, upstream, all local branches, and remote branches. IMPORTANT: Pass your working directory to target your project."
+    :inputSchema {:type "object"
+                  :properties {"directory" {:type "string"
+                                            :description dir-desc}}
+                  :required []}
     :handler handle-magit-branches}
 
    {:name "magit_log"
-    :description "Get recent commit log with hash, author, date, and subject."
+    :description "Get recent commit log with hash, author, date, and subject. IMPORTANT: Pass your working directory to target your project."
     :inputSchema {:type "object"
                   :properties {"count" {:type "integer"
-                                        :description "Number of commits to return (default: 10)"}}
+                                        :description "Number of commits to return (default: 10)"}
+                               "directory" {:type "string"
+                                            :description dir-desc}}
                   :required []}
     :handler handle-magit-log}
 
    {:name "magit_diff"
-    :description "Get diff for staged, unstaged, or all changes."
+    :description "Get diff for staged, unstaged, or all changes. IMPORTANT: Pass your working directory to target your project."
     :inputSchema {:type "object"
                   :properties {"target" {:type "string"
                                          :enum ["staged" "unstaged" "all"]
-                                         :description "What to diff (default: staged)"}}
+                                         :description "What to diff (default: staged)"}
+                               "directory" {:type "string"
+                                            :description dir-desc}}
                   :required []}
     :handler handle-magit-diff}
 
    {:name "magit_stage"
-    :description "Stage files for commit. Use 'all' to stage all modified files, or provide a file path."
+    :description "Stage files for commit. Use 'all' to stage all modified files, or provide a file path. IMPORTANT: Pass your working directory to target your project."
     :inputSchema {:type "object"
                   :properties {"files" {:type "string"
-                                        :description "File path to stage, or 'all' for all modified files"}}
+                                        :description "File path to stage, or 'all' for all modified files"}
+                               "directory" {:type "string"
+                                            :description dir-desc}}
                   :required ["files"]}
     :handler handle-magit-stage}
 
    {:name "magit_commit"
-    :description "Create a git commit with the given message."
+    :description "Create a git commit with the given message. IMPORTANT: Pass your working directory to target your project."
     :inputSchema {:type "object"
                   :properties {"message" {:type "string"
                                           :description "Commit message"}
                                "all" {:type "boolean"
-                                      :description "If true, stage all changes before committing"}}
+                                      :description "If true, stage all changes before committing"}
+                               "directory" {:type "string"
+                                            :description dir-desc}}
                   :required ["message"]}
     :handler handle-magit-commit}
 
    {:name "magit_push"
-    :description "Push to remote. Optionally set upstream tracking for new branches."
+    :description "Push to remote. Optionally set upstream tracking for new branches. IMPORTANT: Pass your working directory to target your project."
     :inputSchema {:type "object"
                   :properties {"set_upstream" {:type "boolean"
-                                               :description "Set upstream tracking if not already set"}}
+                                               :description "Set upstream tracking if not already set"}
+                               "directory" {:type "string"
+                                            :description dir-desc}}
                   :required []}
     :handler handle-magit-push}
 
    {:name "magit_pull"
-    :description "Pull from upstream remote."
-    :inputSchema {:type "object" :properties {}}
+    :description "Pull from upstream remote. IMPORTANT: Pass your working directory to target your project."
+    :inputSchema {:type "object"
+                  :properties {"directory" {:type "string"
+                                            :description dir-desc}}
+                  :required []}
     :handler handle-magit-pull}
 
    {:name "magit_fetch"
-    :description "Fetch from remote(s). Fetches all remotes if no specific remote is provided."
+    :description "Fetch from remote(s). Fetches all remotes if no specific remote is provided. IMPORTANT: Pass your working directory to target your project."
     :inputSchema {:type "object"
                   :properties {"remote" {:type "string"
-                                         :description "Specific remote to fetch from (optional)"}}
+                                         :description "Specific remote to fetch from (optional)"}
+                               "directory" {:type "string"
+                                            :description dir-desc}}
                   :required []}
     :handler handle-magit-fetch}
 
    {:name "magit_feature_branches"
-    :description "Get list of feature/fix/feat branches for shipping. Used by /ship and /ship-pr skills."
-    :inputSchema {:type "object" :properties {}}
+    :description "Get list of feature/fix/feat branches for shipping. Used by /ship and /ship-pr skills. IMPORTANT: Pass your working directory to target your project."
+    :inputSchema {:type "object"
+                  :properties {"directory" {:type "string"
+                                            :description dir-desc}}
+                  :required []}
     :handler handle-magit-feature-branches}])

--- a/start-bb-mcp.sh
+++ b/start-bb-mcp.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Start bb-mcp - Lightweight MCP server using Babashka
+#
+# This is an alternative to start-mcp.sh (JVM) for environments
+# where memory is constrained or fast startup is needed.
+#
+# Memory: ~50MB vs ~500MB (JVM)
+# Startup: ~5ms vs ~2-3s (JVM)
+#
+# Tools provided:
+#   - bash: Execute shell commands
+#   - read_file: Read file contents
+#   - file_write: Write files
+#   - glob_files: Find files by pattern
+#   - grep: Search content with ripgrep
+#   - clojure_eval: Evaluate Clojure (requires shared nREPL)
+#
+# For full Emacs integration (eval_elisp, buffers, memory, kanban),
+# use start-mcp.sh instead.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Ensure babashka is available
+if ! command -v bb &> /dev/null; then
+    echo "Error: babashka (bb) not found in PATH" >&2
+    echo "Install from: https://babashka.org/" >&2
+    exit 1
+fi
+
+# bb-mcp location - can be overridden via BB_MCP_DIR
+BB_MCP_DIR="${BB_MCP_DIR:-$HOME/PP/bb-mcp}"
+
+if [[ ! -d "$BB_MCP_DIR" ]]; then
+    echo "Error: bb-mcp not found at $BB_MCP_DIR" >&2
+    echo "Clone from: https://github.com/your-user/bb-mcp" >&2
+    echo "Or set BB_MCP_DIR environment variable" >&2
+    exit 1
+fi
+
+# nREPL configuration for clojure_eval
+# Port resolution: BB_MCP_NREPL_PORT > .nrepl-port file > 7888
+export BB_MCP_NREPL_PORT="${BB_MCP_NREPL_PORT:-7910}"
+
+# Project directory for .nrepl-port lookup
+export BB_MCP_PROJECT_DIR="${BB_MCP_PROJECT_DIR:-$SCRIPT_DIR}"
+
+cd "$BB_MCP_DIR"
+
+# Run bb-mcp
+exec bb -m bb-mcp.core


### PR DESCRIPTION
## Summary
- Human-in-the-loop decision system for permission prompts in swarm slaves
- Fix resource-guard to use shell instead of slurp for /proc/meminfo
- Fix magit tools to pass directory parameter correctly
- Fix BUG #7: Unwrap emacsclient print format quoting (double-encoding fix)
- Add bb-mcp lightweight alternative

## Commits
- `ae8ee24` fix(emacsclient): Unwrap emacs print format quoting (BUG #7)
- `3ce809e` fix(magit): Pass directory parameter to magit handlers
- `678fe24` fix(resource-guard): Use shell instead of slurp for /proc/meminfo
- `e687c68` feat(swarm): Add human-in-the-loop decision system
- `c3ddef4` feat: Add bb-mcp lightweight alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)