### PR TITLE
fix: namespace facades for bb-mcp compatibility

### DIFF
--- a/src/hive_mcp/agent.clj
+++ b/src/hive_mcp/agent.clj
@@ -1,0 +1,9 @@
+(ns hive-mcp.agent
+  "Facade for backward compatibility.
+   Delegates to hive-mcp.agent.core after tree normalization."
+  (:require [hive-mcp.agent.core :as core]))
+
+(def delegate-drone! core/delegate-drone!)
+(def delegate-agentic-drone! core/delegate-agentic-drone!)
+(def tools core/tools)
+(def register-tools! core/register-tools!)

--- a/src/hive_mcp/channel.clj
+++ b/src/hive_mcp/channel.clj
@@ -1,0 +1,17 @@
+(ns hive-mcp.channel
+  "Facade for backward compatibility.
+   Delegates to hive-mcp.channel.core after tree normalization."
+  (:require [hive-mcp.channel.core :as core]))
+
+(def start-server! core/start-server!)
+(def stop-server! core/stop-server!)
+(def force-stop-server! core/force-stop-server!)
+(def broadcast! core/broadcast!)
+(def publish! core/publish!)
+(def emit-event! core/emit-event!)
+(def subscribe! core/subscribe!)
+(def unsubscribe! core/unsubscribe!)
+(def client-count core/client-count)
+(def server-connected? core/server-connected?)
+(def channel-tools core/channel-tools)
+(def mark-coordinator-running! core/mark-coordinator-running!)

--- a/src/hive_mcp/hooks.clj
+++ b/src/hive_mcp/hooks.clj
@@ -1,0 +1,9 @@
+(ns hive-mcp.hooks
+  "Facade for backward compatibility.
+   Delegates to hive-mcp.hooks.core after tree normalization."
+  (:require [hive-mcp.hooks.core :as core]))
+
+(def hook-events core/hook-events)
+(def create-registry core/create-registry)
+(def register-hook core/register-hook)
+(def trigger-hooks core/trigger-hooks)

--- a/src/hive_mcp/server.clj
+++ b/src/hive_mcp/server.clj
@@ -1,0 +1,12 @@
+(ns hive-mcp.server
+  "Facade for backward compatibility.
+   Delegates to hive-mcp.server.core after tree normalization.
+   Required by bb-mcp dynamic tool forwarding which resolves
+   server-context-atom via ns-resolve."
+  (:require [hive-mcp.server.core :as core]))
+
+;; Alias the atom itself (not its value) so ns-resolve returns
+;; a Var whose deref yields the same atom as core's private var.
+(def server-context-atom (deref #'core/server-context-atom))
+
+(def -main core/-main)

--- a/src/hive_mcp/telemetry.clj
+++ b/src/hive_mcp/telemetry.clj
@@ -1,0 +1,16 @@
+(ns hive-mcp.telemetry
+  "Facade for backward compatibility.
+   Delegates to hive-mcp.telemetry.core after tree normalization."
+  (:require [hive-mcp.telemetry.core :as core]))
+
+(defmacro with-timing [& args] `(core/with-timing ~@args))
+(defmacro with-eval-telemetry [& args] `(core/with-eval-telemetry ~@args))
+(def configure-logging! core/configure-logging!)
+(def log-eval-request core/log-eval-request)
+(def log-eval-result core/log-eval-result)
+(def log-eval-exception core/log-eval-exception)
+(def emit-health-event! core/emit-health-event!)
+(def health-summary core/health-summary)
+(def get-recent-errors core/get-recent-errors)
+(def health-error-types core/health-error-types)
+(def health-severities core/health-severities)

--- a/src/hive_mcp/transport.clj
+++ b/src/hive_mcp/transport.clj
@@ -1,0 +1,26 @@
+(ns hive-mcp.transport
+  "Facade for backward compatibility.
+   Delegates to hive-mcp.transport.core after tree normalization."
+  (:require [hive-mcp.transport.core :as core]))
+
+(def ITransport core/ITransport)
+(def IServer core/IServer)
+(def connect! core/connect!)
+(def disconnect! core/disconnect!)
+(def send! core/send!)
+(def recv! core/recv!)
+(def connected? core/connected?)
+(def encode-msg core/encode-msg)
+(def decode-msg core/decode-msg)
+(def decode-msg-from-stream core/decode-msg-from-stream)
+(def unix-transport core/unix-transport)
+(def tcp-transport core/tcp-transport)
+(def start-unix-server! core/start-unix-server!)
+(def start-tcp-server! core/start-tcp-server!)
+(def start-server! core/start-server!)
+(def stop-server! core/stop-server!)
+(def server-running? core/server-running?)
+(def broadcast! core/broadcast!)
+(def get-clients core/get-clients)
+(def client-count core/client-count)
+(def get-stream core/get-stream)


### PR DESCRIPTION
## Summary
- Add 6 thin facade namespaces (server, agent, channel, hooks, telemetry, transport) that re-export key vars from their respective `core.clj` modules
- Fixes bb-mcp dynamic tool forwarding which silently fails when `hive-mcp.server` namespace doesn't exist after tree normalization
- **Critical fix**: Without `server.clj` facade, ALL MCP tools return empty responses

## Known Issue
- `memory query` and `memory metadata` return `[]` — pre-existing crud decomposition bug (tracked in kanban)

## Test plan
- [x] Verified all MCP tools work after facade creation
- [x] Tested memory add/get/search/expiring (working)
- [x] Confirmed memory query/metadata bug is pre-existing, not from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)