### PR TITLE
chore: Use git deps for hive-events and hive-hot

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -62,12 +62,12 @@
                              :exclusions [org.apache.logging.log4j/log4j-slf4j2-impl]}
 
         ;; hive-events - re-frame inspired event system for JVM
-        ;; Git submodule for local development
-        io.github.hive/events {:local/root "hive-events"}
+        io.github.hive-agi/hive-events
+        {:git/tag "v0.1.0" :git/sha "240a09e"}
 
         ;; hive-hot - unified hot-reload with events integration
-        ;; Symlinked for local development
-        io.github.hive/hot {:local/root "hive-hot"}
+        io.github.hive-agi/hive-hot
+        {:git/tag "v0.1.1" :git/sha "65530d1"}
 
         ;; Prometheus metrics - iapetos provides idiomatic Clojure wrapper
         ;; CLARITY-T: Telemetry first - observable system


### PR DESCRIPTION
## Summary
Replace local/root dependencies with git/tag references for external libraries.

## Changes
- `io.github.hive-agi/hive-events` → v0.1.0
- `io.github.hive-agi/hive-hot` → v0.1.1

## Benefits
- Project can be used without cloning submodules
- Reproducible builds with pinned versions
- Easier for external contributors

## Test plan
- [x] `clojure -P` downloads deps successfully
- [x] Server loads without errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)