### PR TITLE
ci: Add MELPA validation workflow + rename cci addon

### DIFF
--- a/.github/workflows/melpa-check.yml
+++ b/.github/workflows/melpa-check.yml
@@ -1,0 +1,120 @@
+name: MELPA Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.el'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.el'
+  workflow_dispatch:
+
+jobs:
+  package-lint:
+    name: Package Lint (Emacs ${{ matrix.emacs-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version: ['28.2', '29.4']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - name: Install package-lint
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'package-lint)"
+
+      - name: Run package-lint on main file
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(require 'package-lint)" \
+            --eval "(setq package-lint-main-file \"elisp/emacs-mcp.el\")" \
+            -f package-lint-batch-and-exit \
+            elisp/emacs-mcp.el
+
+  byte-compile:
+    name: Byte Compile (Emacs ${{ matrix.emacs-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version: ['28.2', '29.4']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - name: Install dependencies
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(dolist (pkg '(websocket magit projectile)) (unless (package-installed-p pkg) (package-install pkg)))"
+
+      - name: Byte-compile main file
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(package-initialize)" \
+            --eval "(setq byte-compile-error-on-warn t)" \
+            --eval "(add-to-list 'load-path \"./elisp\")" \
+            --eval "(add-to-list 'load-path \"./elisp/addons\")" \
+            -f batch-byte-compile \
+            elisp/emacs-mcp.el
+
+      - name: Byte-compile core files (warnings allowed)
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(package-initialize)" \
+            --eval "(setq byte-compile-error-on-warn nil)" \
+            --eval "(add-to-list 'load-path \"./elisp\")" \
+            --eval "(add-to-list 'load-path \"./elisp/addons\")" \
+            -f batch-byte-compile \
+            elisp/emacs-mcp-memory.el \
+            elisp/emacs-mcp-context.el \
+            elisp/emacs-mcp-api.el || true
+
+  checkdoc:
+    name: Checkdoc
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: '29.4'
+
+      - name: Run checkdoc on main file
+        run: |
+          emacs --batch \
+            --eval "(require 'checkdoc)" \
+            --eval "(setq checkdoc-spellcheck-documentation-flag nil)" \
+            --eval "(with-current-buffer (find-file-noselect \"elisp/emacs-mcp.el\") (checkdoc-current-buffer t))"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ melpa/
 backups/
 
 arxiv/
+
+# MELPA clone for local testing
+melpa/

--- a/docs/ADDON_REFERENCE.md
+++ b/docs/ADDON_REFERENCE.md
@@ -352,7 +352,7 @@ M-x emacs-mcp-melpazoid-transient
 
 ---
 
-## claude-code-ide
+## cci (claude-code-ide)
 
 **Purpose**: Swarm orchestration via claude-code-ide.el with hivemind completion tracking.
 
@@ -377,8 +377,8 @@ M-x emacs-mcp-melpazoid-transient
 
 **Usage**:
 ```elisp
-(require 'emacs-mcp-claude-code-ide)
-(emacs-mcp-claude-code-ide-mode 1)
+(require 'emacs-mcp-cci)
+(emacs-mcp-cci-mode 1)
 
 ;; Spawn a ling
 (emacs-mcp-cci-spawn "worker" :presets '("hivemind" "tdd"))


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI for MELPA compliance validation and fixes package-lint issues in the cci addon.

## Changes

### GitHub Actions CI (`.github/workflows/melpa-check.yml`)
- **package-lint**: Validates main file against MELPA standards
- **byte-compile**: Ensures clean compilation on Emacs 28.2 and 29.4
- **checkdoc**: Validates docstrings

### Addon Rename (`emacs-mcp-cci.el`)
- Renamed from `emacs-mcp-claude-code-ide.el` to `emacs-mcp-cci.el`
- Fixed all package-lint prefix errors:
  - `defgroup emacs-mcp-cci`
  - `emacs-mcp-cci-mode` (with backwards-compat alias)
  - All functions use `emacs-mcp-cci-` prefix
- Added URL header
- Removed problematic `with-eval-after-load` pattern

### Cleanup
- Added `melpa/` to `.gitignore` (local testing clone caused melpazoid failures)
- Updated `docs/ADDON_REFERENCE.md` with new naming

## Package-lint Results

After changes:
```
((1 0 warning "The word \"emacs\" is redundant in Emacs package names."))
```

Only one expected warning (consistent with all emacs-mcp addons).

## Test Plan

- [ ] CI workflow runs successfully on push
- [ ] package-lint passes on main file
- [ ] byte-compile passes on Emacs 28.2 and 29.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)