### PR TITLE
feat(agent): Add OpenRouterBackend for multi-provider LLM access

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,7 +30,10 @@
         ;; Chroma vector database client for semantic memory search
         ;; Using local fork with v2 API support (pending upstream PR)
         io.github.levand/clojure-chroma-client
-        {:local/root "clojure-chroma-client"}}
+        {:local/root "clojure-chroma-client"}
+
+        ;; for openrouter integration 
+        clj-http/clj-http {:mvn/version "3.13.1"}}
 
  :aliases
  {:mcp

--- a/src/hive_mcp/agent/cider.clj
+++ b/src/hive_mcp/agent/cider.clj
@@ -14,6 +14,7 @@
    - Integrates with existing agent.delegate! flow"
   (:require [hive-mcp.agent.protocol :as proto]
             [hive-mcp.agent :as agent]
+            [hive-mcp.agent.openrouter :as openrouter]
             [hive-mcp.emacsclient :as ec]
             [clojure.data.json :as json]
             [taoensso.timbre :as log])
@@ -179,15 +180,18 @@
   "Factory function for creating LLM backends.
    
    Supports:
-     :ollama - HTTP backend to Ollama (default)
-     :cider  - nREPL session backend via CIDER pool
+     :ollama     - HTTP backend to Ollama (default)
+     :cider      - nREPL session backend via CIDER pool
+     :openrouter - OpenRouter API (100+ models via unified API)
    
    Examples:
      (make-backend :ollama {:model \"devstral-small:24b\"})
-     (make-backend :cider {:timeout-ms 60000})"
+     (make-backend :cider {:timeout-ms 60000})
+     (make-backend :openrouter {:api-key \"sk-or-...\" :model \"anthropic/claude-3-haiku\"})"
   ([type] (make-backend type {}))
   ([type opts]
    (case type
      :ollama (agent/ollama-backend opts)
      :cider (cider-backend opts)
-     (throw (ex-info "Unknown backend type" {:type type :available [:ollama :cider]})))))
+     :openrouter (openrouter/openrouter-backend opts)
+     (throw (ex-info "Unknown backend type" {:type type :available [:ollama :cider :openrouter]})))))

--- a/src/hive_mcp/agent/openrouter.clj
+++ b/src/hive_mcp/agent/openrouter.clj
@@ -1,0 +1,79 @@
+(ns hive-mcp.agent.openrouter
+  "OpenRouter backend for agent delegation.
+   
+   Provides access to 100+ models via OpenRouter API.
+   Uses OpenAI-compatible format with tool calling support."
+  (:require [hive-mcp.agent.protocol :as proto]
+            [clj-http.client :as http]
+            [clojure.data.json :as json]
+            [taoensso.timbre :as log]))
+
+(def ^:private api-url "https://openrouter.ai/api/v1/chat/completions")
+
+(defn- format-tools
+  "Convert MCP tool format to OpenAI function format."
+  [tools]
+  (when (seq tools)
+    (mapv (fn [{:keys [name description inputSchema]}]
+            {:type "function"
+             :function {:name name
+                        :description description
+                        :parameters inputSchema}})
+          tools)))
+
+(defn- parse-tool-calls
+  "Parse OpenAI-format tool calls to internal format."
+  [tool-calls]
+  (mapv (fn [tc]
+          {:id (:id tc)
+           :name (get-in tc [:function :name])
+           :arguments (json/read-str (get-in tc [:function :arguments]) :key-fn keyword)})
+        tool-calls))
+
+(defn- chat-request
+  "Make chat completion request to OpenRouter."
+  [api-key model messages tools]
+  (let [body (cond-> {:model model
+                      :messages messages}
+               (seq tools) (assoc :tools (format-tools tools)))
+        response (http/post api-url
+                            {:headers {"Authorization" (str "Bearer " api-key)
+                                       "Content-Type" "application/json"
+                                       "HTTP-Referer" "https://github.com/BuddhiLW/hive-mcp"}
+                             :body (json/write-str body)
+                             :as :json})]
+    (:body response)))
+
+(defrecord OpenRouterBackend [api-key model]
+  proto/LLMBackend
+
+  (chat [_ messages tools]
+    (log/debug "OpenRouter chat request" {:model model :msg-count (count messages)})
+    (let [response (chat-request api-key model messages tools)
+          choice (get-in response [:choices 0 :message])
+          tool-calls (:tool_calls choice)]
+      (if (seq tool-calls)
+        {:type :tool_calls
+         :calls (parse-tool-calls tool-calls)}
+        {:type :text
+         :content (:content choice)})))
+
+  (model-name [_] model))
+
+(defn openrouter-backend
+  "Create an OpenRouterBackend.
+   
+   Options:
+     :api-key - OpenRouter API key (required, or set OPENROUTER_API_KEY env)
+     :model   - Model to use (default: anthropic/claude-3-haiku)
+   
+   Popular models:
+     anthropic/claude-3-opus, anthropic/claude-3-sonnet, anthropic/claude-3-haiku
+     openai/gpt-4-turbo, openai/gpt-3.5-turbo
+     mistralai/mistral-large, mistralai/mixtral-8x7b
+     meta-llama/llama-3-70b-instruct"
+  [{:keys [api-key model] :or {model "anthropic/claude-3-haiku"}}]
+  (let [key (or api-key (System/getenv "OPENROUTER_API_KEY"))]
+    (when-not key
+      (throw (ex-info "OpenRouter API key required" {:env "OPENROUTER_API_KEY"})))
+    (->OpenRouterBackend key model)))


### PR DESCRIPTION
## Summary
- Add `OpenRouterBackend` implementing `LLMBackend` protocol
- Access 100+ models via unified API (Claude, GPT-4, Llama, Mistral, etc.)
- OpenAI-compatible format with tool calling support
- Update `make-backend` factory with `:openrouter` option

## Implementation
**Created via ling delegation** (devstral-small-2 local model):
- Researcher ling analyzed existing OllamaBackend pattern
- Implementer ling wrote OpenRouterBackend + factory update

## Usage
```clojure
(make-backend :openrouter {:api-key "sk-or-..." 
                           :model "anthropic/claude-3-haiku"})
;; Or use OPENROUTER_API_KEY env var
```

## Test plan
- [x] Verify module compiles
- [x] Verify factory returns OpenRouterBackend
- [ ] Integration test with OpenRouter API (requires API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)