### PR TITLE
docs: Add hive-mcp-cli as recommended installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,19 @@ export HIVE_MCP_DIR="$HOME/hive-mcp"
 export BB_MCP_DIR="$HOME/bb-mcp"
 ```
 
-### 2. Clone & Install
+### 2. Install
+
+**Option A: Automated (Recommended)**
 
 ```bash
-git clone --recursive https://github.com/hive-agi/hive-mcp.git "$HIVE_MCP_DIR"
+go install github.com/hive-agi/hive-mcp-cli/cmd/hive@latest
+hive setup
+```
+
+**Option B: Manual**
+
+```bash
+git clone https://github.com/hive-agi/hive-mcp.git "$HIVE_MCP_DIR"
 git clone https://github.com/hive-agi/bb-mcp.git "$BB_MCP_DIR"
 ```
 


### PR DESCRIPTION
## Summary
- Remove `--recursive` flag from clone command (no submodules needed since git deps migration)
- Add `go install` CLI option as recommended method (Option A)
- Keep manual clone as Option B for users without Go

## Related
- hive-mcp-cli v0.1.0: https://github.com/hive-agi/hive-mcp-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)