### PR TITLE
feat: done-archive extension, KG hierarchy backend detection, crystal edge fix

### DIFF
--- a/src/hive_mcp/extensions/loader.clj
+++ b/src/hive_mcp/extensions/loader.clj
@@ -65,7 +65,7 @@
 ;;   :dd  = decompose           :cb  = context-budget
 ;;   :bx  = multi-batch         :fb  = forge-belt
 ;;   :ch  = crystal-hooks       :cl  = crystal-recall
-;;   :ck  = crystal-tools
+;;   :ck  = crystal-tools       :da  = done-archive
 
 (def ^:private ext-group-a
   {:ns 'hive-knowledge.similarity
@@ -306,6 +306,14 @@
   {:ns 'hive-knowledge.crystal-tools
    :fns [["build-crystal-edges" :ck/a]]})
 
+;; --- Group AC: Done Archive ---
+(def ^:private ext-group-ac
+  {:ns 'hive-knowledge.done-archive
+   :fns [["archive-done-task!"   :da/archive!]
+         ["query-done-tasks"     :da/query]
+         ["recent-completions"   :da/recent]
+         ["milestone-progress"   :da/milestone]]})
+
 ;; =============================================================================
 ;; All Extension Manifests
 ;; =============================================================================
@@ -316,10 +324,10 @@
    ext-group-f ext-group-g ext-group-h ext-group-i ext-group-j
    ext-group-k ext-group-l ext-group-m ext-group-n ext-group-o
    ext-group-p
-   ;; IP migration groups (Q-AB)
+   ;; IP migration groups (Q-AC)
    ext-group-q ext-group-r ext-group-s ext-group-t ext-group-u
    ext-group-v ext-group-w ext-group-x ext-group-y ext-group-z
-   ext-group-aa ext-group-ab])
+   ext-group-aa ext-group-ab ext-group-ac])
 
 ;; =============================================================================
 ;; Extension Self-Registration

--- a/src/hive_mcp/tools/consolidated/workflow.clj
+++ b/src/hive_mcp/tools/consolidated/workflow.clj
@@ -286,7 +286,9 @@
                                         (or (:spawn-mode opts) effective-spawn-mode)
                                         (assoc :spawn-mode (or (:spawn-mode opts) effective-spawn-mode))
                                         (or (:model opts) model)
-                                        (assoc :model (or (:model opts) model)))))}
+                                        (assoc :model (or (:model opts) model)))))
+                  :dispatch-fn    (fn [_agent-id _task] true)
+                  :wait-ready-fn  (fn [_agent-id] true)}
      :kanban-ops {:list-fn   (fn [dir]
                                (survey {:directory dir
                                         :vulcan-mode effective-vulcan?}))

--- a/src/hive_mcp/tools/crystal.clj
+++ b/src/hive_mcp/tools/crystal.clj
@@ -81,7 +81,7 @@
   [{:keys [progress-notes completed-tasks memory-ids-created]}]
   (->> (concat (keep :id progress-notes)
                (keep :id completed-tasks)
-               (or memory-ids-created []))
+               (keep :id memory-ids-created))
        (filter some?)
        (distinct)
        (vec)))


### PR DESCRIPTION
## Summary
- Add done-archive extension group (ext-group-ac) in loader.clj
- Walk .hive-project.edn hierarchy for KG backend detection (parent-first authority)
- Fix memory-ids-created extraction: `(keep :id)` instead of `(or x [])`
- Add dispatch-fn/wait-ready-fn stubs in forge-strike workflow
- Archive done tasks to Datahike before Chroma deletion (requiring-resolve fallback)

## Test plan
- [ ] Verify extension loader picks up ext-group-ac
- [ ] Verify KG backend hierarchy walk resolves correctly
- [ ] Verify crystal edge building with new memory-ids-created format

🤖 Generated with [Claude Code](https://claude.com/claude-code)