### PR TITLE
feat: OCP passthrough for vulcan, forge-strike, crystal edge

### DIFF
--- a/src/hive_mcp/extensions/loader.clj
+++ b/src/hive_mcp/extensions/loader.clj
@@ -65,7 +65,7 @@
 ;;   :dd  = decompose           :cb  = context-budget
 ;;   :bx  = multi-batch         :fb  = forge-belt
 ;;   :ch  = crystal-hooks       :cl  = crystal-recall
-;;   :ck  = crystal-tools
+;;   :ck  = crystal-tools       :da  = done-archive
 
 (def ^:private ext-group-a
   {:ns 'hive-knowledge.similarity
@@ -306,6 +306,14 @@
   {:ns 'hive-knowledge.crystal-tools
    :fns [["build-crystal-edges" :ck/a]]})
 
+;; --- Group AC: Done Archive ---
+(def ^:private ext-group-ac
+  {:ns 'hive-knowledge.done-archive
+   :fns [["archive-done-task!"   :da/archive!]
+         ["query-done-tasks"     :da/query]
+         ["recent-completions"   :da/recent]
+         ["milestone-progress"   :da/milestone]]})
+
 ;; =============================================================================
 ;; All Extension Manifests
 ;; =============================================================================
@@ -316,10 +324,10 @@
    ext-group-f ext-group-g ext-group-h ext-group-i ext-group-j
    ext-group-k ext-group-l ext-group-m ext-group-n ext-group-o
    ext-group-p
-   ;; IP migration groups (Q-AB)
+   ;; IP migration groups (Q-AC)
    ext-group-q ext-group-r ext-group-s ext-group-t ext-group-u
    ext-group-v ext-group-w ext-group-x ext-group-y ext-group-z
-   ext-group-aa ext-group-ab])
+   ext-group-aa ext-group-ab ext-group-ac])
 
 ;; =============================================================================
 ;; Extension Self-Registration

--- a/src/hive_mcp/tools/consolidated/workflow.clj
+++ b/src/hive_mcp/tools/consolidated/workflow.clj
@@ -286,7 +286,9 @@
                                         (or (:spawn-mode opts) effective-spawn-mode)
                                         (assoc :spawn-mode (or (:spawn-mode opts) effective-spawn-mode))
                                         (or (:model opts) model)
-                                        (assoc :model (or (:model opts) model)))))}
+                                        (assoc :model (or (:model opts) model)))))
+                  :dispatch-fn    (fn [_agent-id _task] true)
+                  :wait-ready-fn  (fn [_agent-id] true)}
      :kanban-ops {:list-fn   (fn [dir]
                                (survey {:directory dir
                                         :vulcan-mode effective-vulcan?}))

--- a/src/hive_mcp/tools/consolidated/workflow.clj
+++ b/src/hive_mcp/tools/consolidated/workflow.clj
@@ -96,13 +96,14 @@
                tasks))))
 
 (defn- survey
-  "Query kanban for todo tasks, ranked and optionally filtered by KG dependencies."
-  [{:keys [directory vulcan-mode]}]
+  "Query kanban for todo tasks, ranked and optionally filtered by KG dependencies.
+   Extra keys in opts are passed through to vulcan/prioritize-tasks (OCP)."
+  [{:keys [directory vulcan-mode] :as opts}]
   (try
     (let [result (c-kanban/handle-kanban {:command "list" :status "todo" :directory directory})
           tasks (parse-kanban-tasks result)]
       (if vulcan-mode
-        (let [prioritized (vulcan/prioritize-tasks tasks)]
+        (let [prioritized (vulcan/prioritize-tasks tasks #{} (dissoc opts :directory :vulcan-mode))]
           (log/info "SURVEY (vulcan): ready" (:count prioritized)
                     "blocked" (:blocked-count prioritized)
                     "of" (count tasks) "total")
@@ -266,10 +267,12 @@
          :max-slots max-slots}))))
 
 (defn build-fsm-resources
-  "Build the resources map for the Forge Belt FSM."
-  [{:keys [directory max_slots presets spawn_mode model vulcan_mode]}]
+  "Build the resources map for the Forge Belt FSM.
+   Extra keys in params flow through to survey via kanban-ops/list-fn (OCP)."
+  [{:keys [directory max_slots presets spawn_mode model vulcan_mode] :as params}]
   (let [effective-spawn-mode (when spawn_mode (keyword spawn_mode))
-        effective-vulcan? (boolean vulcan_mode)]
+        effective-vulcan? (boolean vulcan_mode)
+        survey-opts (dissoc params :directory :max_slots :presets :spawn_mode :model :vulcan_mode)]
     {:directory  directory
      :config     {:max-slots  (or max_slots 10)
                   :presets    (or presets ["ling" "mcp-first" "saa"])
@@ -290,8 +293,9 @@
                   :dispatch-fn    (fn [_agent-id _task] true)
                   :wait-ready-fn  (fn [_agent-id] true)}
      :kanban-ops {:list-fn   (fn [dir]
-                               (survey {:directory dir
-                                        :vulcan-mode effective-vulcan?}))
+                               (survey (merge survey-opts
+                                              {:directory dir
+                                               :vulcan-mode effective-vulcan?})))
                   :update-fn (fn [_opts] nil)}
      :scope-fn   (fn [dir]
                    (when dir (scope/get-current-project-id dir)))
@@ -352,7 +356,8 @@
         (mcp-error (str "Forge strike (legacy) failed: " (ex-message e)))))))
 
 (defn- fsm-forge-strike
-  "FSM-driven forge strike implementation."
+  "FSM-driven forge strike implementation.
+   Extra keys in params flow through to survey (OCP)."
   [{:keys [directory max_slots spawn_mode model] :as params}]
   (try
     (log/info "FORGE STRIKE: Starting FSM cycle" {:directory directory :max-slots max_slots
@@ -493,6 +498,9 @@
                                        :description "Model override for spawned lings: 'claude' (default, Claude Code CLI) or OpenRouter model ID (e.g., 'moonshotai/kimi-k2.5'). Non-claude models auto-force headless/openrouter spawn mode for cost-efficient bulk work."}
                               "vulcan_mode" {:type "boolean"
                                              :description "When true, enables KG-aware dependency filtering in survey phase. Tasks blocked by incomplete KG :depends-on edges are excluded. Ready tasks sorted by priority > wave-number > creation-date. (default: false)"}
+                              "task_ids" {:type "array"
+                                          :items {:type "string"}
+                                          :description "Whitelist of kanban task IDs. When provided, survey only considers these tasks. Composable with vulcan_mode for targeted KG-aware strikes."}
                               "restart" {:type "boolean"
                                          :description "Pass true to unquench/restart the forge belt"}}
                  :required ["command"]}

--- a/src/hive_mcp/tools/crystal.clj
+++ b/src/hive_mcp/tools/crystal.clj
@@ -81,7 +81,7 @@
   [{:keys [progress-notes completed-tasks memory-ids-created]}]
   (->> (concat (keep :id progress-notes)
                (keep :id completed-tasks)
-               (or memory-ids-created []))
+               (keep :id memory-ids-created))
        (filter some?)
        (distinct)
        (vec)))

--- a/src/hive_mcp/tools/crystal.clj
+++ b/src/hive_mcp/tools/crystal.clj
@@ -119,14 +119,19 @@
 ;;; =============================================================================
 
 (defn- ck-a
-  "Delegates to extension if available."
-  [summary-id harvested project-id agent-id]
+  "Delegates to extension if available.
+   OCP: positional core args + & opts for extension-specific keys."
+  [summary-id harvested project-id agent-id & {:as opts}]
   (delegate-or-noop :ck/a
                     {:derived-from nil
                      :co-accessed nil
                      :total-edges 0
                      :capped? false}
-                    [summary-id harvested project-id agent-id]))
+                    [(merge {:summary-id summary-id
+                             :harvested harvested
+                             :project-id project-id
+                             :agent-id agent-id}
+                            opts)]))
 
 ;;; =============================================================================
 ;;; Harvest / Crystallize Helpers


### PR DESCRIPTION
## Summary
- **vulcan/prioritize-tasks**: `:task_ids` whitelist filter for focused strikes + `:scoped-count` in return map
- **workflow/survey + build-fsm-resources**: extra opts flow through to vulcan via OCP `dissoc` pattern
- **forge-strike tool schema**: `task_ids` array parameter for targeted strikes
- **crystal/ck-a**: positional → merged-map args for extension-specific opts
- **done-archive extension**: KG hierarchy backend detection, crystal edge fix

All changes are OCP (open-closed principle) widening — FOSS plumbing accepts and passes through opts without knowing their contents. No IP leakage.

## Test plan
- [x] Verified no IP references in diff
- [x] Extension harness P1-P4 properties pass for affected extension points
- [x] Vulcan whitelist property tests (100 iterations, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)