### PR TITLE
fix(ci): create GitHub release even when tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Check if tag exists
-        id: check
+        id: check_tag
         run: |
           if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -40,13 +40,24 @@ jobs:
           fi
 
       - name: Create tag
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check_tag.outputs.exists == 'false'
         run: |
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
+      - name: Check if release exists
+        id: check_release
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Create GitHub release
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## Summary
- Decouple tag existence check from release existence check in the Release workflow
- Pre-existing tags (e.g. from `bb-depsolve bump`) no longer skip release creation
- Adds a separate `gh release view` check so releases are created whenever missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)