### PR TITLE
fix: Resolve byte-compile warnings for Emacs 28/29

### DIFF
--- a/elisp/emacs-mcp-ai-bridge.el
+++ b/elisp/emacs-mcp-ai-bridge.el
@@ -234,11 +234,11 @@ LIMIT defaults to 20."
   (and (require 'emacs-mcp-swarm nil t)
        (fboundp 'emacs-mcp-swarm-dispatch)))
 
-(cl-defun emacs-mcp-ai-dispatch-to-swarm (task &key preset slave-id callback source)
+(cl-defun emacs-mcp-ai-dispatch-to-swarm (task &key preset slave-id _callback source)
   "Dispatch TASK to swarm agent.
 PRESET is the agent preset (e.g., \"code-review\").
 SLAVE-ID optionally targets a specific slave.
-CALLBACK is called with result when complete.
+_CALLBACK is reserved for future async result handling.
 SOURCE identifies the calling AI package.
 
 Returns task-id on success, nil on failure."

--- a/elisp/emacs-mcp-channel.el
+++ b/elisp/emacs-mcp-channel.el
@@ -192,8 +192,9 @@ MSG should be an alist like \\='((\"type\" . \"event\"))."
 
 ;;;; Process Filter & Sentinel
 
-(defun emacs-mcp-channel--filter (proc str)
-  "Process filter for channel PROC receiving STR."
+(defun emacs-mcp-channel--filter (_proc str)
+  "Process filter for channel receiving STR.
+_PROC is the process (unused, required by Emacs process API)."
   (with-current-buffer (or emacs-mcp-channel--buffer
                            (setq emacs-mcp-channel--buffer
                                  (get-buffer-create " *mcp-channel*")))
@@ -219,8 +220,9 @@ Returns t if a message was decoded, nil otherwise."
         t)
     (error nil)))
 
-(defun emacs-mcp-channel--sentinel (proc event)
-  "Sentinel for channel PROC handling EVENT."
+(defun emacs-mcp-channel--sentinel (_proc event)
+  "Sentinel for channel handling EVENT.
+_PROC is the process (unused, required by Emacs process API)."
   (cond
    ((string-match-p "deleted\\|connection broken\\|exited\\|failed" event)
     (message "emacs-mcp-channel: Connection lost: %s" (string-trim event))
@@ -312,7 +314,7 @@ Returns t if a message was decoded, nil otherwise."
 ;;;###autoload
 (defun emacs-mcp-channel-send (msg)
   "Send MSG through the channel.
-MSG should be an alist like '((\"type\" . \"event\") (\"data\" . \"value\")).
+MSG should be an alist like \\='((\"type\" . \"event\") ...).
 If not connected, queues the message for later sending."
   (if (emacs-mcp-channel-connected-p)
       (let ((encoded (emacs-mcp-channel--encode msg)))

--- a/elisp/emacs-mcp-memory.el
+++ b/elisp/emacs-mcp-memory.el
@@ -20,6 +20,15 @@
 (require 'project)
 (require 'seq)
 
+;; Compatibility: plistp was added in Emacs 29
+(unless (fboundp 'plistp)
+  (defun plistp (object)
+    "Return non-nil if OBJECT is a plist."
+    (and (listp object)
+         (or (null object)
+             (and (keywordp (car object))
+                  (plistp (cddr object)))))))
+
 ;;; Customization
 
 (defgroup emacs-mcp-memory nil
@@ -477,13 +486,15 @@ If TAGS are provided, they are merged with the existing entry's tags."
 PROJECT-ID specifies the project (defaults to current).
 Returns list of matching entries, most recent first.
 LIMIT caps the number of results.
-DURATION filters by lifespan category (symbol from `emacs-mcp-memory-durations').
-Entries without :duration are treated as `long-term' for backwards compatibility.
+DURATION filters by lifespan category (symbol from
+\=`emacs-mcp-memory-durations').
+Entries without :duration are treated as long-term for
+backwards compatibility.
 SCOPE-FILTER controls scope filtering:
   - nil: apply automatic scope filtering (global + current project)
-  - t or 'all: return all entries regardless of scope
-  - 'global: return only scope:global entries
-  - string: filter by specific scope tag (e.g., \"scope:project:myproj\")"
+  - t or \\='all: return all entries regardless of scope
+  - \\='global: return only scope:global entries
+  - string: filter by specific scope tag"
   (let* ((pid (or project-id (emacs-mcp-memory--project-id)))
          (type-str (if (symbolp type) (symbol-name type) type))
          (data (emacs-mcp-memory--get-data pid type-str))

--- a/elisp/emacs-mcp-workflows.el
+++ b/elisp/emacs-mcp-workflows.el
@@ -439,7 +439,8 @@ Returns count of successfully moved tasks."
 
 (defun emacs-mcp-workflow-wrap--gather-session-data ()
   "Auto-gather session data from all available sources.
-Returns plist with :recent-notes, :recent-commits, :kanban-activity, :ai-interactions."
+Returns plist with :recent-notes, :recent-commits,
+:kanban-activity, :ai-interactions."
   (list :recent-notes (emacs-mcp-workflow-wrap--gather-recent-notes)
         :recent-commits (emacs-mcp-workflow-wrap--gather-git-commits)
         :kanban-activity (emacs-mcp-workflow-wrap--gather-kanban-activity)


### PR DESCRIPTION
## Summary
Resolves all byte-compile warnings for both Emacs 28 and 29.

## Changes

### Emacs 28 Compatibility
- Added `plistp` compatibility shim (function was added in Emacs 29)
- Affects: memory.el, kanban.el, api.el (via require chain)

### Docstring Fixes
- Wrapped docstrings to stay under 80 characters
- Escaped single quotes with `\='` for Emacs 29+ (which warns about unescaped quotes)

### Unused Argument Warnings
- Prefixed intentionally unused arguments with `_`
- `_proc` in channel filter/sentinel (required by Emacs process API)
- `_callback` in ai-bridge (reserved for future async handling)

## Test plan
- [ ] CI passes with zero byte-compile warnings
- [ ] Package-lint passes
- [ ] Checkdoc passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)