### PR TITLE
fix: merge missing migration files from release branch

### DIFF
--- a/.hive-project.edn
+++ b/.hive-project.edn
@@ -8,6 +8,10 @@
  ;; Enable hot-reload for this Clojure project
  :hot-reload false
 
- ;; Knowledge Graph storage backend (:datascript | :datalevin)
- ;; Datalevin persists to data/kg/datalevin/ via LMDB
+ ;; Knowledge Graph storage backend:
+ ;;   :datascript - In-memory (fast, ephemeral)
+ ;;   :datalevin  - LMDB-backed (persistent, data/kg/datalevin/)
+ ;;   :datahike   - Content-addressed (persistent + time-travel, data/kg/datahike/)
+ ;; Migration: (require '[hive-mcp.knowledge-graph.migration :as mig])
+ ;;            (mig/migrate-to-datahike! {:dry-run true})
  :kg-backend :datalevin}

--- a/README.md
+++ b/README.md
@@ -162,4 +162,26 @@ docker compose up -d              # Chroma vector DB
 
 ---
 
+## Dependencies & Quirks
+
+### claude-code-ide.el Fork
+
+The swarm integration requires a **forked version** of [claude-code-ide.el](https://github.com/manzaltu/claude-code-ide.el):
+
+```elisp
+(package! claude-code-ide
+  :recipe (:host github :repo "BuddhiLW/claude-code-ide.el"
+           :branch "feat/system-prompt-file-spawn"))
+```
+
+**Why?** The swarm spawns lings with specialized presets (coordinator, worker, TDD, etc.).
+The fork adds a `system-prompt-file` parameter that injects preset content via
+`--system-prompt $(cat file)`. Without this, spawned lings have no context about their role.
+
+The upstream [manzaltu/claude-code-ide.el](https://github.com/manzaltu/claude-code-ide.el)
+only supports `--append-system-prompt` with inline text, which is insufficient for
+multi-page preset injection.
+
+---
+
 [AGPL-3.0-or-later](LICENSE)

--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ The swarm integration requires a **forked version** of [claude-code-ide.el](http
 
 ```elisp
 (package! claude-code-ide
-  :recipe (:host github :repo "BuddhiLW/claude-code-ide.el"
-           :branch "feat/system-prompt-file-spawn"))
+  :recipe (:host github :repo "BuddhiLW/claude-code-ide.el"))
 ```
 
 **Why?** The swarm spawns lings with specialized presets (coordinator, worker, TDD, etc.).

--- a/presets/hivemind.md
+++ b/presets/hivemind.md
@@ -22,14 +22,16 @@ You are a **hivemind-coordinated agent**. You MUST communicate with the coordina
 **Minimum shout frequency: Every 30-60 seconds of work.**
 
 ```
-hivemind_shout(event_type: "started", task: "description")
-hivemind_shout(event_type: "progress", message: "Read config.clj, found 3 handlers")
-hivemind_shout(event_type: "progress", message: "Delegating edit to drone")
-hivemind_shout(event_type: "progress", message: "Drone completed, verifying...")
-hivemind_shout(event_type: "completed", message: "result summary")
-hivemind_shout(event_type: "error", message: "what failed")
-hivemind_shout(event_type: "blocked", message: "need X")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "started", task: "description")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "progress", message: "Read config.clj, found 3 handlers")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "progress", message: "Delegating edit to drone")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "progress", message: "Drone completed, verifying...")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "completed", message: "result summary")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "error", message: "what failed")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "blocked", message: "need X")
 ```
+
+**CRITICAL:** Always pass `agent_id: $CLAUDE_SWARM_SLAVE_ID` to ALL hivemind tools. Without it, Olympus will show you as "idle" even when working.
 
 ### Ask Before Destructive Actions
 ```
@@ -87,11 +89,11 @@ clojure_eval     # REPL evaluation
 ## Workflow Pattern
 
 ```
-1. SHOUT started:   hivemind_shout(event_type: "started", task: "...")
+1. SHOUT started:   hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "started", task: "...")
 2. DO work:         Use MCP tools (mcp__emacs__*, mcp__claude-context__*)
-3. SHOUT progress:  hivemind_shout(event_type: "progress", message: "...")
-4. ASK if unsure:   hivemind_ask(question: "...", options: [...])
-5. SHOUT complete:  hivemind_shout(event_type: "completed", message: "result")
+3. SHOUT progress:  hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "progress", message: "...")
+4. ASK if unsure:   hivemind_ask(agent_id: $CLAUDE_SWARM_SLAVE_ID, question: "...", options: [...])
+5. SHOUT complete:  hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "completed", message: "result")
 ```
 
 ## Anti-Patterns (NEVER DO)
@@ -108,14 +110,14 @@ Grep(pattern: "x")           # Use mcp__emacs__grep
 # BAD - Destructive action without asking
 [delete files without hivemind_ask]
 
-# GOOD - Full hivemind integration
-hivemind_shout(event_type: "started", task: "Refactor auth module")
+# GOOD - Full hivemind integration (always include agent_id!)
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "started", task: "Refactor auth module")
 mcp__claude-context__search_code(query: "authentication")
 mcp__emacs__read_file(path: "/src/auth.clj")
-hivemind_shout(event_type: "progress", message: "Found 3 files to modify")
-hivemind_ask(question: "Proceed with refactoring these 3 files?", options: ["yes", "no", "show diff first"])
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "progress", message: "Found 3 files to modify")
+hivemind_ask(agent_id: $CLAUDE_SWARM_SLAVE_ID, question: "Proceed with refactoring these 3 files?", options: ["yes", "no", "show diff first"])
 # ... continue based on response
-hivemind_shout(event_type: "completed", message: "Refactored 3 files")
+hivemind_shout(agent_id: $CLAUDE_SWARM_SLAVE_ID, event_type: "completed", message: "Refactored 3 files")
 ```
 
 ## Tool Error Recovery (MANDATORY)

--- a/src/hive_mcp/autopoiesis/basic.clj
+++ b/src/hive_mcp/autopoiesis/basic.clj
@@ -1,0 +1,117 @@
+(ns hive-mcp.autopoiesis.basic
+  "BasicAutopoiesis - No-op fallback implementation.
+   
+   This implementation is used when the proprietary hive-knowledge
+   library is not available. It provides safe, neutral responses
+   for all IAutopoiesis protocol methods.
+   
+   CLARITY-L: Layers stay pure - this is the default adapter.
+   CLARITY-Y: Yield safe failure - graceful degradation when
+   advanced autopoiesis is not configured.")
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(require '[hive-mcp.autopoiesis.protocol :as proto])
+
+;; =============================================================================
+;; BasicAutopoiesis Record
+;; =============================================================================
+
+(defrecord BasicAutopoiesis []
+  proto/IAutopoiesis
+
+  (observe [_this _event]
+    ;; No-op: observations are not recorded without an autopoiesis engine
+    {:observed false
+     :reason "No autopoiesis engine configured. Install hive-knowledge for observation tracking."})
+
+  (trust? [_this _entry]
+    ;; Neutral trust: without an engine, we can't compute trust signals
+    ;; Return 0.5 (neutral) to avoid biasing decisions
+    0.5)
+
+  (emerge [_this _scope]
+    ;; No emergence detection: return empty pattern list
+    ;; Callers should handle empty results gracefully
+    [])
+
+  (learn [_this _feedback]
+    ;; No learning: feedback is acknowledged but not processed
+    {:learned false
+     :model-updates 0
+     :new-patterns 0
+     :reason "No autopoiesis engine configured. Install hive-knowledge for learning capabilities."})
+
+  (decay [_this]
+    ;; No decay: without an engine, we don't modify knowledge
+    ;; Memory's built-in TTL still applies via duration categories
+    {:decayed-count 0
+     :promoted-count 0
+     :expired-count 0
+     :timestamp (java.time.Instant/now)}))
+
+;; =============================================================================
+;; Constructor
+;; =============================================================================
+
+(defn basic-autopoiesis
+  "Create a new BasicAutopoiesis instance.
+   
+   This is a no-op implementation that provides safe defaults
+   when the full autopoiesis engine is not available.
+   
+   Returns a BasicAutopoiesis record."
+  []
+  (->BasicAutopoiesis))
+
+;; =============================================================================
+;; Initialization
+;; =============================================================================
+
+(defn init-basic!
+  "Initialize the autopoiesis system with the basic no-op implementation.
+   
+   Call this during system startup if hive-knowledge is not available.
+   This ensures the system can operate (with degraded capabilities)
+   without the advanced autopoiesis features.
+   
+   Returns the BasicAutopoiesis instance."
+  []
+  (let [instance (basic-autopoiesis)]
+    (proto/set-autopoiesis! instance)
+    instance))
+
+;; =============================================================================
+;; Introspection
+;; =============================================================================
+
+(defn basic-autopoiesis?
+  "Check if the given autopoiesis instance is a BasicAutopoiesis.
+   
+   Useful for conditional logic based on capabilities:
+   
+   (if (basic-autopoiesis? (proto/get-autopoiesis))
+     (log/warn \"Running with degraded autopoiesis\")
+     (perform-advanced-emergence))"
+  [instance]
+  (instance? BasicAutopoiesis instance))
+
+(defn capabilities
+  "Return the capabilities of BasicAutopoiesis.
+   
+   Returns a map describing what this implementation can do:
+   - :observe - false (no observation recording)
+   - :trust   - :neutral (always returns 0.5)
+   - :emerge  - false (no pattern detection)
+   - :learn   - false (no model updates)
+   - :decay   - false (no staleness management)"
+  []
+  {:observe false
+   :trust :neutral
+   :emerge false
+   :learn false
+   :decay false
+   :implementation "BasicAutopoiesis"
+   :version "1.0.0"})

--- a/src/hive_mcp/autopoiesis/protocol.clj
+++ b/src/hive_mcp/autopoiesis/protocol.clj
@@ -1,0 +1,159 @@
+(ns hive-mcp.autopoiesis.protocol
+  "Protocol definition for autopoietic (self-creating) knowledge systems.
+   
+   Autopoiesis = self-creation. The system observes events, evaluates trust,
+   detects emergent patterns, learns from feedback, and decays stale knowledge.
+
+   CLARITY-L: Layers stay pure - this is the port (interface).
+   Implementation lives in proprietary hive-knowledge repo.
+   
+   CLARITY-I: Inputs guarded at protocol boundary.
+   
+   See also:
+   - hive-mcp.autopoiesis.schema for Malli schemas
+   - hive-mcp.autopoiesis.basic for no-op fallback implementation")
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defprotocol IAutopoiesis
+  "Protocol for autopoietic (self-creating) knowledge systems.
+   
+   Autopoiesis (from Greek auto- 'self' + poiesis 'creation') describes systems
+   that maintain and reproduce themselves. In hive-mcp, this means knowledge that:
+   
+   1. **Observes** - Records events from agent interactions
+   2. **Trusts** - Evaluates reliability of knowledge entries
+   3. **Emerges** - Detects patterns across observations
+   4. **Learns** - Updates models from explicit feedback
+   5. **Decays** - Applies staleness to outdated knowledge
+   
+   Implementations:
+   - BasicAutopoiesis: No-op fallback (hive-mcp, open source)
+   - AdvancedAutopoiesis: GNN-powered emergence (hive-knowledge, proprietary)"
+
+  (observe [this event]
+    "Record an observation event from agent interactions.
+     
+     event - Map conforming to :autopoiesis/observation-event schema:
+       {:event-type   - :memory-access | :pattern-match | :feedback | :decay
+        :timestamp    - Instant when event occurred
+        :data         - Event-specific payload
+        :source       - Origin (e.g., \"memory-query\", \"crystallization\")
+        :agent-id     - Agent that triggered the event}
+     
+     Returns map with observation result:
+       {:observed    - boolean, whether observation was recorded
+        :event-id    - string, unique ID for this observation (if recorded)
+        :reason      - string, explanation if not observed}")
+
+  (trust? [this entry]
+    "Compute trust score for a knowledge entry.
+     
+     Trust is computed from multiple signals:
+     - Access patterns (frequently accessed = more trustworthy)
+     - Feedback history (helpful ratings increase trust)
+     - Source reliability (axioms > decisions > notes)
+     - Age and staleness (recent knowledge has higher baseline trust)
+     - Grounding status (grounded entries have higher trust)
+     
+     entry - Memory entry map with at least :id key
+     
+     Returns double in range [0.0, 1.0]:
+       0.0 = completely untrustworthy (should be expired)
+       0.5 = neutral (no signal either way)
+       1.0 = highly trustworthy (core knowledge)")
+
+  (emerge [this scope]
+    "Detect emergent patterns in the given scope.
+     
+     Emergence detection uses multiple levels:
+     - L0: Hash-based exact matching
+     - L1: Weisfeiler-Leman graph kernel similarity
+     - L2: GNN structural embeddings
+     - L3: Cross-project pattern synthesis
+     
+     scope - String identifying the scope to analyze:
+       - nil or \"global\" for all knowledge
+       - \"project:<id>\" for project-specific
+       - \"session:<id>\" for session-specific
+     
+     Returns vector of pattern candidates:
+       [{:pattern-id   - Unique identifier
+         :pattern-type - :cluster | :sequence | :hierarchy | :anomaly
+         :confidence   - Trust score [0.0, 1.0]
+         :evidence     - Vector of entry IDs supporting pattern
+         :scope        - Scope where pattern was detected}]")
+
+  (learn [this feedback]
+    "Update internal models from explicit feedback.
+     
+     Learning integrates:
+     - Helpfulness ratings from agents/users
+     - Pattern confirmations/rejections
+     - Explicit corrections to knowledge
+     
+     feedback - Map conforming to :autopoiesis/feedback schema:
+       {:entry-id  - ID of the entry being rated
+        :rating    - :helpful | :unhelpful | :correct | :incorrect
+        :context   - Optional context about the feedback
+        :agent-id  - Agent providing feedback}
+     
+     Returns learning report:
+       {:learned       - boolean, whether learning occurred
+        :model-updates - int, number of model parameters updated
+        :new-patterns  - int, patterns discovered from this feedback
+        :reason        - string, explanation if not learned}")
+
+  (decay [this]
+    "Apply staleness decay to all knowledge.
+     
+     Decay process:
+     1. Check all entries against their TTL
+     2. Demote entries with low trust scores
+     3. Promote entries with high engagement
+     4. Expire entries past their lifetime
+     
+     Should be called periodically (e.g., daily cron, session end).
+     
+     Returns decay report:
+       {:decayed-count  - int, entries that had staleness increased
+        :promoted-count - int, entries promoted to longer duration
+        :expired-count  - int, entries removed due to TTL
+        :timestamp      - Instant when decay was applied}"))
+
+;; =============================================================================
+;; Active Autopoiesis Management
+;; =============================================================================
+
+;; Atom holding the currently active IAutopoiesis implementation.
+(defonce ^:private active-autopoiesis (atom nil))
+
+(defn set-autopoiesis!
+  "Set the active autopoiesis implementation.
+   Called during system initialization.
+   
+   autopoiesis - Must satisfy IAutopoiesis protocol"
+  [autopoiesis]
+  {:pre [(satisfies? IAutopoiesis autopoiesis)]}
+  (reset! active-autopoiesis autopoiesis))
+
+(defn get-autopoiesis
+  "Get the active autopoiesis implementation.
+   Throws if no implementation has been set."
+  []
+  (or @active-autopoiesis
+      (throw (ex-info "No autopoiesis engine configured. Call set-autopoiesis! first."
+                      {:hint "Initialize with basic-autopoiesis or load hive-knowledge"}))))
+
+(defn autopoiesis-set?
+  "Check if an autopoiesis implementation has been configured."
+  []
+  (some? @active-autopoiesis))
+
+(defn reset-autopoiesis!
+  "Reset the active autopoiesis to nil.
+   Used for testing and system shutdown."
+  []
+  (reset! active-autopoiesis nil))

--- a/src/hive_mcp/autopoiesis/schema.clj
+++ b/src/hive_mcp/autopoiesis/schema.clj
@@ -1,0 +1,159 @@
+(ns hive-mcp.autopoiesis.schema
+  "Malli schemas for autopoiesis types.
+   
+   Defines the data shapes for observations, trust scores, patterns,
+   feedback, and reports used by the IAutopoiesis protocol.
+   
+   CLARITY-I: Inputs guarded - all protocol inputs should be validated
+   against these schemas at boundaries.")
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(require '[malli.core :as m])
+
+;; =============================================================================
+;; Base Types
+;; =============================================================================
+
+(def TrustScore
+  "Trust score in range [0.0, 1.0].
+   0.0 = untrustworthy, 0.5 = neutral, 1.0 = highly trusted."
+  [:double {:min 0.0 :max 1.0}])
+
+(def EventType
+  "Types of observation events."
+  [:enum :memory-access :pattern-match :feedback :decay
+   :crystallization :grounding :query :mutation])
+
+(def PatternType
+  "Types of emergent patterns."
+  [:enum :cluster :sequence :hierarchy :anomaly
+   :cross-project :temporal :structural])
+
+(def FeedbackRating
+  "Feedback rating values."
+  [:enum :helpful :unhelpful :correct :incorrect])
+
+(def DurationCategory
+  "Memory duration categories."
+  [:enum :ephemeral :short :medium :long :permanent])
+
+;; =============================================================================
+;; Observation Events
+;; =============================================================================
+
+(def ObservationEvent
+  "Schema for observation events recorded by the autopoiesis system."
+  [:map
+   [:event-type EventType]
+   [:timestamp {:optional true} inst?]
+   [:data {:optional true} :map]
+   [:source {:optional true} :string]
+   [:agent-id {:optional true} :string]
+   [:project-id {:optional true} :string]
+   [:session-id {:optional true} :string]])
+
+(def ObservationResult
+  "Schema for observation result."
+  [:map
+   [:observed :boolean]
+   [:event-id {:optional true} :string]
+   [:reason {:optional true} :string]])
+
+;; =============================================================================
+;; Pattern Detection
+;; =============================================================================
+
+(def PatternCandidate
+  "Schema for emergent pattern candidates."
+  [:map
+   [:pattern-id :string]
+   [:pattern-type PatternType]
+   [:confidence TrustScore]
+   [:evidence {:optional true} [:vector :string]]
+   [:scope {:optional true} :string]
+   [:metadata {:optional true} :map]])
+
+(def EmergenceLevel
+  "Emergence detection levels (L0-L3)."
+  [:enum :l0-hash :l1-wl-kernel :l2-gnn :l3-synthesis])
+
+;; =============================================================================
+;; Feedback
+;; =============================================================================
+
+(def Feedback
+  "Schema for explicit feedback on knowledge entries."
+  [:map
+   [:entry-id :string]
+   [:rating FeedbackRating]
+   [:context {:optional true} :string]
+   [:agent-id {:optional true} :string]
+   [:timestamp {:optional true} inst?]])
+
+(def LearningReport
+  "Schema for learning operation report."
+  [:map
+   [:learned :boolean]
+   [:model-updates {:optional true} :int]
+   [:new-patterns {:optional true} :int]
+   [:timestamp {:optional true} inst?]
+   [:reason {:optional true} :string]])
+
+;; =============================================================================
+;; Decay
+;; =============================================================================
+
+(def DecayReport
+  "Schema for decay operation report."
+  [:map
+   [:decayed-count :int]
+   [:promoted-count :int]
+   [:expired-count :int]
+   [:timestamp {:optional true} inst?]
+   [:details {:optional true}
+    [:map
+     [:decayed-entries {:optional true} [:vector :string]]
+     [:promoted-entries {:optional true} [:vector :string]]
+     [:expired-entries {:optional true} [:vector :string]]]]])
+
+;; =============================================================================
+;; Trust Computation
+;; =============================================================================
+
+(def TrustFactors
+  "Factors used in trust computation."
+  [:map
+   [:access-frequency {:optional true} :double]
+   [:feedback-score {:optional true} :double]
+   [:source-reliability {:optional true} :double]
+   [:age-factor {:optional true} :double]
+   [:grounding-bonus {:optional true} :double]])
+
+(def TrustResult
+  "Schema for trust computation result with breakdown."
+  [:map
+   [:score TrustScore]
+   [:factors {:optional true} TrustFactors]
+   [:computed-at {:optional true} inst?]])
+
+;; =============================================================================
+;; Validation Helpers
+;; =============================================================================
+
+(defn valid-observation?
+  "Check if event conforms to ObservationEvent schema."
+  [event]
+  (m/validate ObservationEvent event))
+
+(defn valid-feedback?
+  "Check if feedback conforms to Feedback schema."
+  [feedback]
+  (m/validate Feedback feedback))
+
+(defn valid-pattern?
+  "Check if pattern conforms to PatternCandidate schema."
+  [pattern]
+  (m/validate PatternCandidate pattern))

--- a/src/hive_mcp/enhancer/basic.clj
+++ b/src/hive_mcp/enhancer/basic.clj
@@ -1,0 +1,54 @@
+(ns hive-mcp.enhancer.basic
+  "BasicEnhancer - No-op fallback implementation of IKnowledgeEnhancer.
+
+   CLARITY-L: Layers stay pure - this is the open-source fallback.
+
+   This implementation provides safe defaults when the proprietary
+   hive-knowledge library is not available. All methods return
+   neutral/empty values that allow the system to function without
+   AI-powered enhancement."
+  (:require [hive-mcp.enhancer.protocol :as proto]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defrecord BasicEnhancer []
+  proto/IKnowledgeEnhancer
+
+  (enhance-query [_this query opts]
+    ;; Return query unchanged with empty expansions
+    {:original   query
+     :expanded   query
+     :terms      []
+     :embeddings nil
+     :enhancer   :basic
+     :opts       opts})
+
+  (compute-trust [_this _entry]
+    ;; Return neutral trust score
+    ;; 0.5 = "no opinion" - neither trusted nor untrusted
+    0.5)
+
+  (detect-emergence [_this _scope]
+    ;; No emergence detection without ML models
+    [])
+
+  (suggest-cross-pollination [_this _entry-id]
+    ;; No cross-pollination suggestions without ML models
+    [])
+
+  (extract-learnings [_this _exploration-result]
+    ;; No learning extraction without ML models
+    []))
+
+(defn create-basic-enhancer
+  "Create a new BasicEnhancer instance.
+
+   This is the fallback enhancer used when hive-knowledge
+   is not available on the classpath.
+
+   Returns:
+     BasicEnhancer record implementing IKnowledgeEnhancer"
+  []
+  (->BasicEnhancer))

--- a/src/hive_mcp/enhancer/loader.clj
+++ b/src/hive_mcp/enhancer/loader.clj
@@ -1,0 +1,82 @@
+(ns hive-mcp.enhancer.loader
+  "Dynamic loader for IKnowledgeEnhancer implementations.
+
+   CLARITY-L: Layers stay pure - this bridges open/closed boundary.
+
+   Attempts to load the proprietary hive-knowledge implementation.
+   Falls back to BasicEnhancer if not available.
+
+   This pattern allows hive-mcp to be fully functional without
+   proprietary components while gaining enhanced capabilities
+   when hive-knowledge is on the classpath."
+  (:require [hive-mcp.enhancer.protocol :as proto]
+            [hive-mcp.enhancer.basic :as basic]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defn- try-load-proprietary
+  "Attempt to load the proprietary hive-knowledge enhancer.
+
+   Uses dynamic require to avoid compile-time dependency.
+   Returns the enhancer instance or nil if loading fails."
+  []
+  (try
+    (require 'hive-knowledge.core)
+    (let [create-fn (resolve 'hive-knowledge.core/create-enhancer)]
+      (when create-fn
+        (create-fn)))
+    (catch Exception e
+      ;; Expected when hive-knowledge not on classpath
+      ;; Log at debug level only
+      (when (System/getProperty "hive.debug")
+        (println "[enhancer] Proprietary enhancer not available:" (.getMessage e)))
+      nil)))
+
+(defn load-enhancer
+  "Load the best available knowledge enhancer.
+
+   Attempts to load in order:
+   1. Proprietary hive-knowledge enhancer (if on classpath)
+   2. BasicEnhancer fallback (always available)
+
+   Sets the loaded enhancer as active via set-enhancer!.
+
+   Returns:
+     The loaded enhancer instance (also set as active)
+
+   Side effects:
+     - Requires hive-knowledge.core if available
+     - Sets active enhancer via protocol/set-enhancer!"
+  []
+  (let [enhancer (or (try-load-proprietary)
+                     (basic/create-basic-enhancer))]
+    (proto/set-enhancer! enhancer)
+    enhancer))
+
+(defn enhancer-type
+  "Get the type of the currently active enhancer.
+
+   Returns:
+     :proprietary - hive-knowledge enhancer loaded
+     :basic       - fallback BasicEnhancer
+     :none        - no enhancer loaded yet"
+  []
+  (if (proto/enhancer-set?)
+    (let [enhancer (proto/get-enhancer)]
+      (if (instance? hive_mcp.enhancer.basic.BasicEnhancer enhancer)
+        :basic
+        :proprietary))
+    :none))
+
+(defn reload-enhancer!
+  "Force reload of the enhancer.
+
+   Useful for development when hive-knowledge has been
+   added to the classpath after initial load.
+
+   Returns:
+     The newly loaded enhancer instance"
+  []
+  (load-enhancer))

--- a/src/hive_mcp/enhancer/protocol.clj
+++ b/src/hive_mcp/enhancer/protocol.clj
@@ -1,0 +1,158 @@
+(ns hive-mcp.enhancer.protocol
+  "IKnowledgeEnhancer - Bridge to proprietary knowledge enhancement.
+
+   CLARITY-L: Layers stay pure - this is the port (interface).
+   Implementation lives in proprietary hive-knowledge repo.
+
+   This is the primary integration point between open hive-mcp
+   and closed hive-knowledge. The protocol defines AI-powered
+   knowledge enhancement capabilities that require ML/GNN models.")
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defprotocol IKnowledgeEnhancer
+  "Protocol for AI-powered knowledge enhancement.
+
+   Provides semantic query enhancement, trust computation,
+   emergence detection, and cross-pollination suggestions.
+
+   Implementations:
+   - BasicEnhancer: No-op fallback (open source, in this repo)
+   - ProprietaryEnhancer: Full ML/GNN implementation (hive-knowledge repo)
+
+   Usage:
+   1. Call (load-enhancer) at system startup
+   2. Use (get-enhancer) to access the active implementation
+   3. If hive-knowledge is on classpath, ProprietaryEnhancer loads
+   4. Otherwise, BasicEnhancer provides safe no-op defaults"
+
+  (enhance-query [this query opts]
+    "Enhance a query with semantic context.
+
+     Uses embedding models to expand query with related concepts,
+     synonyms, and domain-specific terms.
+
+     Parameters:
+       query - The original query string or structured query map
+       opts  - Enhancement options:
+               :scope      - Project scope for context (optional)
+               :max-terms  - Max expansion terms (default 10)
+               :threshold  - Similarity threshold 0.0-1.0 (default 0.7)
+
+     Returns:
+       Enriched query map with:
+       :original    - The input query
+       :expanded    - Query with semantic expansions
+       :terms       - Vector of expansion terms with scores
+       :embeddings  - Vector embeddings if available (nil in BasicEnhancer)")
+
+  (compute-trust [this entry]
+    "Compute trust score for a memory entry using ML models.
+
+     Analyzes entry content, source, access patterns, and validation
+     history to compute a trust score.
+
+     Parameters:
+       entry - Memory entry map with at least :id, :content, :type
+
+     Returns:
+       Trust score 0.0-1.0 where:
+       0.0-0.3 - Low trust (unverified, inconsistent)
+       0.3-0.7 - Medium trust (some validation)
+       0.7-1.0 - High trust (verified, consistent, grounded)
+
+     BasicEnhancer returns 0.5 (neutral) for all entries.")
+
+  (detect-emergence [this scope]
+    "Detect emergent patterns using GNN analysis.
+
+     Analyzes the knowledge graph structure to find:
+     - Clusters of related concepts forming new abstractions
+     - Cross-project patterns that indicate reusable knowledge
+     - Structural similarities suggesting hidden relationships
+
+     Parameters:
+       scope - Scope to analyze (project-id, :global, or nil for all)
+
+     Returns:
+       Vector of emergence candidates:
+       [{:type       :cluster|:cross-project|:structural
+         :confidence 0.0-1.0
+         :entries    [entry-ids involved]
+         :suggested  {:type :convention|:decision|:axiom
+                      :content \"Proposed synthesis...\"
+                      :rationale \"Why this emerged...\"}}]
+
+     BasicEnhancer returns empty vector [].")
+
+  (suggest-cross-pollination [this entry-id]
+    "Suggest cross-project knowledge sharing opportunities.
+
+     Identifies entries in other projects that could benefit from
+     or contribute to the given entry's knowledge.
+
+     Parameters:
+       entry-id - ID of the source entry
+
+     Returns:
+       Vector of suggestions:
+       [{:target-project \"project-id\"
+         :target-entry   \"entry-id\" or nil if new
+         :action         :share|:merge|:link|:promote
+         :confidence     0.0-1.0
+         :rationale      \"Why this cross-pollination...\"}]
+
+     BasicEnhancer returns empty vector [].")
+
+  (extract-learnings [this exploration-result]
+    "Extract structured learnings from exploration results.
+
+     Analyzes code exploration, debugging sessions, or research
+     results to extract reusable knowledge.
+
+     Parameters:
+       exploration-result - Map with exploration data:
+         :files-read    - Files examined
+         :patterns      - Code patterns found
+         :decisions     - Decisions made
+         :problems      - Problems encountered
+         :solutions     - Solutions applied
+
+     Returns:
+       Vector of extracted learnings:
+       [{:type        :convention|:snippet|:decision|:note
+         :content     \"The learning...\"
+         :confidence  0.0-1.0
+         :tags        [suggested tags]
+         :duration    :ephemeral|:short|:medium|:long|:permanent
+         :scope       suggested scope}]
+
+     BasicEnhancer returns empty vector []."))
+
+;; =============================================================================
+;; Active Enhancer Management
+;; =============================================================================
+
+(defonce ^:private active-enhancer (atom nil))
+
+(defn set-enhancer!
+  "Set the active knowledge enhancer implementation.
+   Called during system initialization by loader."
+  [enhancer]
+  {:pre [(satisfies? IKnowledgeEnhancer enhancer)]}
+  (reset! active-enhancer enhancer))
+
+(defn get-enhancer
+  "Get the active knowledge enhancer.
+   Throws if no enhancer has been loaded."
+  []
+  (or @active-enhancer
+      (throw (ex-info "No knowledge enhancer configured. Call load-enhancer first."
+                      {:hint "Use hive-mcp.enhancer.loader/load-enhancer"}))))
+
+(defn enhancer-set?
+  "Check if an enhancer has been configured."
+  []
+  (some? @active-enhancer))

--- a/src/hive_mcp/introspect/basic.clj
+++ b/src/hive_mcp/introspect/basic.clj
@@ -1,0 +1,82 @@
+(ns hive-mcp.introspect.basic
+  "BasicIntrospect - No-op fallback implementation of IIntrospect.
+
+   Provides stub responses when no real introspection engine is available.
+   Used as the default in hive-mcp (open source) without hive-logic.
+
+   CLARITY-Y: Yield safe failure - graceful degradation when
+   introspection capabilities are not available.
+
+   SOLID-L: Liskov Substitution - this implementation can be used
+   anywhere IIntrospect is expected, returning 'not available' responses."
+  (:require [hive-mcp.introspect.protocol :as proto]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defrecord BasicIntrospect []
+  proto/IIntrospect
+
+  (explain [_this fact]
+    {:fact fact
+     :derivation []
+     :confidence 0.0
+     :grounded false
+     :status :not-available
+     :message "Introspection not available. Install hive-logic for full provenance tracking."})
+
+  (trace [_this query]
+    {:query query
+     :steps []
+     :result nil
+     :stats {}
+     :status :not-available
+     :message "Query tracing not available. Install hive-logic for execution tracing."})
+
+  (diff [_this v1 v2]
+    {:v1 v1
+     :v2 v2
+     :added []
+     :removed []
+     :changed []
+     :stats {:added-count 0 :removed-count 0 :changed-count 0}
+     :status :not-available
+     :message "Knowledge diff not available. Install hive-logic for version comparison."}))
+
+;; =============================================================================
+;; Constructor
+;; =============================================================================
+
+(defn create-basic-introspect
+  "Create a BasicIntrospect instance (no-op fallback).
+
+   Use this when:
+   - hive-logic is not installed
+   - Testing without introspection dependencies
+   - Graceful degradation in production
+
+   Example:
+     (def introspector (create-basic-introspect))
+     (proto/set-introspector! introspector)"
+  []
+  (->BasicIntrospect))
+
+;; =============================================================================
+;; Convenience Functions
+;; =============================================================================
+
+(defn introspection-available?
+  "Check if real introspection is available.
+   Returns false for BasicIntrospect (no-op fallback)."
+  [introspector]
+  (not (instance? BasicIntrospect introspector)))
+
+(defn ensure-introspector!
+  "Ensure an introspector is set. Uses BasicIntrospect if none configured.
+
+   Call this during system startup to guarantee introspection calls
+   won't fail, even if they return 'not available' responses."
+  []
+  (when-not (proto/introspector-set?)
+    (proto/set-introspector! (create-basic-introspect))))

--- a/src/hive_mcp/introspect/protocol.clj
+++ b/src/hive_mcp/introspect/protocol.clj
@@ -1,0 +1,123 @@
+(ns hive-mcp.introspect.protocol
+  "IIntrospect - Provenance and explanation protocol.
+
+   Provides the WHY behind knowledge - provenance tracking,
+   derivation chains, and diff analysis for introspectable reasoning.
+
+   CLARITY-L: Layers stay pure - this is the port (interface).
+   Implementation lives in proprietary hive-logic repo.
+
+   CLARITY-I: Inputs are guarded at protocol boundary.
+   CLARITY-R: Represented intent - each method captures a distinct
+              aspect of knowledge provenance.")
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defprotocol IIntrospect
+  "Protocol for introspectable reasoning systems.
+
+   Provides the WHY behind knowledge - provenance tracking,
+   derivation chains, and diff analysis.
+
+   DDD: This is a domain port (interface) in the hexagonal architecture.
+   Implementations are adapters that can be swapped for different
+   reasoning backends (Datalog, Prolog, LLM-based, etc.).
+
+   SOLID-D: Depend on abstractions (this protocol), not concretions
+   (specific reasoning engine implementations)."
+
+  (explain [this fact]
+    "Explain why a fact exists. Returns derivation chain with sources.
+
+     Arguments:
+       fact - A fact identifier (keyword, string, or map with :id)
+
+     Returns a map with:
+       :fact       - The fact being explained
+       :derivation - Vector of derivation steps, each with:
+                     :source - Where this knowledge came from
+                     :rule   - What rule/inference produced it (if derived)
+                     :timestamp - When it was derived
+       :confidence - Overall confidence score (0.0-1.0)
+       :grounded   - Whether fact is grounded in original source
+
+     Example:
+       (explain introspector :user-is-admin)
+       => {:fact :user-is-admin
+           :derivation [{:source :memory-entry-123
+                         :rule :role-based-access
+                         :timestamp #inst \"2026-02-03\"}]
+           :confidence 0.95
+           :grounded true}")
+
+  (trace [this query]
+    "Trace the execution of a query. Returns step-by-step derivation.
+
+     Arguments:
+       query - A Datalog-style query or natural language query string
+
+     Returns a map with:
+       :query  - Original query
+       :steps  - Vector of execution steps, each with:
+                 :operation - What happened (:match, :filter, :join, :derive)
+                 :data      - Data involved at this step
+                 :cost      - Computational cost estimate
+       :result - Final query result
+       :stats  - Execution statistics (time, memory, etc.)
+
+     Example:
+       (trace introspector '[:find ?e :where [?e :type :convention]])
+       => {:query [:find ?e :where [?e :type :convention]]
+           :steps [{:operation :scan, :data :memory-store}...]
+           :result #{1 2 3}
+           :stats {:time-ms 12, :datoms-scanned 150}}")
+
+  (diff [this v1 v2]
+    "Compare two knowledge versions. Returns semantic diff.
+
+     Arguments:
+       v1 - First version (transaction ID, timestamp, or snapshot)
+       v2 - Second version (transaction ID, timestamp, or snapshot)
+
+     Returns a map with:
+       :v1      - First version identifier
+       :v2      - Second version identifier
+       :added   - Facts present in v2 but not v1
+       :removed - Facts present in v1 but not v2
+       :changed - Facts that changed (with before/after values)
+       :stats   - Summary statistics
+
+     Example:
+       (diff introspector #inst \"2026-02-01\" #inst \"2026-02-03\")
+       => {:v1 #inst \"2026-02-01\"
+           :v2 #inst \"2026-02-03\"
+           :added [{:id :new-convention, :type :convention}...]
+           :removed []
+           :changed [{:id :old-decision, :before {...} :after {...}}]
+           :stats {:added-count 5, :removed-count 0, :changed-count 1}}"))
+
+;; =============================================================================
+;; Active Introspector Management
+;; =============================================================================
+
+(defonce ^:private active-introspector (atom nil))
+
+(defn set-introspector!
+  "Set the active introspector implementation.
+   Called during system initialization."
+  [introspector]
+  {:pre [(satisfies? IIntrospect introspector)]}
+  (reset! active-introspector introspector))
+
+(defn get-introspector
+  "Get the active introspector.
+   Returns nil if no introspector has been set (introspection not available)."
+  []
+  @active-introspector)
+
+(defn introspector-set?
+  "Check if an introspector has been configured."
+  []
+  (some? @active-introspector))

--- a/src/hive_mcp/migration/adapter.clj
+++ b/src/hive_mcp/migration/adapter.clj
@@ -1,0 +1,171 @@
+(ns hive-mcp.migration.adapter
+  "Protocol and registry for migration adapters.
+
+   Adapters transform data for export/import to external systems:
+   - Logseq (markdown + EDN properties)
+   - Obsidian (markdown + YAML frontmatter)
+   - Notion (JSON API format)
+   - Custom (user-defined transforms)
+
+   CLARITY-L: Clean protocol boundary for extensibility."
+  (:require [clojure.walk :as walk]
+            [taoensso.timbre :as log]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Adapter Protocol
+;; =============================================================================
+
+(defprotocol IAdapter
+  "Protocol for data transformation adapters."
+
+  (adapter-id [this]
+    "Return unique keyword identifier for this adapter.")
+
+  (adapter-info [this]
+    "Return map with :name, :description, :version, :formats.")
+
+  (export-transform [this data opts]
+    "Transform internal data format to external format.
+     Returns transformed data structure.")
+
+  (import-transform [this data opts]
+    "Transform external format to internal data format.
+     Returns data ready for import.")
+
+  (validate-external [this data]
+    "Validate external data before import.
+     Returns {:valid? boolean, :errors [...]}"))
+
+;; =============================================================================
+;; Adapter Registry
+;; =============================================================================
+
+(defonce ^:private adapter-registry (atom {}))
+
+(defn register-adapter!
+  "Register an adapter implementation.
+
+   Arguments:
+     adapter - Implementation of IAdapter protocol
+
+   Returns the adapter."
+  [adapter]
+  (let [id (adapter-id adapter)]
+    (log/info "Registering migration adapter" {:id id})
+    (swap! adapter-registry assoc id adapter)
+    adapter))
+
+(defn get-adapter
+  "Get adapter by ID.
+
+   Arguments:
+     id - Adapter keyword (:logseq, :obsidian, :notion, etc.)
+
+   Returns adapter or nil."
+  [id]
+  (get @adapter-registry id))
+
+(defn list-adapters
+  "List all registered adapters.
+
+   Returns vector of {:id :name :description :formats}."
+  []
+  (->> @adapter-registry
+       vals
+       (mapv adapter-info)))
+
+;; =============================================================================
+;; Built-in Adapters
+;; =============================================================================
+
+;; Identity adapter (EDN passthrough)
+(defrecord IdentityAdapter []
+  IAdapter
+  (adapter-id [_] :edn)
+  (adapter-info [_]
+    {:id :edn
+     :name "EDN Passthrough"
+     :description "Native EDN format, no transformation"
+     :version "1.0.0"
+     :formats #{:edn}})
+  (export-transform [_ data _opts] data)
+  (import-transform [_ data _opts] data)
+  (validate-external [_ data]
+    {:valid? (map? data)
+     :errors (when-not (map? data) ["Expected map"])}))
+
+;; JSON adapter (for interop)
+(defrecord JsonAdapter []
+  IAdapter
+  (adapter-id [_] :json)
+  (adapter-info [_]
+    {:id :json
+     :name "JSON Format"
+     :description "JSON export/import with keyword conversion"
+     :version "1.0.0"
+     :formats #{:json}})
+
+  (export-transform [_ data _opts]
+    ;; Convert keywords to strings for JSON compat
+    (walk/postwalk
+     (fn [x]
+       (cond
+         (keyword? x) (str (namespace x) "/" (name x))
+         :else x))
+     data))
+
+  (import-transform [_ data _opts]
+    ;; Convert namespaced strings back to keywords
+    (walk/postwalk
+     (fn [x]
+       (if (and (string? x) (re-matches #"\w+/\w+" x))
+         (keyword x)
+         x))
+     data))
+
+  (validate-external [_ data]
+    {:valid? (or (map? data) (sequential? data))
+     :errors (when-not (or (map? data) (sequential? data))
+               ["Expected map or collection"])}))
+
+;; Register built-in adapters
+(register-adapter! (->IdentityAdapter))
+(register-adapter! (->JsonAdapter))
+
+;; =============================================================================
+;; Adapter Helpers
+;; =============================================================================
+
+(defn transform-export
+  "Apply adapter transformation for export.
+
+   Arguments:
+     adapter-id - Keyword (:edn, :json, :logseq, etc.)
+     data       - Data to transform
+     opts       - Adapter-specific options
+
+   Returns transformed data or throws if adapter not found."
+  [adapter-id data & [opts]]
+  (if-let [adapter (get-adapter adapter-id)]
+    (export-transform adapter data opts)
+    (throw (ex-info "Unknown adapter" {:adapter adapter-id
+                                       :available (keys @adapter-registry)}))))
+
+(defn transform-import
+  "Apply adapter transformation for import.
+
+   Arguments:
+     adapter-id - Keyword (:edn, :json, :logseq, etc.)
+     data       - External data to transform
+     opts       - Adapter-specific options
+
+   Returns internal format data or throws if adapter not found."
+  [adapter-id data & [opts]]
+  (if-let [adapter (get-adapter adapter-id)]
+    (import-transform adapter data opts)
+    (throw (ex-info "Unknown adapter" {:adapter adapter-id
+                                       :available (keys @adapter-registry)}))))

--- a/src/hive_mcp/swarm/datascript.clj
+++ b/src/hive_mcp/swarm/datascript.clj
@@ -102,6 +102,8 @@
 
 ;; Slave queries
 (def get-slave queries/get-slave)
+(def get-slave-by-name queries/get-slave-by-name)
+(def get-slave-by-name-or-id queries/get-slave-by-name-or-id)
 (def get-all-slaves queries/get-all-slaves)
 (def get-slaves-by-status queries/get-slaves-by-status)
 (def get-slaves-by-project queries/get-slaves-by-project)

--- a/src/hive_mcp/tools/memory/crud.clj
+++ b/src/hive_mcp/tools/memory/crud.clj
@@ -173,7 +173,7 @@
                 (mcp-json (cond-> (fmt/entry->json-alist created)
                             (seq edge-ids) (assoc :kg_edges_created edge-ids)))))))))
     (catch clojure.lang.ExceptionInfo e
-      (if (= :coercion-error (:type (ex-data e)))
+      (if (#{:coercion-error :embedding-too-long} (:type (ex-data e)))
         (mcp-error (.getMessage e))
         (throw e)))))
 

--- a/src/hive_mcp/tools/memory/search.clj
+++ b/src/hive_mcp/tools/memory/search.clj
@@ -8,7 +8,9 @@
    - search-semantic: Vector similarity search using Chroma embeddings"
   (:require [hive-mcp.chroma :as chroma]
             [hive-mcp.knowledge-graph.edges :as kg-edges]
+            [hive-mcp.tools.memory.scope :as scope]
             [hive-mcp.tools.core :refer [mcp-error coerce-int!]]
+            [hive-mcp.agent.context :as ctx]
             [clojure.data.json :as json]
             [clojure.string :as str]
             [taoensso.timbre :as log]))
@@ -36,45 +38,70 @@
 ;; Search Handler
 ;; ============================================================
 
+(defn- matches-scope-filter?
+  "Check if a search result matches the scope filter.
+   Search results have different structure than entries - tags are in metadata."
+  [result scope-filter]
+  (if (nil? scope-filter)
+    true
+    (let [tags-str (get-in result [:metadata :tags] "")
+          tags (when (and tags-str (not= tags-str ""))
+                 (set (str/split tags-str #",")))]
+      (or (contains? tags scope-filter)
+          (contains? tags "scope:global")))))
+
 (defn handle-search-semantic
   "Search project memory using semantic similarity (vector search).
-   Requires Chroma to be configured with an embedding provider."
-  [{:keys [query limit type]}]
-  (log/info "mcp-memory-search-semantic:" query)
-  (try
-    (let [limit-val (coerce-int! limit :limit 10)
-          status (chroma/status)]
-      (if-not (:configured? status)
-        {:type "text"
-         :text (json/write-str
-                {:error "Chroma semantic search not configured"
-                 :message "To enable semantic search, configure Chroma with an embedding provider. See hive-mcp.chroma namespace."
-                 :status status})
-         :isError true}
-        (try
-          (let [results (chroma/search-similar query
-                                               :limit limit-val
-                                               :type type)
-                formatted (mapv format-search-result results)]
-            ;; Record co-access pattern for semantic search results (async, non-blocking)
-            (when (>= (count formatted) 2)
-              (future
-                (try
-                  (kg-edges/record-co-access!
-                   (mapv :id formatted)
-                   {:created-by "system:semantic-search"})
-                  (catch Exception e
-                    (log/debug "Co-access recording failed (non-fatal):" (.getMessage e))))))
-            {:type "text"
-             :text (json/write-str {:results formatted
-                                    :count (count formatted)
-                                    :query query})})
-          (catch Exception e
-            {:type "text"
-             :text (json/write-str {:error (str "Semantic search failed: " (.getMessage e))
-                                    :status status})
-             :isError true}))))
-    (catch clojure.lang.ExceptionInfo e
-      (if (= :coercion-error (:type (ex-data e)))
-        (mcp-error (.getMessage e))
-        (throw e)))))
+   Requires Chroma to be configured with an embedding provider.
+   When directory is provided, filters results to that project scope."
+  [{:keys [query limit type directory]}]
+  (let [directory (or directory (ctx/current-directory))]
+    (log/info "mcp-memory-search-semantic:" query "directory:" directory)
+    (try
+      (let [limit-val (coerce-int! limit :limit 10)
+            status (chroma/status)]
+        (if-not (:configured? status)
+          {:type "text"
+           :text (json/write-str
+                  {:error "Chroma semantic search not configured"
+                   :message "To enable semantic search, configure Chroma with an embedding provider. See hive-mcp.chroma namespace."
+                   :status status})
+           :isError true}
+          (try
+            (let [project-id (scope/get-current-project-id directory)
+                  ;; Over-fetch to allow for scope filtering
+                  results (chroma/search-similar query
+                                                 :limit (* limit-val 3)
+                                                 :type type)
+                  ;; Apply scope filter
+                  scope-filter (when (and project-id (not= project-id "global"))
+                                 (scope/make-scope-tag project-id))
+                  filtered (if scope-filter
+                             (filter #(matches-scope-filter? % scope-filter) results)
+                             results)
+                  ;; Take requested limit after filtering
+                  limited (take limit-val filtered)
+                  formatted (mapv format-search-result limited)]
+              ;; Record co-access pattern for semantic search results (async, non-blocking)
+              (when (>= (count formatted) 2)
+                (future
+                  (try
+                    (kg-edges/record-co-access!
+                     (mapv :id formatted)
+                     {:scope project-id :created-by "system:semantic-search"})
+                    (catch Exception e
+                      (log/debug "Co-access recording failed (non-fatal):" (.getMessage e))))))
+              {:type "text"
+               :text (json/write-str {:results formatted
+                                      :count (count formatted)
+                                      :query query
+                                      :scope project-id})})
+            (catch Exception e
+              {:type "text"
+               :text (json/write-str {:error (str "Semantic search failed: " (.getMessage e))
+                                      :status status})
+               :isError true}))))
+      (catch clojure.lang.ExceptionInfo e
+        (if (= :coercion-error (:type (ex-data e)))
+          (mcp-error (.getMessage e))
+          (throw e))))))

--- a/src/hive_mcp/tools/migration.clj
+++ b/src/hive_mcp/tools/migration.clj
@@ -1,0 +1,445 @@
+(ns hive-mcp.tools.migration
+  "MCP tool for unified migration operations.
+
+   Commands:
+   - status     - Current backend info and data counts
+   - backup     - Create timestamped backup
+   - restore    - Restore from backup
+   - export     - Export with optional adapter transform
+   - import     - Import with optional adapter transform
+   - switch     - Switch backend with auto-migration
+   - sync       - Mirror to secondary backend
+   - list       - List available backups
+   - validate   - Validate backup integrity
+   - adapters   - List available adapters
+
+   CLARITY-T: All operations logged with full context."
+  (:require [hive-mcp.migration.core :as core]
+            [hive-mcp.migration.adapter :as adapter]
+            [hive-mcp.knowledge-graph.connection :as kg-conn]
+            [hive-mcp.knowledge-graph.migration :as kg-mig]
+            [hive-mcp.knowledge-graph.protocol :as kg-proto]
+            [clojure.java.io :as io]
+            [taoensso.timbre :as log]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Status Command
+;; =============================================================================
+
+(defn- get-kg-status
+  "Get current KG backend status and counts."
+  []
+  (let [backend (kg-mig/detect-current-backend)
+        counts (try
+                 {:edges (count (kg-conn/query '[:find ?e :where [?e :kg-edge/id]]))
+                  :disc (count (kg-conn/query '[:find ?e :where [?e :disc/path]]))
+                  :synthetic (count (kg-conn/query '[:find ?e :where [?e :kg-synthetic/id]]))}
+                 (catch Exception e
+                   {:error (.getMessage e)}))]
+    {:backend backend
+     :counts counts
+     :temporal? (kg-conn/temporal-store?)}))
+
+(defn cmd-status
+  "Get migration status for all scopes.
+
+   Returns:
+     {:kg       {:backend :datalevin, :counts {...}, :temporal? false}
+      :backups  {:count N, :latest {...}}}"
+  [_params]
+  (log/info "Migration status check")
+  (let [kg-status (get-kg-status)
+        backups (core/list-backups {:limit 5})
+        latest-kg (core/latest-backup :kg)]
+    {:kg kg-status
+     :backups {:count (count (core/list-backups {:limit 1000}))
+               :latest latest-kg
+               :recent (take 3 backups)}}))
+
+;; =============================================================================
+;; Backup Command
+;; =============================================================================
+
+(defn cmd-backup
+  "Create timestamped backup.
+
+   Parameters:
+     :scope   - :kg, :memory, :full (default: :kg)
+     :dir     - Backup directory (default: data/backups)
+     :adapter - Export adapter :edn, :json (default: :edn)
+
+   Returns:
+     {:success true, :path \"...\", :size N, :counts {...}}"
+  [{:keys [scope dir adapter]
+    :or {scope :kg
+         dir "data/backups"
+         adapter :edn}}]
+  (log/info "Creating backup" {:scope scope :dir dir :adapter adapter})
+  (core/ensure-backup-dir! dir)
+
+  (case scope
+    :kg
+    (let [;; Export KG data
+          export-data (kg-mig/export-to-edn)
+          counts (:counts export-data)
+          backend (kg-mig/detect-current-backend)
+          ;; Generate unique filename
+          filename (core/generate-backup-name :kg backend)
+          path (str dir "/" filename)
+          ;; Apply adapter transform if not :edn
+          transformed (if (= adapter :edn)
+                        export-data
+                        (adapter/transform-export adapter export-data))
+          ;; Create metadata
+          metadata (core/backup-metadata :kg backend counts)]
+      (core/write-backup! path metadata {:data transformed}))
+
+    ;; TODO: :memory and :full scopes
+    (throw (ex-info "Scope not yet implemented" {:scope scope}))))
+
+;; =============================================================================
+;; Restore Command
+;; =============================================================================
+
+(defn cmd-restore
+  "Restore from backup file.
+
+   Parameters:
+     :path    - Full path to backup file (required if no :latest)
+     :latest  - Restore latest backup for scope (e.g., :kg)
+     :dry-run - Preview without applying (default: false)
+     :adapter - Import adapter (default: :edn)
+
+   Returns:
+     {:success true, :imported {...}, :validation {...}}"
+  [{:keys [path latest dry-run adapter]
+    :or {dry-run false
+         adapter :edn}}]
+  (let [backup-path (or path
+                        (when latest
+                          (:path (core/latest-backup latest))))]
+    (when-not backup-path
+      (throw (ex-info "No backup path specified and no latest found"
+                      {:latest latest})))
+
+    (log/info "Restoring backup" {:path backup-path :dry-run dry-run})
+
+    ;; Validate first
+    (let [validation (core/validate-backup backup-path)]
+      (when-not (:valid? validation)
+        (throw (ex-info "Backup validation failed" validation)))
+
+      (if dry-run
+        {:dry-run true
+         :path backup-path
+         :metadata (:metadata validation)
+         :would-import (:metadata validation)}
+
+        ;; Actually restore
+        (let [backup-data (core/read-backup backup-path)
+              data (if (= adapter :edn)
+                     (:data backup-data)
+                     (adapter/transform-import adapter (:data backup-data)))
+              result (kg-mig/import-from-edn data)]
+          {:success (empty? (:errors result))
+           :path backup-path
+           :imported (:imported result)
+           :errors (:errors result)})))))
+
+;; =============================================================================
+;; List Command
+;; =============================================================================
+
+(defn cmd-list
+  "List available backups.
+
+   Parameters:
+     :scope   - Filter by scope (:kg, :memory, :full)
+     :backend - Filter by backend
+     :limit   - Max results (default: 20)
+     :dir     - Backup directory
+
+   Returns:
+     {:backups [...], :count N}"
+  [{:keys [scope backend limit dir]
+    :or {limit 20
+         dir "data/backups"}}]
+  (let [backups (core/list-backups {:scope scope
+                                    :backend backend
+                                    :limit limit
+                                    :dir dir})]
+    {:backups backups
+     :count (count backups)}))
+
+;; =============================================================================
+;; Switch Command
+;; =============================================================================
+
+(defn cmd-switch
+  "Switch KG backend with automatic migration.
+
+   Parameters:
+     :target   - Target backend :datascript, :datalevin, :datahike (required)
+     :db-path  - Path for persistent backends
+     :dry-run  - Preview without switching (default: false)
+     :backup   - Create backup before switch (default: true)
+
+   Returns:
+     {:success true, :from :datalevin, :to :datahike, :migrated {...}}"
+  [{:keys [target db-path dry-run backup]
+    :or {dry-run false
+         backup true}}]
+  (when-not target
+    (throw (ex-info "Target backend required" {:valid [:datascript :datalevin :datahike]})))
+
+  (let [current (kg-mig/detect-current-backend)]
+    (log/info "Switching backend" {:from current :to target :dry-run dry-run})
+
+    (when (= current target)
+      (throw (ex-info "Already using target backend" {:current current :target target})))
+
+    ;; Create backup first if requested
+    (when (and backup (not dry-run))
+      (log/info "Creating pre-switch backup")
+      (cmd-backup {:scope :kg}))
+
+    (if dry-run
+      {:dry-run true
+       :from current
+       :to target
+       :would-migrate (kg-mig/export-to-edn)}
+
+      ;; Perform migration
+      (let [target-opts (when db-path {:db-path db-path})
+            result (case target
+                     :datahike (kg-mig/migrate-to-datahike!
+                                (merge target-opts {:dry-run false}))
+                     :datalevin (kg-mig/migrate-to-datalevin!
+                                 (merge target-opts {:dry-run false}))
+                     :datascript (kg-mig/migrate-store! current :datascript
+                                                        {:dry-run false}))]
+        {:success (:valid? (:validation result) true)
+         :from current
+         :to target
+         :migrated (:imported result)
+         :validation (:validation result)}))))
+
+;; =============================================================================
+;; Sync Command
+;; =============================================================================
+
+(defn cmd-sync
+  "Sync KG data to secondary backend without switching.
+
+   Parameters:
+     :target      - Target backend (required)
+     :target-opts - Backend-specific options
+     :backup      - Create backup of target before sync (default: true)
+
+   Returns:
+     {:success true, :synced {...}, :validation {...}}"
+  [{:keys [target target-opts]
+    :or {target-opts {}}}]
+  (when-not target
+    (throw (ex-info "Target backend required" {:valid [:datascript :datalevin :datahike]})))
+
+  (log/info "Syncing to secondary backend" {:target target})
+  (let [result (kg-mig/sync-to-backend! target {:target-opts target-opts})]
+    {:success (:valid? (:validation result))
+     :from (:source-backend result)
+     :to target
+     :synced (:imported result)
+     :validation (:validation result)}))
+
+;; =============================================================================
+;; Validate Command
+;; =============================================================================
+
+(defn cmd-validate
+  "Validate backup file integrity.
+
+   Parameters:
+     :path - Path to backup file (required)
+
+   Returns:
+     {:valid? boolean, :errors [...], :metadata {...}}"
+  [{:keys [path]}]
+  (when-not path
+    (throw (ex-info "Backup path required" {})))
+  (core/validate-backup path))
+
+;; =============================================================================
+;; Adapters Command
+;; =============================================================================
+
+(defn cmd-adapters
+  "List available migration adapters.
+
+   Returns:
+     {:adapters [{:id :edn, :name \"...\", :description \"...\"}...]}"
+  [_params]
+  {:adapters (adapter/list-adapters)})
+
+;; =============================================================================
+;; Export Command
+;; =============================================================================
+
+(defn cmd-export
+  "Export data with optional adapter transformation.
+
+   Parameters:
+     :scope   - :kg, :memory (default: :kg)
+     :path    - Output file path (required)
+     :adapter - Transform adapter :edn, :json (default: :edn)
+     :format  - Output format :edn, :json (default: matches adapter)
+
+   Returns:
+     {:success true, :path \"...\", :counts {...}}"
+  [{:keys [scope path adapter]
+    :or {scope :kg
+         adapter :edn}}]
+  (when-not path
+    (throw (ex-info "Output path required" {})))
+
+  (log/info "Exporting data" {:scope scope :path path :adapter adapter})
+
+  (case scope
+    :kg
+    (let [data (kg-mig/export-to-edn)
+          transformed (adapter/transform-export adapter data)
+          parent-dir (.getParentFile (io/file path))]
+      (when (and parent-dir (not (.exists parent-dir)))
+        (.mkdirs parent-dir))
+      (spit path (pr-str transformed))
+      {:success true
+       :path path
+       :counts (:counts data)
+       :adapter adapter})
+
+    (throw (ex-info "Scope not yet implemented" {:scope scope}))))
+
+;; =============================================================================
+;; Import Command
+;; =============================================================================
+
+(defn cmd-import
+  "Import data with optional adapter transformation.
+
+   Parameters:
+     :path         - Input file path (required)
+     :adapter      - Transform adapter :edn, :json (default: :edn)
+     :dry-run      - Preview without importing (default: false)
+     :merge-strategy - :replace, :append, :merge (default: :append)
+
+   Returns:
+     {:success true, :imported {...}}"
+  [{:keys [path adapter dry-run]
+    :or {adapter :edn
+         dry-run false}}]
+  (when-not path
+    (throw (ex-info "Input path required" {})))
+
+  (log/info "Importing data" {:path path :adapter adapter :dry-run dry-run})
+
+  (let [raw-data (-> path slurp clojure.edn/read-string)
+        data (adapter/transform-import adapter raw-data)]
+
+    (if dry-run
+      {:dry-run true
+       :path path
+       :would-import {:edges (count (:edges data))
+                      :disc (count (:disc data))
+                      :synthetic (count (:synthetic data))}}
+
+      (let [result (kg-mig/import-from-edn data)]
+        {:success (empty? (:errors result))
+         :path path
+         :imported (:imported result)
+         :errors (:errors result)}))))
+
+;; =============================================================================
+;; Help Command
+;; =============================================================================
+
+(defn cmd-help
+  "Show migration tool help.
+
+   Returns command documentation."
+  [_params]
+  {:commands
+   [{:command "status"
+     :description "Current backend info and data counts"
+     :params []}
+    {:command "backup"
+     :description "Create timestamped backup"
+     :params [{:name "scope" :type "keyword" :default ":kg"}
+              {:name "dir" :type "string" :default "data/backups"}
+              {:name "adapter" :type "keyword" :default ":edn"}]}
+    {:command "restore"
+     :description "Restore from backup file"
+     :params [{:name "path" :type "string" :required false}
+              {:name "latest" :type "keyword" :required false}
+              {:name "dry-run" :type "boolean" :default false}]}
+    {:command "list"
+     :description "List available backups"
+     :params [{:name "scope" :type "keyword"}
+              {:name "limit" :type "integer" :default 20}]}
+    {:command "switch"
+     :description "Switch backend with auto-migration"
+     :params [{:name "target" :type "keyword" :required true}
+              {:name "db-path" :type "string"}
+              {:name "dry-run" :type "boolean" :default false}
+              {:name "backup" :type "boolean" :default true}]}
+    {:command "sync"
+     :description "Mirror to secondary backend without switching"
+     :params [{:name "target" :type "keyword" :required true}
+              {:name "target-opts" :type "map"}]}
+    {:command "export"
+     :description "Export with optional adapter transform"
+     :params [{:name "scope" :type "keyword" :default ":kg"}
+              {:name "path" :type "string" :required true}
+              {:name "adapter" :type "keyword" :default ":edn"}]}
+    {:command "import"
+     :description "Import with optional adapter transform"
+     :params [{:name "path" :type "string" :required true}
+              {:name "adapter" :type "keyword" :default ":edn"}
+              {:name "dry-run" :type "boolean" :default false}]}
+    {:command "validate"
+     :description "Validate backup file integrity"
+     :params [{:name "path" :type "string" :required true}]}
+    {:command "adapters"
+     :description "List available migration adapters"
+     :params []}]})
+
+;; =============================================================================
+;; Tool Dispatcher
+;; =============================================================================
+
+(defn handle-migration
+  "Main dispatcher for migration tool.
+
+   Parameters:
+     :command - One of: status, backup, restore, list, switch, sync,
+                        export, import, validate, adapters, help
+
+   Plus command-specific parameters."
+  [{:keys [command] :as params}]
+  (log/debug "Migration tool" {:command command :params (dissoc params :command)})
+  (let [cmd-params (dissoc params :command)]
+    (case (keyword command)
+      :status   (cmd-status cmd-params)
+      :backup   (cmd-backup cmd-params)
+      :restore  (cmd-restore cmd-params)
+      :list     (cmd-list cmd-params)
+      :switch   (cmd-switch cmd-params)
+      :sync     (cmd-sync cmd-params)
+      :export   (cmd-export cmd-params)
+      :import   (cmd-import cmd-params)
+      :validate (cmd-validate cmd-params)
+      :adapters (cmd-adapters cmd-params)
+      :help     (cmd-help cmd-params)
+      (cmd-help cmd-params))))


### PR DESCRIPTION
## Summary
- Merges `release/kg-schema-and-plans` branch which contains migration files that were committed after the original PR #89 was merged
- Fixes `FileNotFoundException` on startup where `hive-mcp.tools.consolidated.migration` requires `hive-mcp.tools.migration` which didn't exist

## Files Added
- `src/hive_mcp/tools/migration.clj` - Migration CLI handlers
- `src/hive_mcp/migration/adapter.clj` - Migration adapter protocol
- `src/hive_mcp/autopoiesis/*.clj` - Autopoiesis modules
- `src/hive_mcp/enhancer/*.clj` - Enhancer modules
- `src/hive_mcp/introspect/*.clj` - Introspect modules
- Updated `src/hive_mcp/knowledge_graph/migration.clj` with `detect-current-backend`

## Test plan
- [ ] `./start-mcp.sh` starts without FileNotFoundException
- [ ] bb-mcp can connect to hive-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)