### PR TITLE
fix: catchup enrichment fire-and-forget

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -112,7 +112,7 @@
 
         ;; hive-dsl — Result monad, rescue/guard DSL, error taxonomy
         io.github.hive-agi/hive-dsl
-        {:git/tag "v0.3.2" :git/sha "5625daa78f038332cc51105573eae9fd05445e3f"}
+        {:git/tag "v0.3.5" :git/sha "224b3c257e6aaf48ffa78b1e3362aca04e3fbd1f"}
 
         ;; hive-emacs — Emacs vessel addon (IEditor, daemon, CIDER/Magit/Projectile)
         io.github.hive-agi/hive-emacs {:git/tag "v0.2.0" :git/sha "05a3a07"}}

--- a/deps.edn
+++ b/deps.edn
@@ -115,7 +115,7 @@
         {:git/tag "v0.3.2" :git/sha "5625daa78f038332cc51105573eae9fd05445e3f"}
 
         ;; hive-emacs — Emacs vessel addon (IEditor, daemon, CIDER/Magit/Projectile)
-        io.github.hive-agi/hive-emacs {:git/tag "v0.1.2" :git/sha "9bb6fb0"}}
+        io.github.hive-agi/hive-emacs {:git/tag "v0.2.0" :git/sha "05a3a07"}}
 
  :aliases
  {:mcp

--- a/src/hive_mcp/agent/drone.clj
+++ b/src/hive_mcp/agent/drone.clj
@@ -20,6 +20,7 @@
             [hive-mcp.telemetry.prometheus :as prom]
             [clojure.set]
             [hive-dsl.result :as r]
+            [hive-dsl.bounded-atom :refer [bkeys]]
             [taoensso.timbre :as log]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
@@ -191,7 +192,7 @@
             selected-model (or model (:model model-selection))
             step-budget (or max-steps (decompose/get-step-budget task effective-files))
             augmented-task (augment/augment-task task effective-files {:project-root cwd})
-            diffs-before (set (keys @diff/pending-diffs))
+            diffs-before (set (bkeys diff/pending-diffs))
             effective-root (or cwd (diff/get-project-root))
             drone-sandbox (sandbox/create-sandbox (or effective-files []) effective-root)
 
@@ -211,7 +212,7 @@
                                             :allowed-dirs (:allowed-dirs drone-sandbox)
                                             :blocked-patterns (map str (:blocked-patterns drone-sandbox))
                                             :blocked-tools (:blocked-tools drone-sandbox)}})
-            diffs-after (set (keys @diff/pending-diffs))
+            diffs-after (set (bkeys diff/pending-diffs))
             new-diff-ids (clojure.set/difference diffs-after diffs-before)
             duration-ms (- (System/currentTimeMillis) start-time)
 

--- a/src/hive_mcp/agent/drone/backend/sdk_drone.clj
+++ b/src/hive_mcp/agent/drone/backend/sdk_drone.clj
@@ -32,7 +32,9 @@
                     {:backend :sdk-drone}))))
 
 (defn- drain-output-channel
-  "Drain all messages from a core.async channel into a vector with timeout."
+  "Drain all messages from a core.async channel into a vector with timeout.
+   On timeout, closes the channel to unblock the drain thread — prevents
+   leaking the future thread and ManyToManyChannel."
   [ch timeout-ms]
   (let [collected (atom [])
         drain-future (future
@@ -44,7 +46,10 @@
                                  (recur))))))
         result (deref drain-future timeout-ms ::timeout)]
     (if (= ::timeout result)
-      {:messages @collected :timed-out? true}
+      (do
+        (async/close! ch)           ;; Unblock drain-future's <!! → returns nil
+        (future-cancel drain-future) ;; Try to interrupt if still blocked
+        {:messages @collected :timed-out? true})
       result)))
 
 (defn- extract-result-text

--- a/src/hive_mcp/agent/drone/diff_mgmt.clj
+++ b/src/hive_mcp/agent/drone/diff_mgmt.clj
@@ -3,7 +3,8 @@
   (:require [hive-mcp.tools.diff :as diff]
             [clojure.data.json :as json]
             [clojure.set]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bget bput! bounded-swap! bkeys]]))
 
 (defrecord DiffResults
            [applied failed proposed])
@@ -24,7 +25,7 @@
   (if (empty? new-diff-ids)
     (empty-diff-results)
     (let [results (for [diff-id new-diff-ids]
-                    (let [diff-info (get @diff/pending-diffs diff-id)
+                    (let [diff-info (bget diff/pending-diffs diff-id)
                           response (diff/handle-apply-diff {:diff_id diff-id})
                           parsed (try (json/read-str (:text response) :key-fn keyword)
                                       (catch Exception _ nil))]
@@ -46,7 +47,8 @@
   [new-diff-ids wave-id]
   (when (and (seq new-diff-ids) wave-id)
     (doseq [diff-id new-diff-ids]
-      (swap! diff/pending-diffs update diff-id assoc :wave-id wave-id))
+      (when-let [current (bget diff/pending-diffs diff-id)]
+        (bput! diff/pending-diffs diff-id (assoc current :wave-id wave-id))))
     (log/debug "Tagged diffs with wave-id" {:wave-id wave-id :count (count new-diff-ids)})))
 
 (defn get-new-diff-ids
@@ -57,7 +59,7 @@
 (defn capture-diffs-before
   "Capture the current set of pending diff IDs."
   []
-  (set (keys @diff/pending-diffs)))
+  (set (bkeys diff/pending-diffs)))
 
 (defn handle-diff-results!
   "Handle diff application based on execution mode."

--- a/src/hive_mcp/agent/ling/openrouter_headless_backend.clj
+++ b/src/hive_mcp/agent/ling/openrouter_headless_backend.clj
@@ -1,9 +1,8 @@
 (ns hive-mcp.agent.ling.openrouter-headless-backend
   "OpenRouter headless backend implementing IHeadlessBackend.
 
-   Stays in hive-mcp (not provider-specific — serves as multi-model
-   headless ling backend via OpenRouter API). Registers as :openrouter
-   in the headless-registry during server init.
+   Streaming-only backend for multi-model headless lings via the
+   OpenRouter API.
 
    Refactored from openrouter-strategy.clj to implement the addon
    protocol pattern instead of directly implementing ILingStrategy."

--- a/src/hive_mcp/channel/async_result.clj
+++ b/src/hive_mcp/channel/async_result.clj
@@ -1,6 +1,7 @@
 (ns hive-mcp.channel.async-result
   "Async tool result buffer for piggyback delivery with cursor+budget drain."
-  (:require [taoensso.timbre :as log])
+  (:require [taoensso.timbre :as log]
+            [hive-dsl.context.identity :as ctx-id])
   (:import [java.time Instant]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
@@ -73,7 +74,9 @@
 (defn enqueue-result!
   "Enqueue a completed async result into the buffer with content-hash dedup."
   [agent-id project-id result-map]
-  (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
+  (let [buffer-key (ctx-id/make-buffer-key
+                    (ctx-id/parse-caller-id agent-id)
+                    (ctx-id/parse-project-scope project-id))
         entry (assoc result-map
                      :timestamp (now-epoch-seconds)
                      :content-hash (content-hash result-map))]
@@ -94,7 +97,9 @@
 (defn drain!
   "Drain next batch of async results within char budget for an agent+project."
   [agent-id project-id]
-  (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
+  (let [buffer-key (ctx-id/make-buffer-key
+                    (ctx-id/parse-caller-id agent-id)
+                    (ctx-id/parse-project-scope project-id))
         buf (get @buffers buffer-key)]
     (when (and buf (< (:cursor buf) (count (:entries buf))))
       (let [{:keys [entries cursor]} buf
@@ -138,7 +143,9 @@
 (defn has-pending?
   "Check if an agent+project has undrained async results."
   [agent-id project-id]
-  (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
+  (let [buffer-key (ctx-id/make-buffer-key
+                    (ctx-id/parse-caller-id agent-id)
+                    (ctx-id/parse-project-scope project-id))
         buf (get @buffers buffer-key)]
     (and (some? buf)
          (< (:cursor buf) (count (:entries buf))))))
@@ -155,7 +162,9 @@
 (defn clear-buffer!
   "Clear buffer for a specific agent+project. For testing."
   [agent-id project-id]
-  (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]]
+  (let [buffer-key (ctx-id/make-buffer-key
+                    (ctx-id/parse-caller-id agent-id)
+                    (ctx-id/parse-project-scope project-id))]
     (swap! buffers dissoc buffer-key)))
 
 (defn reset-all!

--- a/src/hive_mcp/channel/memory_piggyback.clj
+++ b/src/hive_mcp/channel/memory_piggyback.clj
@@ -30,23 +30,26 @@
     (seq (:tags entry)) (assoc :tags (vec (:tags entry)))))
 
 (defn enqueue!
-  "Enqueue entries into the memory piggyback buffer. Idempotent."
+  "Enqueue entries into the memory piggyback buffer.
+   Replaces any existing buffer for the same key (fresh catchup supersedes stale)."
   ([agent-id project-id entries]
    (enqueue! agent-id project-id entries nil))
   ([agent-id project-id entries context-refs]
-   (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]]
-     (if (bget buffers buffer-key)
-       (log/debug "memory-piggyback: buffer already exists for" buffer-key "- skipping enqueue")
-       (let [formatted (mapv format-entry entries)]
-         (bput! buffers buffer-key
-                (cond-> {:entries formatted
-                         :cursor 0
-                         :done false
-                         :seq-num 0}
-                  (some? context-refs)
-                  (assoc :context-refs context-refs)))
-         (log/info "memory-piggyback: enqueued" (count formatted) "entries for" buffer-key
-                   (when context-refs (str " with " (count context-refs) " context-refs"))))))))
+   (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
+         existing (bget buffers buffer-key)
+         formatted (mapv format-entry entries)]
+     (when existing
+       (log/info "memory-piggyback: replacing existing buffer for" buffer-key
+                 "(had" (- (count (:entries existing)) (:cursor existing 0)) "undrained entries)"))
+     (bput! buffers buffer-key
+            (cond-> {:entries formatted
+                     :cursor 0
+                     :done false
+                     :seq-num 0}
+              (some? context-refs)
+              (assoc :context-refs context-refs)))
+     (log/info "memory-piggyback: enqueued" (count formatted) "entries for" buffer-key
+               (when context-refs (str " with " (count context-refs) " context-refs"))))))
 
 (defn drain!
   "Drain next batch of entries within char budget for an agent+project."

--- a/src/hive_mcp/channel/memory_piggyback.clj
+++ b/src/hive_mcp/channel/memory_piggyback.clj
@@ -2,7 +2,8 @@
   "Memory piggyback channel for incremental delivery of axioms and conventions via cursor+budget drain."
   (:require [taoensso.timbre :as log]
             [hive-dsl.bounded-atom :refer [bounded-atom bput! bget bounded-swap!
-                                           bclear! register-sweepable!]]))
+                                           bclear! register-sweepable!]]
+            [hive-dsl.context.identity :as ctx-id]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -35,7 +36,9 @@
   ([agent-id project-id entries]
    (enqueue! agent-id project-id entries nil))
   ([agent-id project-id entries context-refs]
-   (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
+   (let [buffer-key (ctx-id/make-buffer-key
+                     (ctx-id/parse-caller-id agent-id)
+                     (ctx-id/parse-project-scope project-id))
          existing (bget buffers buffer-key)
          formatted (mapv format-entry entries)]
      (when existing
@@ -54,7 +57,9 @@
 (defn drain!
   "Drain next batch of entries within char budget for an agent+project."
   [agent-id project-id]
-  (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
+  (let [buffer-key (ctx-id/make-buffer-key
+                    (ctx-id/parse-caller-id agent-id)
+                    (ctx-id/parse-project-scope project-id))
         buf (bget buffers buffer-key)]
     (when (and buf (not (:done buf)))
       (let [{:keys [entries cursor seq-num]} buf
@@ -97,14 +102,18 @@
 (defn has-pending?
   "Check if an agent+project has undrained memory entries."
   [agent-id project-id]
-  (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
+  (let [buffer-key (ctx-id/make-buffer-key
+                    (ctx-id/parse-caller-id agent-id)
+                    (ctx-id/parse-project-scope project-id))
         buf (bget buffers buffer-key)]
     (and (some? buf) (not (:done buf)))))
 
 (defn clear-buffer!
   "Clear buffer for a specific agent+project. For testing."
   [agent-id project-id]
-  (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]]
+  (let [buffer-key (ctx-id/make-buffer-key
+                    (ctx-id/parse-caller-id agent-id)
+                    (ctx-id/parse-project-scope project-id))]
     (bounded-swap! buffers dissoc buffer-key)))
 
 (defn reset-all!
@@ -120,12 +129,15 @@
 
    Returns true if a buffer was adopted, false otherwise."
   [new-agent-id project-id]
-  (let [new-key [(or new-agent-id "coordinator") (or project-id "global")]
+  (let [new-key (ctx-id/make-buffer-key
+                 (ctx-id/parse-caller-id new-agent-id)
+                 (ctx-id/parse-project-scope project-id))
+        proj-str (or project-id "global")
         ;; Find orphaned coordinator buffer for same project
         donor (->> @(:atom buffers)
                    (filter (fn [[[aid proj] entry]]
                              (let [buf (:data entry)]
-                               (and (= proj (or project-id "global"))
+                               (and (= proj proj-str)
                                     (not= aid new-agent-id)
                                     (clojure.string/starts-with? (str aid) "coordinator:")
                                     (not (:done buf))))))

--- a/src/hive_mcp/channel/memory_piggyback.clj
+++ b/src/hive_mcp/channel/memory_piggyback.clj
@@ -1,6 +1,8 @@
 (ns hive-mcp.channel.memory-piggyback
   "Memory piggyback channel for incremental delivery of axioms and conventions via cursor+budget drain."
-  (:require [taoensso.timbre :as log]))
+  (:require [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bounded-atom bput! bget bounded-swap!
+                                           bclear! register-sweepable!]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -9,9 +11,14 @@
   "Max chars per drain batch."
   32000)
 
+;; gc-fix-3: buffers — LRU eviction, 200 entries, 30min TTL
+;; Piggyback buffers are ephemeral per-agent state. Orphaned buffers waste memory.
 (defonce ^{:doc "Map of [agent-id project-id] -> buffer state."}
   buffers
-  (atom {}))
+  (bounded-atom {:max-entries 200
+                 :ttl-ms 1800000    ;; 30 minutes
+                 :eviction-policy :lru}))
+(register-sweepable! buffers :piggyback-buffers)
 
 (defn- format-entry
   "Convert a catchup entry to compact piggyback format."
@@ -28,10 +35,10 @@
    (enqueue! agent-id project-id entries nil))
   ([agent-id project-id entries context-refs]
    (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]]
-     (if (get @buffers buffer-key)
+     (if (bget buffers buffer-key)
        (log/debug "memory-piggyback: buffer already exists for" buffer-key "- skipping enqueue")
        (let [formatted (mapv format-entry entries)]
-         (swap! buffers assoc buffer-key
+         (bput! buffers buffer-key
                 (cond-> {:entries formatted
                          :cursor 0
                          :done false
@@ -45,7 +52,7 @@
   "Drain next batch of entries within char budget for an agent+project."
   [agent-id project-id]
   (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
-        buf (get @buffers buffer-key)]
+        buf (bget buffers buffer-key)]
     (when (and buf (not (:done buf)))
       (let [{:keys [entries cursor seq-num]} buf
             total (count entries)
@@ -69,8 +76,8 @@
             delivered new-cursor
             remaining (- total new-cursor)]
         (if is-done
-          (swap! buffers dissoc buffer-key)
-          (swap! buffers assoc buffer-key
+          (bounded-swap! buffers dissoc buffer-key)
+          (bput! buffers buffer-key
                  {:entries entries
                   :cursor new-cursor
                   :done false
@@ -88,19 +95,19 @@
   "Check if an agent+project has undrained memory entries."
   [agent-id project-id]
   (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]
-        buf (get @buffers buffer-key)]
+        buf (bget buffers buffer-key)]
     (and (some? buf) (not (:done buf)))))
 
 (defn clear-buffer!
   "Clear buffer for a specific agent+project. For testing."
   [agent-id project-id]
   (let [buffer-key [(or agent-id "coordinator") (or project-id "global")]]
-    (swap! buffers dissoc buffer-key)))
+    (bounded-swap! buffers dissoc buffer-key)))
 
 (defn reset-all!
   "Reset all buffers. For testing."
   []
-  (clojure.core/reset! buffers {}))
+  (bclear! buffers))
 
 (defn adopt-buffer!
   "Adopt an orphaned buffer from a previous coordinator instance.
@@ -112,21 +119,21 @@
   [new-agent-id project-id]
   (let [new-key [(or new-agent-id "coordinator") (or project-id "global")]
         ;; Find orphaned coordinator buffer for same project
-        donor (->> @buffers
-                   (filter (fn [[[aid proj] buf]]
-                             (and (= proj (or project-id "global"))
-                                  (not= aid new-agent-id)
-                                  (clojure.string/starts-with? (str aid) "coordinator:")
-                                  (not (:done buf)))))
+        donor (->> @(:atom buffers)
+                   (filter (fn [[[aid proj] entry]]
+                             (let [buf (:data entry)]
+                               (and (= proj (or project-id "global"))
+                                    (not= aid new-agent-id)
+                                    (clojure.string/starts-with? (str aid) "coordinator:")
+                                    (not (:done buf))))))
                    first)]
-    (when-let [[donor-key donor-buf] donor]
-      (swap! buffers (fn [bufs]
-                       (-> bufs
-                           (dissoc donor-key)
-                           (assoc new-key donor-buf))))
-      (log/info "memory-piggyback: adopted buffer from" donor-key "→" new-key
-                "(" (- (count (:entries donor-buf)) (:cursor donor-buf)) "entries remaining)")
-      true)))
+    (when-let [[donor-key donor-entry] donor]
+      (let [donor-buf (:data donor-entry)]
+        (bounded-swap! buffers dissoc donor-key)
+        (bput! buffers new-key donor-buf)
+        (log/info "memory-piggyback: adopted buffer from" donor-key "->" new-key
+                  "(" (- (count (:entries donor-buf)) (:cursor donor-buf)) "entries remaining)")
+        true))))
 
 (defn evict-orphaned-buffers!
   "Evict coordinator buffers that have no matching active caller.
@@ -137,13 +144,13 @@
 
    Returns count of evicted buffers."
   [active-caller-id]
-  (let [orphaned (->> @buffers
-                      (filter (fn [[[aid _proj] _buf]]
+  (let [orphaned (->> @(:atom buffers)
+                      (filter (fn [[[aid _proj] _entry]]
                                 (and (clojure.string/starts-with? (str aid) "coordinator:")
                                      (not (clojure.string/starts-with? (str aid) (str active-caller-id "-"))))))
                       (map first)
                       vec)]
     (when (seq orphaned)
-      (swap! buffers #(apply dissoc % orphaned))
+      (bounded-swap! buffers #(apply dissoc % orphaned))
       (log/info "memory-piggyback: evicted" (count orphaned) "orphaned buffers:" orphaned))
     (count orphaned)))

--- a/src/hive_mcp/concurrency/pool.clj
+++ b/src/hive_mcp/concurrency/pool.clj
@@ -170,6 +170,15 @@
   [& body]
   `(submit-event! (fn [] ~@body)))
 
+(defmacro with-solo
+  "Submit body to Clojure's solo executor (unbounded cached thread pool).
+   Returns a Future (clojure.core/future).
+   Use for coordinator tasks that internally spawn IO/compute pool work —
+   avoids nested-pool contention where a bounded-pool thread blocks
+   while spawning more work on the same pool."
+  [& body]
+  `(future ~@body))
+
 ;; =============================================================================
 ;; Monitoring
 ;; =============================================================================

--- a/src/hive_mcp/crystal/hooks.clj
+++ b/src/hive_mcp/crystal/hooks.clj
@@ -431,9 +431,10 @@
 ;; =============================================================================
 
 (defn- surface-rescue-error
-  "If rescue attached ::result/error metadata, surface :error into map for backward compat."
+  "If rescue/guard attached error metadata, surface :error into map for backward compat.
+   rescue and guard (hive-dsl.result) attach {:hive-dsl.result/error {:message ...}}."
   [m]
-  (if-let [err (::result/error (meta m))]
+  (if-let [err (:hive-dsl.result/error (meta m))]
     (assoc m :error (:message err))
     m))
 
@@ -443,19 +444,14 @@
 (def ^:private noop-d {:decayed 0 :expired 0 :total-scanned 0})
 (def ^:private noop-e {:files-captured 0})
 
-;; =============================================================================
-;; Lifecycle Operations — delegates to extensions
-;; =============================================================================
-
-(def ^:private ^:const op-timeout 5000)
+(def ^:private ^:const op-timeout 15000)
 
 (defn- timed-deref [fut default]
-  (try
-    (let [r (deref fut op-timeout ::timeout)]
-      (if (= r ::timeout)
-        (do (future-cancel fut) (assoc default :error "timed-out"))
-        r))
-    (catch Exception e (assoc default :error (.getMessage e)))))
+  (let [r (result/guard Exception default
+                        (deref fut op-timeout ::timeout))]
+    (if (= r ::timeout)
+      (do (future-cancel fut) (assoc default :error "timed-out"))
+      (surface-rescue-error r))))
 
 (defn- run-lifecycle-ops!
   "Run post-crystallization lifecycle operations in parallel with timeout guard.
@@ -538,8 +534,9 @@
             base-tags (into (or (:tags summary) []) ["auto-kg" "session-wrap" "temporal"])
             tags (scope/inject-project-scope base-tags project-id)
             expires (dur/calculate-expires "short")
-            ;; Start lifecycle ops NOW — they run concurrently with embedding
-            lifecycle-fut (pool/with-io (run-lifecycle-ops! project-id directory :harvested harvested))
+            ;; Start lifecycle ops on solo executor (avoids IO pool nesting —
+            ;; run-lifecycle-ops! internally submits 5 ops to IO pool via pool/with-io)
+            lifecycle-fut (pool/with-solo (run-lifecycle-ops! project-id directory :harvested harvested))
             t0 (System/currentTimeMillis)
             store-r (result/try-effect* :crystal/store-failed
                                         (chroma/index-memory-entry!

--- a/src/hive_mcp/emacs/client.clj
+++ b/src/hive_mcp/emacs/client.clj
@@ -1,9 +1,9 @@
 (ns hive-mcp.emacs.client
   "Delegation shim — routes to hive-emacs.client.
 
-   Full emacsclient implementation (50 forms, circuit breaker, daemon death
-   detection) extracted to hive-emacs project. This shim preserves backward
-   compatibility for 28 direct callers in hive-mcp core.
+   Full emacsclient implementation (50 forms, 3-state circuit breaker,
+   daemon death detection) extracted to hive-emacs project. This shim
+   preserves backward compatibility for 28 direct callers in hive-mcp core.
 
    Dynamic vars kept for backward compat; real vars live in hive-emacs.client."
   (:require [taoensso.timbre :as log]))
@@ -51,7 +51,8 @@
   "Execute elisp code with a timeout.
    Delegates to hive-emacs.client/eval-elisp-with-timeout.
    Returns a map with :success, :result or :error keys.
-   On timeout, returns {:success false :error \"...\" :timed-out true}"
+   On timeout, returns {:success false :error \"...\" :timed-out true}
+   On circuit-open, returns {:success false :error \"...\" :circuit-open true}"
   ([code] (eval-elisp-with-timeout code *default-timeout-ms*))
   ([code timeout-ms]
    (if-let [f (resolve-emacs-fn 'hive-emacs.client/eval-elisp-with-timeout)]
@@ -67,14 +68,16 @@
 
 (defn eval-elisp!
   "Execute elisp and return result string, or throw on non-timeout error.
-   On timeout, returns {:error :timeout :msg \"...\"}."
+   On timeout, returns {:error :timeout :msg \"...\"}.
+   On circuit-open, returns {:error :circuit-open :msg \"...\"}."
   [code]
-  (let [{:keys [success result error timed-out]} (eval-elisp code)]
+  (let [{:keys [success result error timed-out circuit-open]} (eval-elisp code)]
     (cond
-      success   result
-      timed-out {:error :timeout :msg error}
-      :else     (throw (ex-info "Elisp evaluation failed"
-                                {:error error :code code})))))
+      success      result
+      timed-out    {:error :timeout :msg error}
+      circuit-open {:error :circuit-open :msg error}
+      :else        (throw (ex-info "Elisp evaluation failed"
+                                   {:error error :code code})))))
 
 (defn emacs-running?
   "Check if Emacs server is running. Returns false on timeout."

--- a/src/hive_mcp/events/core.clj
+++ b/src/hive_mcp/events/core.clj
@@ -8,6 +8,8 @@
    - Metrics interceptor for observability
    - validate-event interceptor for data validation
    - init! for hive-mcp-specific coeffect registration
+   - Deregistration API (unreg-event, unreg-fx, unreg-cofx)
+   - Inspection API (registered-events, registered-effects, registered-coeffects)
 
    Core event machinery (interceptor chain, fx, cofx) lives in
    hive-events (io.github.hive-agi/hive-events). This namespace is
@@ -24,9 +26,11 @@
 
    Kept in hive-mcp (extensions):
    - Event registry & dispatch (Prometheus + malli wrapping)
-   - Metrics interceptor (rolling window telemetry)
+   - Metrics interceptor (bounded rolling window telemetry)
    - Debug interceptor (timbre instead of println)
    - Validation interceptor (malli schema)
+   - Deregistration (unreg-event, unreg-fx, unreg-cofx)
+   - Inspection (registered-events, registered-effects, registered-coeffects, handler-registry-status)
    - init! / reset-all! / with-clean-registry"
 
   (:require [hive.events.interceptor :as interceptor]
@@ -56,6 +60,49 @@
 (defonce ^:private *event-handlers (atom {}))
 
 ;; =============================================================================
+;; Metrics Configuration (E2)
+;; =============================================================================
+
+(def ^:private default-metrics-config
+  "Default configuration for metrics buffer sizes."
+  {:max-timings 1000
+   :max-timings-per-type 200})
+
+(defonce ^:private *metrics-config (atom default-metrics-config))
+
+(defn configure-metrics!
+  "Configure metrics buffer limits.
+
+   Options:
+   - :max-timings          - Max samples in the global :timings buffer (default: 1000)
+   - :max-timings-per-type - Max samples per event type in :timings-by-type (default: 200)
+
+   Example:
+   ```clojure
+   (configure-metrics! {:max-timings 500 :max-timings-per-type 100})
+   ```"
+  [{:keys [max-timings max-timings-per-type]}]
+  (swap! *metrics-config merge
+         (cond-> {}
+           max-timings          (assoc :max-timings max-timings)
+           max-timings-per-type (assoc :max-timings-per-type max-timings-per-type))))
+
+;; =============================================================================
+;; Bounded Buffer Helpers (E2)
+;; =============================================================================
+
+(defn- bounded-conj
+  "Append `val` to vector `v`, dropping the oldest entry when `(count v) >= cap`.
+   Returns [updated-vec dropped?].
+
+   Uses subvec for O(~1) FIFO eviction on Clojure persistent vectors."
+  [v val cap]
+  (let [v (or v [])]
+    (if (>= (count v) cap)
+      [(conj (subvec v 1) val) true]
+      [(conj v val) false])))
+
+;; =============================================================================
 ;; Metrics State - hive-mcp specific
 ;; =============================================================================
 
@@ -67,14 +114,16 @@
     :events-by-type    {kw N} ; Count per event-id keyword
     :effects-executed  N      ; Total effects successfully executed
     :errors           N       ; Total effect execution errors
-    :timings-by-type  {kw []} ; Rolling window of dispatch times per event type (ms)
-    :timings          [...]}  ; Rolling window of all dispatch times (ms)"
+    :timings-by-type  {kw []} ; Bounded rolling window of dispatch times per event type (ms)
+    :timings          [...]   ; Bounded rolling window of all dispatch times (ms)
+    :timings-dropped  N}      ; Total timings dropped due to buffer overflow (never resets)"
   (atom {:events-dispatched 0
          :events-by-type {}
          :effects-executed 0
          :errors 0
          :timings-by-type {}
-         :timings []}))
+         :timings []
+         :timings-dropped 0}))
 
 (defn get-metrics
   "Get current metrics snapshot.
@@ -87,10 +136,14 @@
    - :avg-dispatch-ms    - Average dispatch time across all events (ms)
    - :avg-by-type        - Map of event-id -> average dispatch time (ms)
    - :timings-count      - Number of timing samples
-   - :timings-by-type    - Map of event-id -> [timing samples]"
+   - :timings-by-type    - Map of event-id -> [timing samples]
+   - :timings-buffer-size     - Current size of global timings buffer
+   - :timings-buffer-capacity - Configured max for global timings buffer
+   - :timings-dropped         - Total timings dropped due to buffer overflow"
 
   []
   (let [m @*metrics
+        cfg @*metrics-config
         timings (:timings m)
         timings-by-type (:timings-by-type m)
         avg-ms (if (seq timings)
@@ -106,17 +159,21 @@
     (assoc m
            :avg-dispatch-ms avg-ms
            :avg-by-type avg-by-type
-           :timings-count (count timings))))
+           :timings-count (count timings)
+           :timings-buffer-size (count timings)
+           :timings-buffer-capacity (:max-timings cfg)
+           :timings-dropped (:timings-dropped m 0))))
 
 (defn reset-metrics!
-  "Reset all metrics counters. For testing."
+  "Reset all metrics counters including dropped counter. For testing."
   []
   (reset! *metrics {:events-dispatched 0
                     :events-by-type {}
                     :effects-executed 0
                     :errors 0
                     :timings-by-type {}
-                    :timings []}))
+                    :timings []
+                    :timings-dropped 0}))
 
 ;; =============================================================================
 ;; Re-exports from hive.events — Interceptor Primitives
@@ -410,7 +467,10 @@
    - Dispatch timing in ms (recorded in :after)
    - Per-event-type timings (tracked in :timings-by-type)
 
-   Uses a rolling window of 100 timing samples per event type to compute averages."
+   Timings are bounded by configurable limits (see configure-metrics!):
+   - Global :timings capped at :max-timings (default 1000)
+   - Per-type :timings-by-type capped at :max-timings-per-type (default 200)
+   Oldest entries are dropped first (FIFO)."
 
   (->interceptor
    :id :metrics
@@ -431,12 +491,20 @@
                   elapsed-ms (when start-ns
                                (/ (- (System/nanoTime) start-ns) 1000000.0))]
               (when elapsed-ms
-                (swap! *metrics
-                       (fn [m]
-                         (-> m
-                             (update :timings #(take 100 (conj % elapsed-ms)))
-                             (update-in [:timings-by-type event-id]
-                                        #(take 100 (conj (or % []) elapsed-ms))))))))
+                (let [{:keys [max-timings max-timings-per-type]} @*metrics-config]
+                  (swap! *metrics
+                         (fn [m]
+                           (let [[new-timings global-dropped?]
+                                 (bounded-conj (:timings m) elapsed-ms max-timings)
+                                 [new-type-timings type-dropped?]
+                                 (bounded-conj (get-in m [:timings-by-type event-id])
+                                               elapsed-ms max-timings-per-type)
+                                 total-dropped (+ (if global-dropped? 1 0)
+                                                  (if type-dropped? 1 0))]
+                             (-> m
+                                 (assoc :timings new-timings)
+                                 (assoc-in [:timings-by-type event-id] new-type-timings)
+                                 (update :timings-dropped + total-dropped))))))))
             context)))
 
 (def trim-v
@@ -614,6 +682,80 @@
    Public API to avoid accessing private state."
   [event-id]
   (contains? @*event-handlers event-id))
+
+;; =============================================================================
+;; Deregistration API (E1)
+;; =============================================================================
+
+(defn unreg-event
+  "Remove event handler for event-id.
+   Returns true if the handler was found and removed, false if not found.
+   Thread-safe (uses swap! on atom)."
+  [event-id]
+  (let [removed? (atom false)]
+    (swap! *event-handlers
+           (fn [handlers]
+             (if (contains? handlers event-id)
+               (do (reset! removed? true)
+                   (dissoc handlers event-id))
+               handlers)))
+    @removed?))
+
+(defn unreg-fx
+  "Remove effect handler for fx-id.
+   Returns true if the handler was found and removed, false if not found.
+   Delegates to hive.events.fx/unreg-fx. Thread-safe."
+  [fx-id]
+  (fx/unreg-fx fx-id))
+
+(defn unreg-cofx
+  "Remove coeffect handler for cofx-id.
+   Returns true if the handler was found and removed, false if not found.
+   Delegates to hive.events.cofx/unreg-cofx. Thread-safe."
+  [cofx-id]
+  (cofx/unreg-cofx cofx-id))
+
+;; =============================================================================
+;; Inspection / Diagnostics API (E1)
+;; =============================================================================
+
+(defn registered-events
+  "Return set of registered event IDs."
+  []
+  (set (keys @*event-handlers)))
+
+(defn registered-effects
+  "Return set of registered effect IDs.
+   Delegates to hive.events.fx/registered-fx-ids."
+  []
+  (fx/registered-fx-ids))
+
+(defn registered-coeffects
+  "Return set of registered coeffect IDs.
+   Delegates to hive.events.cofx/registered-cofx-ids."
+  []
+  (cofx/registered-cofx-ids))
+
+(defn handler-registry-status
+  "Return a summary of all registered handlers across event, fx, and cofx registries.
+
+   Returns:
+   {:event-count  N
+    :fx-count     N
+    :cofx-count   N
+    :events       [sorted event-id keywords]
+    :effects      [sorted fx-id keywords]
+    :coeffects    [sorted cofx-id keywords]}"
+  []
+  (let [events (registered-events)
+        effects (registered-effects)
+        coeffects (registered-coeffects)]
+    {:event-count (count events)
+     :fx-count    (count effects)
+     :cofx-count  (count coeffects)
+     :events      (vec (sort events))
+     :effects     (vec (sort effects))
+     :coeffects   (vec (sort coeffects))}))
 
 ;; =============================================================================
 ;; Testing Helpers

--- a/src/hive_mcp/events/effects.clj
+++ b/src/hive_mcp/events/effects.clj
@@ -1,17 +1,18 @@
 (ns hive-mcp.events.effects
-  "Concrete effect implementations for the hive-mcp event system — facade module.
+  "Concrete effect implementations for the hive-mcp event system -- facade module.
 
    This namespace re-exports key public vars from the effects sub-modules
    for backward compatibility. New code should require specific sub-modules:
 
-   - hive-mcp.events.effects.coeffect         — coeffects (now, agent-context, db-snapshot, etc.)
-   - hive-mcp.events.effects.notification     — shout, log, channel, olympus
-   - hive-mcp.events.effects.memory           — memory-write, wrap-notify, wrap-crystallize
-   - hive-mcp.events.effects.agent            — dispatch-task, swarm-send-prompt, agora, saa
-   - hive-mcp.events.effects.dispatch         — event chaining (dispatch, dispatch-n)
-   - hive-mcp.events.effects.infrastructure   — ds-transact, git, kanban, metrics
-   - hive-mcp.events.effects.kg               — knowledge graph edges
-   - hive-mcp.events.effects.drone-loop       — drone-loop FSM side effects
+   - hive-mcp.events.effects.coeffect         -- coeffects (now, agent-context, db-snapshot, etc.)
+   - hive-mcp.events.effects.notification     -- shout, log, channel, olympus
+   - hive-mcp.events.effects.memory           -- memory-write, wrap-notify, wrap-crystallize
+   - hive-mcp.events.effects.agent            -- dispatch-task, swarm-send-prompt, agora, saa
+   - hive-mcp.events.effects.dispatch         -- event chaining (dispatch, dispatch-n)
+   - hive-mcp.events.effects.infrastructure   -- ds-transact, git, kanban, metrics
+   - hive-mcp.events.effects.kg               -- knowledge graph edges
+   - hive-mcp.events.effects.drone-loop       -- drone-loop FSM side effects
+   - hive-mcp.events.effects.lifecycle        -- GC lifecycle sweep (gc-fix-4)
 
    Usage:
    ```clojure
@@ -27,6 +28,7 @@
             [hive-mcp.events.effects.infrastructure :as infra-effects]
             [hive-mcp.events.effects.kg :as kg-effects]
             [hive-mcp.events.effects.drone-loop :as drone-loop-effects]
+            [hive-mcp.events.effects.lifecycle :as lifecycle-effects]
             [taoensso.timbre :as log]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
@@ -65,6 +67,7 @@
    - infrastructure: :ds-transact :git-commit :kanban-sync :kanban-move-done :report-metrics :tool-registry-refresh
    - kg:           :kg-add-edge :kg-update-confidence :kg-increment-confidence :kg-remove-edge :kg-remove-edges-for-node
    - drone-loop:   :drone/seed-session :drone/emit :drone/record-obs :drone/record-reason
+   - lifecycle:    :lifecycle/sweep-fx (gc-fix-4)
 
    Coeffects registered (POC-08/09/10/11):
    - :now             - Current timestamp in milliseconds
@@ -93,13 +96,14 @@
     (infra-effects/register-infrastructure-effects!)
     (kg-effects/register-kg-effects!)
     (drone-loop-effects/register-drone-loop-effects!)
+    (lifecycle-effects/register-lifecycle-effects!)
 
     ;; NOTE: :crystal/wrap-notify event handler is registered in
     ;; hive-mcp.events.handlers.crystal/register-handlers! with proper
     ;; defensive stats handling. Do NOT duplicate here.
 
     (reset! *registered true)
-    (log/info "[hive-events] All effect/coeffect submodules registered (coeffect, notification, memory, agent, dispatch, infrastructure, kg, drone-loop)")
+    (log/info "[hive-events] All effect/coeffect submodules registered (coeffect, notification, memory, agent, dispatch, infrastructure, kg, drone-loop, lifecycle)")
     true))
 
 (defn reset-registration!

--- a/src/hive_mcp/events/effects/lifecycle.clj
+++ b/src/hive_mcp/events/effects/lifecycle.clj
@@ -1,0 +1,104 @@
+(ns hive-mcp.events.effects.lifecycle
+  "Lifecycle effect handlers for GC sweep side-effects.
+
+   Effects implemented:
+   - :lifecycle/sweep-fx - Execute bounded atom eviction via gc.bounded-atom registry
+
+   Part of gc-fix-4: prevents GC death spiral from unbounded atom growth.
+
+   Usage:
+   ```clojure
+   (require '[hive-mcp.events.effects.lifecycle :as lifecycle-effects])
+   (lifecycle-effects/register-lifecycle-effects!)
+   ```"
+
+  (:require [hive-mcp.events.core :as ev]
+            [hive-mcp.gc.bounded-atom :as batom]
+            [taoensso.timbre :as log]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; State: Last sweep result for query
+;; =============================================================================
+
+(defonce ^{:doc "Last sweep result for status queries."}
+  *last-sweep-result
+  (atom nil))
+
+;; =============================================================================
+;; Effect: :lifecycle/sweep-fx
+;; =============================================================================
+
+(defn- handle-sweep-fx
+  "Execute a :lifecycle/sweep-fx effect -- bounded atom eviction.
+
+   Calls batom/sweep-all! to evict stale/over-capacity entries from
+   all registered bounded atoms. Stores the result for status queries.
+
+   Expected data shape:
+   {:atom-ids nil}       ; sweep all registered atoms
+   {:atom-ids [:my-atom]} ; sweep specific atoms only (future extension)
+
+   The sweep is idempotent -- calling twice in succession will not
+   double-evict because entries evicted in the first pass are already gone."
+  [{:keys [atom-ids]}]
+  (try
+    (let [result (if (seq atom-ids)
+                   ;; Selective sweep: only specified atoms
+                   ;; For now, sweep-all! sweeps everything; selective is a
+                   ;; future extension. Log the intent.
+                   (do
+                     (log/debug "[lifecycle-fx] Selective sweep requested for:" atom-ids
+                                "-- sweeping all (selective not yet implemented)")
+                     (batom/sweep-all!))
+                   ;; Full sweep
+                   (batom/sweep-all!))]
+      (reset! *last-sweep-result
+              (assoc result :timestamp (java.time.Instant/now)))
+      (when (pos? (:total-evicted result))
+        (log/info "[lifecycle-fx] Sweep result:" (:total-evicted result) "evicted,"
+                  (:atom-count result) "atoms swept in"
+                  (:duration-ms result) "ms"))
+      result)
+    (catch Exception e
+      (log/error "[lifecycle-fx] Sweep failed:" (.getMessage e))
+      {:total-evicted 0
+       :per-atom      []
+       :duration-ms   0
+       :atom-count    0
+       :error         (.getMessage e)})))
+
+;; =============================================================================
+;; Query API
+;; =============================================================================
+
+(defn last-sweep-result
+  "Return the last sweep result, or nil if no sweep has been run."
+  []
+  @*last-sweep-result)
+
+;; =============================================================================
+;; Registration
+;; =============================================================================
+
+(defn register-lifecycle-effects!
+  "Register lifecycle effect handlers.
+
+   Effects registered:
+   - :lifecycle/sweep-fx - Execute bounded atom GC sweep
+
+   Called from hive-mcp.events.effects/register-effects!"
+  []
+  (ev/reg-fx :lifecycle/sweep-fx handle-sweep-fx)
+  (log/info "[hive-events.lifecycle] Lifecycle effects registered: :lifecycle/sweep-fx"))
+
+;; =============================================================================
+;; Testing Helpers
+;; =============================================================================
+
+(defn reset-state!
+  "Reset lifecycle effect state. For testing only."
+  []
+  (reset! *last-sweep-result nil))

--- a/src/hive_mcp/events/handlers.clj
+++ b/src/hive_mcp/events/handlers.clj
@@ -15,6 +15,7 @@
    - handlers.kg     - Knowledge Graph (:kg/edge-created, :kg/edge-updated, :kg/edge-removed, :kg/node-promoted)
    - handlers.agora  - Agora events (:agora/turn-dispatched, :agora/timeout, :agora/turn-completed, :agora/dispatch-next, :agora/execute-drone, :agora/debate-started, :agora/stage-transition, :agora/consensus)
    - handlers.saa    - SAA workflow (:saa/started, :saa/phase-complete, :saa/completed, :saa/failed)
+   - handlers.lifecycle - GC lifecycle (:lifecycle/sweep)
 
    ## Usage
    ```clojure
@@ -65,9 +66,10 @@
    - :agora/stage-transition  - Research -> debate stage transition
    - :agora/consensus         - Crystallize debate result to memory
    - :saa/started             - SAA workflow initiated
-   - :saa/phase-complete      - SAA phase transition (Silence→Abstract→Act)
+   - :saa/phase-complete      - SAA phase transition (Silence->Abstract->Act)
    - :saa/completed           - SAA workflow finished successfully
-   - :saa/failed              - SAA workflow error"
+   - :saa/failed              - SAA workflow error
+   - :lifecycle/sweep         - Bounded atom GC sweep (gc-fix-4)"
 
   (:require [hive-mcp.events.handlers.task :as task]
             [hive-mcp.events.handlers.ling :as ling]
@@ -83,7 +85,8 @@
             [hive-mcp.events.handlers.kg :as kg]
             [hive-mcp.events.handlers.agora :as agora]
             [hive-mcp.events.handlers.saa :as saa]
-            [hive-mcp.events.handlers.memory-read :as memory-read]))
+            [hive-mcp.events.handlers.memory-read :as memory-read]
+            [hive-mcp.events.handlers.lifecycle :as lifecycle]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -114,6 +117,7 @@
    - kg/register-handlers!       - Knowledge Graph edges
    - agora/register-handlers!    - Agora events
    - saa/register-handlers!      - SAA workflow lifecycle
+   - lifecycle/register-handlers! - GC lifecycle sweep (gc-fix-4)
 
    Returns true if handlers were registered, false if already registered."
   []
@@ -134,9 +138,10 @@
     (agora/register-handlers!)
     (saa/register-handlers!)
     (memory-read/register-handlers!)
+    (lifecycle/register-handlers!)
 
     (reset! *registered true)
-    (println "[hive-events] Handlers registered: :task/complete :task/shout-complete :git/commit-modified :ling/started :ling/completed :ling/ready-for-wrap :session/end :session/wrap :kanban/sync :kanban/done :crystal/wrap-request :crystal/wrap-notify :wave/start :wave/item-done :wave/complete :validated-wave/start :validated-wave/iteration-start :validated-wave/success :validated-wave/partial :validated-wave/retry :drone/started :drone/completed :drone/failed :claim/file-released :claim/notify-waiting :system/error :hot/reload-start :hot/reload-success :file/changed :kg/edge-created :kg/edge-updated :kg/edge-removed :kg/node-promoted :agora/turn-dispatched :agora/timeout :agora/turn-completed :agora/dispatch-next :agora/execute-drone :agora/debate-started :agora/stage-transition :agora/consensus :saa/started :saa/phase-complete :saa/completed :saa/failed :memory/query :memory/search :memory/get")
+    (println "[hive-events] Handlers registered: :task/complete :task/shout-complete :git/commit-modified :ling/started :ling/completed :ling/ready-for-wrap :session/end :session/wrap :kanban/sync :kanban/done :crystal/wrap-request :crystal/wrap-notify :wave/start :wave/item-done :wave/complete :validated-wave/start :validated-wave/iteration-start :validated-wave/success :validated-wave/partial :validated-wave/retry :drone/started :drone/completed :drone/failed :claim/file-released :claim/notify-waiting :system/error :hot/reload-start :hot/reload-success :file/changed :kg/edge-created :kg/edge-updated :kg/edge-removed :kg/node-promoted :agora/turn-dispatched :agora/timeout :agora/turn-completed :agora/dispatch-next :agora/execute-drone :agora/debate-started :agora/stage-transition :agora/consensus :saa/started :saa/phase-complete :saa/completed :saa/failed :memory/query :memory/search :memory/get :lifecycle/sweep")
     true))
 
 (defn reset-registration!

--- a/src/hive_mcp/events/handlers/lifecycle.clj
+++ b/src/hive_mcp/events/handlers/lifecycle.clj
@@ -1,0 +1,84 @@
+(ns hive-mcp.events.handlers.lifecycle
+  "Lifecycle event handlers for GC sweep.
+
+   Handles:
+   - :lifecycle/sweep - Trigger bounded atom sweep across all registered atoms
+
+   The sweep event produces a :lifecycle/sweep-fx effect that performs
+   the actual eviction side-effect via the bounded atom registry.
+
+   Part of gc-fix-4: prevents GC death spiral from unbounded atom growth."
+
+  (:require [hive-mcp.events.core :as ev]
+            [taoensso.timbre :as log]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Handler: :lifecycle/sweep
+;; =============================================================================
+
+(defn handle-lifecycle-sweep
+  "Handler for :lifecycle/sweep events.
+
+   Produces :lifecycle/sweep-fx effect to trigger bounded atom eviction.
+   The handler is pure -- actual side-effects happen in the effect handler.
+
+   Event shape:
+   [:lifecycle/sweep {}]                     ; sweep all
+   [:lifecycle/sweep {:atom-ids [:my-atom]}] ; sweep specific atoms (optional)
+
+   Produces effects:
+   - :lifecycle/sweep-fx - Execute the sweep
+   - :log                - Log the sweep trigger"
+  [_coeffects [_ data]]
+  (let [atom-ids (:atom-ids data)]
+    (log/debug "[lifecycle] Sweep event received, atom-ids:" atom-ids)
+    {:lifecycle/sweep-fx {:atom-ids atom-ids}
+     :log {:level :info
+           :message (str "Lifecycle sweep triggered"
+                         (when (seq atom-ids)
+                           (str " for atoms: " (pr-str atom-ids))))}}))
+
+;; =============================================================================
+;; Convenience Function
+;; =============================================================================
+
+(defn trigger-sweep!
+  "Convenience function to dispatch a :lifecycle/sweep event.
+
+   Dispatches synchronously and returns the sweep stats from the effect.
+
+   Usage:
+   (trigger-sweep!)                        ; sweep all registered atoms
+   (trigger-sweep! {:atom-ids [:my-atom]}) ; sweep specific atoms"
+  ([]
+   (trigger-sweep! {}))
+  ([opts]
+   (ev/dispatch [:lifecycle/sweep (or opts {})])))
+
+;; =============================================================================
+;; Registration
+;; =============================================================================
+
+(defonce ^:private *registered (atom false))
+
+(defn register-handlers!
+  "Register lifecycle event handlers. Call at startup.
+
+   Handlers registered:
+   - :lifecycle/sweep - Bounded atom GC sweep
+
+   Safe to call multiple times."
+  []
+  (when-not @*registered
+    (ev/reg-event :lifecycle/sweep [] handle-lifecycle-sweep)
+    (reset! *registered true)
+    (log/info "[hive-events] Lifecycle handlers registered: :lifecycle/sweep")
+    true))
+
+(defn reset-registration!
+  "Reset registration state. Primarily for testing."
+  []
+  (reset! *registered false))

--- a/src/hive_mcp/gc/bounded_atom.clj
+++ b/src/hive_mcp/gc/bounded_atom.clj
@@ -1,0 +1,161 @@
+(ns hive-mcp.gc.bounded-atom
+  "Bounded atom registry with TTL-based eviction and capacity limits.
+
+   Provides infrastructure for managing atoms that can grow unboundedly
+   (GC death spiral prevention). Each registered bounded atom declares:
+   - :max-entries  - Maximum number of entries allowed
+   - :ttl-ms       - Time-to-live for entries (nil = no TTL)
+   - :evict-fn     - Function to evict stale/over-capacity entries
+   - :count-fn     - Function to count current entries
+   - :name         - Human-readable name for stats reporting
+
+   The registry is the backbone for :lifecycle/sweep events, which
+   iterate over all registered bounded atoms and call their eviction
+   functions.
+
+   Usage:
+   ```clojure
+   (register! :my-atom
+     {:name         \"my-cache\"
+      :atom-ref     my-atom
+      :max-entries  1000
+      :ttl-ms       300000
+      :count-fn     (fn [a] (count @a))
+      :evict-fn     (fn [a opts] (evict-stale! a opts))})
+
+   (sweep-all!)  ;; => {:total-evicted N :per-atom [...] :duration-ms T}
+   ```"
+  (:require [taoensso.timbre :as log]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Registry
+;; =============================================================================
+
+(defonce ^{:doc "Registry of bounded atoms. Map of keyword -> bounded-atom-spec.
+  Each spec: {:name str :atom-ref IDeref :max-entries int :ttl-ms long
+              :count-fn (fn [atom-ref]) :evict-fn (fn [atom-ref opts]) -> evicted-count}"}
+  *registry
+  (atom {}))
+
+;; =============================================================================
+;; Registration API
+;; =============================================================================
+
+(defn register!
+  "Register a bounded atom for lifecycle sweep management.
+
+   Args:
+   - id   - Keyword identifier for this bounded atom
+   - spec - Map with keys:
+     :name         - Human-readable name (defaults to (name id))
+     :atom-ref     - The atom (or IDeref) to manage
+     :max-entries  - Maximum entries before capacity eviction (required)
+     :ttl-ms       - TTL in milliseconds (nil = no TTL eviction)
+     :count-fn     - (fn [atom-ref]) -> current entry count (required)
+     :evict-fn     - (fn [atom-ref {:keys [max-entries ttl-ms now-ms]}]) -> evicted count (required)
+
+   Returns the id.
+   Idempotent -- re-registering with same id overwrites."
+  [id spec]
+  {:pre [(keyword? id)
+         (fn? (:count-fn spec))
+         (fn? (:evict-fn spec))
+         (some? (:atom-ref spec))
+         (pos-int? (:max-entries spec))]}
+  (let [full-spec (assoc spec :name (or (:name spec) (name id)))]
+    (swap! *registry assoc id full-spec)
+    (log/debug "[gc] Registered bounded atom:" (name id)
+               "max-entries:" (:max-entries spec)
+               "ttl-ms:" (:ttl-ms spec))
+    id))
+
+(defn deregister!
+  "Remove a bounded atom from the registry.
+   Returns true if it was registered, false otherwise."
+  [id]
+  (let [existed? (contains? @*registry id)]
+    (swap! *registry dissoc id)
+    existed?))
+
+(defn registered?
+  "Check if a bounded atom is registered."
+  [id]
+  (contains? @*registry id))
+
+(defn registered-ids
+  "Return the set of all registered bounded atom IDs."
+  []
+  (set (keys @*registry)))
+
+(defn get-spec
+  "Get the spec for a registered bounded atom. Returns nil if not registered."
+  [id]
+  (get @*registry id))
+
+;; =============================================================================
+;; Sweep Logic
+;; =============================================================================
+
+(defn- sweep-one
+  "Sweep a single bounded atom. Returns stats map.
+
+   Calls the atom's evict-fn with current config, captures before/after counts.
+   Never throws -- catches and reports errors per-atom."
+  [id {:keys [name atom-ref max-entries ttl-ms count-fn evict-fn]}]
+  (try
+    (let [now-ms    (System/currentTimeMillis)
+          before    (count-fn atom-ref)
+          evicted   (evict-fn atom-ref {:max-entries max-entries
+                                        :ttl-ms     ttl-ms
+                                        :now-ms     now-ms})
+          remaining (count-fn atom-ref)]
+      {:atom-id   id
+       :name      name
+       :evicted   (or evicted (- before remaining))
+       :remaining remaining
+       :error     nil})
+    (catch Exception e
+      (log/warn "[gc] Sweep failed for bounded atom" (clojure.core/name id)
+                ":" (.getMessage e))
+      {:atom-id   id
+       :name      (or name (clojure.core/name id))
+       :evicted   0
+       :remaining -1
+       :error     (.getMessage e)})))
+
+(defn sweep-all!
+  "Sweep all registered bounded atoms. Returns sweep stats.
+
+   Returns:
+   {:total-evicted N
+    :per-atom      [{:atom-id :name :evicted :remaining :error}...]
+    :duration-ms   T
+    :atom-count    N}
+
+   Safe to call even when no atoms are registered -- returns empty stats."
+  []
+  (let [start-ms  (System/currentTimeMillis)
+        registry  @*registry
+        per-atom  (mapv (fn [[id spec]] (sweep-one id spec)) registry)
+        total     (reduce + 0 (map :evicted per-atom))
+        elapsed   (- (System/currentTimeMillis) start-ms)]
+    (when (pos? total)
+      (log/info "[gc] Sweep completed: evicted" total "entries from"
+                (count per-atom) "atoms in" elapsed "ms"))
+    {:total-evicted total
+     :per-atom      per-atom
+     :duration-ms   elapsed
+     :atom-count    (count registry)}))
+
+;; =============================================================================
+;; Testing Helpers
+;; =============================================================================
+
+(defn reset-registry!
+  "Clear the bounded atom registry. For testing only."
+  []
+  (reset! *registry {})
+  nil)

--- a/src/hive_mcp/hivemind/messaging.clj
+++ b/src/hive_mcp/hivemind/messaging.clj
@@ -11,6 +11,7 @@
             [hive-mcp.channel.piggyback :as piggyback]
             [hive-mcp.protocols.event-backbone :as eb]
             [hive-mcp.protocols.delivery-channel :as dc]
+            [hive-mcp.protocols.vessel :as vessel]
             [hive-mcp.swarm.protocol :as proto]
             [hive-mcp.swarm.datascript.registry :as registry]
             [hive-mcp.swarm.datascript.queries :as queries]
@@ -76,12 +77,13 @@
         resolved-slave-id (or (:slave/id resolved-slave) agent-id)
         explicit-project-id (:project-id data)
         directory (:directory data)
-        slave-cwd (:slave/cwd resolved-slave)
-        ;; Resolution: slave-cwd (from DataScript, set at spawn) takes precedence
-        ;; over directory (from tool handler, may be MCP server's cwd).
-        ;; This ensures lings always resolve to their own project scope.
+        ;; IVessel resolution: query all registered vessels for agent context.
+        ;; Vessel delegates to DataScript (slave/cwd, slave/project-id) — the
+        ;; formal answer to the project-id coupling bug (vessel owns context).
+        vessel-ctx (vessel/resolve-agent-context resolved-slave-id)
+        ;; Priority: explicit > vessel > directory > global
         project-id (or explicit-project-id
-                       (when slave-cwd (mem-scope/get-current-project-id slave-cwd))
+                       (:project-id vessel-ctx)
                        (when directory (mem-scope/get-current-project-id directory))
                        "global")
         message (cond-> {:event-type event-type

--- a/src/hive_mcp/hivemind/state.clj
+++ b/src/hive_mcp/hivemind/state.clj
@@ -2,7 +2,9 @@
   "Hivemind state atoms and direct accessors."
 
   (:require [hive-mcp.server.guards :as guards]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bounded-atom bput! bget bounded-swap!
+                                           bclear! register-sweepable!]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -11,20 +13,36 @@
   pending-asks
   (atom {}))
 
+;; gc-fix-3: agent-registry — LRU eviction, 100 entries, 2hr TTL
+;; Stores per-agent message history. LRU evicts least-active agents.
 (defonce ^{:doc "Agent message history ring buffer. Map of agent-id -> {:messages [...] :last-seen timestamp}."}
   agent-registry
-  (atom {}))
+  (bounded-atom {:max-entries 100
+                 :ttl-ms 7200000    ;; 2 hours
+                 :eviction-policy :lru}))
+(register-sweepable! agent-registry :agent-registry)
 
+;; gc-fix-3: pending-swarm-prompts — LRU eviction, 50 entries, 10min TTL
+;; Prompts are ephemeral; unanswered ones stale quickly.
 (defonce ^{:doc "Map of slave-id -> {:prompt :timestamp :session-id}. Permission prompts from Emacs slaves."}
   pending-swarm-prompts
-  (atom {}))
+  (bounded-atom {:max-entries 50
+                 :ttl-ms 600000     ;; 10 minutes
+                 :eviction-policy :lru}))
+(register-sweepable! pending-swarm-prompts :pending-swarm-prompts)
 
-(defonce ling-results (atom {}))
+;; gc-fix-3: ling-results — LRU eviction, 50 entries, 30min TTL
+;; Results are short-lived; reviewed results waste memory.
+(defonce ling-results
+  (bounded-atom {:max-entries 50
+                 :ttl-ms 1800000    ;; 30 minutes
+                 :eviction-policy :lru}))
+(register-sweepable! ling-results :ling-results)
 
 (defn record-ling-result!
   "Record ling completion for coordinator review."
   [agent-id result]
-  (swap! ling-results assoc agent-id
+  (bput! ling-results agent-id
          {:result result
           :timestamp (System/currentTimeMillis)
           :reviewed? false}))
@@ -32,19 +50,24 @@
 (defn get-pending-ling-results
   "Get ling results awaiting coordinator review."
   []
-  (->> @ling-results
-       (filter (fn [[_ v]] (not (:reviewed? v))))
-       (into {})))
+  (->> @(:atom ling-results)
+       (reduce-kv (fn [acc k entry]
+                    (let [data (:data entry)]
+                      (if (not (:reviewed? data))
+                        (assoc acc k data)
+                        acc)))
+                  {})))
 
 (defn mark-ling-reviewed!
   "Mark a ling result as reviewed by coordinator."
   [agent-id]
-  (swap! ling-results assoc-in [agent-id :reviewed?] true))
+  (when-let [current (bget ling-results agent-id)]
+    (bput! ling-results agent-id (assoc current :reviewed? true))))
 
 (defn clear-ling-results!
   "Clear all ling results (e.g., at session end)."
   []
-  (reset! ling-results {}))
+  (bclear! ling-results))
 
 (defn add-swarm-prompt!
   "Add a permission prompt from a swarm slave."
@@ -53,7 +76,7 @@
                      :timestamp timestamp
                      :session-id session-id
                      :received-at (System/currentTimeMillis)}]
-    (swap! pending-swarm-prompts assoc slave-id prompt-data)
+    (bput! pending-swarm-prompts slave-id prompt-data)
     (log/info "Swarm prompt received from" slave-id ":"
               (subs prompt-text 0 (min 50 (count prompt-text))))
     prompt-data))
@@ -61,20 +84,24 @@
 (defn remove-swarm-prompt!
   "Remove a swarm prompt (after it's been answered)."
   [slave-id]
-  (swap! pending-swarm-prompts dissoc slave-id)
+  (bounded-swap! pending-swarm-prompts dissoc slave-id)
   (log/debug "Swarm prompt cleared:" slave-id))
 
 (defn get-swarm-prompts
-  "Get all pending swarm prompts."
+  "Get all pending swarm prompts.
+   Returns map of slave-id -> prompt-data (unwrapped)."
   []
-  @pending-swarm-prompts)
+  (reduce-kv (fn [acc k entry]
+               (assoc acc k (:data entry)))
+             {}
+             @(:atom pending-swarm-prompts)))
 
 (defn clear-agent-registry!
   "Clear agent registry. Guarded — no-op if coordinator running."
   []
   (guards/when-not-coordinator
    "clear-agent-registry! called"
-   (reset! agent-registry {})))
+   (bclear! agent-registry)))
 
 ;; =============================================================================
 ;; Per-agent Cleanup (for ling death)
@@ -83,9 +110,9 @@
 (defn remove-ling-result!
   "Remove a specific ling's result entry (on ling death)."
   [agent-id]
-  (swap! ling-results dissoc agent-id))
+  (bounded-swap! ling-results dissoc agent-id))
 
 (defn clear-agent-messages!
   "Remove a specific agent's message history (on ling death)."
   [agent-id]
-  (swap! agent-registry dissoc agent-id))
+  (bounded-swap! agent-registry dissoc agent-id))

--- a/src/hive_mcp/hivemind/status.clj
+++ b/src/hive_mcp/hivemind/status.clj
@@ -8,7 +8,8 @@
             [hive-mcp.swarm.datascript.registry :as registry]
             [hive-mcp.swarm.logic :as logic]
             [hive-mcp.tools.memory.scope :as mem-scope]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bput! bget bounded-swap! bkeys]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -21,7 +22,11 @@
    (let [ds-slaves (if project-id
                      (proto/get-slaves-by-project registry/default-registry project-id)
                      (proto/get-all-slaves registry/default-registry))
-         msg-history @state/agent-registry]
+         ;; Unwrap bounded-atom entries to get raw agent-id -> data map
+         msg-history (reduce-kv (fn [acc k entry]
+                                  (assoc acc k (:data entry)))
+                                {}
+                                @(:atom state/agent-registry))]
      (reduce
       (fn [acc slave]
         (let [slave-id (:slave/id slave)
@@ -52,13 +57,14 @@
                            :question question
                            :options options})
                         @state/pending-asks)
-    :pending-swarm-prompts (mapv (fn [[slave-id {:keys [prompt timestamp session-id received-at]}]]
-                                   {:slave-id slave-id
-                                    :prompt prompt
-                                    :timestamp timestamp
-                                    :session-id session-id
-                                    :received-at received-at})
-                                 @state/pending-swarm-prompts)
+    :pending-swarm-prompts (mapv (fn [[slave-id entry]]
+                                   (let [{:keys [prompt timestamp session-id received-at]} (:data entry)]
+                                     {:slave-id slave-id
+                                      :prompt prompt
+                                      :timestamp timestamp
+                                      :session-id session-id
+                                      :received-at received-at}))
+                                 @(:atom state/pending-swarm-prompts))
     :channel-connected (channel/server-connected?)
     :ws-connected (ws/connected?)
     :ws-clients (ws/client-count)}))
@@ -66,7 +72,7 @@
 (defn get-agent-messages
   "Get recent messages from a specific agent."
   [agent-id]
-  (let [msg-history-entry (get @state/agent-registry agent-id)
+  (let [msg-history-entry (bget state/agent-registry agent-id)
         ds-slave (proto/get-slave registry/default-registry agent-id)]
     (cond
       msg-history-entry (:messages msg-history-entry)
@@ -78,7 +84,7 @@
 
   [agent-id metadata]
   (let [now (System/currentTimeMillis)]
-    (swap! state/agent-registry assoc agent-id
+    (bput! state/agent-registry agent-id
            {:messages []
             :last-seen now})
     (when-not (proto/get-slave registry/default-registry agent-id)
@@ -97,7 +103,7 @@
 (defn clear-agent!
   "Remove an agent from the registry and release all claims."
   [agent-id]
-  (swap! state/agent-registry dissoc agent-id)
+  (bounded-swap! state/agent-registry dissoc agent-id)
   (logic/release-claims-for-slave! agent-id)
   (proto/remove-slave! registry/default-registry agent-id)
   (log/info "Agent cleared from hivemind:" agent-id))

--- a/src/hive_mcp/hivemind/tools.clj
+++ b/src/hive_mcp/hivemind/tools.clj
@@ -11,7 +11,8 @@
             [hive-mcp.tools.memory.scope :as mem-scope]
             [clojure.data.json :as json]
             [clojure.set :as set]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bkeys]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -55,11 +56,15 @@ The env var fallback reads from MCP server process, NOT your ling process!"
                      _ (when (and (not agent_id) (not ctx-agent))
                          (log/warn "[hivemind_shout] No agent_id in args or context, using fallback:" (or env-agent "unknown-agent")))
 
-                     fallback-used? (and (not agent_id) (not ctx-agent))
-                     effective-dir (or directory
-                                       (ctx/current-directory))]
+                     fallback-used? (and (not agent_id) (not ctx-agent))]
+                 ;; NOTE: Only pass directory if caller explicitly provided it.
+                 ;; Do NOT fall back to ctx/current-directory — that resolves to the
+                 ;; MCP server's cwd, not the ling's cwd. shout! has its own slave-cwd
+                 ;; lookup from DataScript which correctly uses the ling's registered cwd.
                  (messaging/shout! effective-id (keyword event_type)
-                                   (merge {:task task :message message :directory effective-dir} data))
+                                   (merge {:task task :message message}
+                                          (when directory {:directory directory})
+                                          data))
                  {:type "text" :text (json/write-str (cond-> {:success true
                                                               :agent_id effective-id}
                                                        fallback-used?
@@ -173,13 +178,15 @@ The specific agent lookup is still allowed even if agent is from another project
                      ds-agents (if project-id
                                  (clojure.core/set (map :slave/id (proto/get-slaves-by-project registry/default-registry project-id)))
                                  (clojure.core/set (map :slave/id (proto/get-all-slaves registry/default-registry))))
+                     ;; Iterate raw bounded-atom entries for project filtering
                      msg-agents (if project-id
-                                  (->> @state/agent-registry
-                                       (filter (fn [[_id {:keys [messages]}]]
-                                                 (some #(= project-id (:project-id %)) messages)))
+                                  (->> @(:atom state/agent-registry)
+                                       (filter (fn [[_id entry]]
+                                                 (some #(= project-id (:project-id %))
+                                                       (:messages (:data entry)))))
                                        (map first)
                                        set)
-                                  (clojure.core/set (keys @state/agent-registry)))
+                                  (clojure.core/set (bkeys state/agent-registry)))
                      available-agents (vec (set/union ds-agents msg-agents))]
                  {:type "text"
                   :text (json/write-str

--- a/src/hive_mcp/knowledge_graph/connection.clj
+++ b/src/hive_mcp/knowledge_graph/connection.clj
@@ -16,6 +16,7 @@
             [hive-mcp.config.core :as config]
             [hive-dsl.result :as r]
             [hive-dsl.batch :as dsl-batch]
+            [clojure.core.async :as async]
             [clojure.java.io :as io]
             [taoensso.timbre :as log]))
 
@@ -151,6 +152,134 @@
   nil)
 
 ;; =============================================================================
+;; Write-Coalescing Queue (Drain-and-Flush)
+;; =============================================================================
+;;
+;; Leverages Queue concurrency primitive (Grokking Simplicity Ch 15):
+;; Individual transact! calls are coalesced into batched writes.
+;;
+;; Design: core.async channel + go-loop consumer.
+;; - Producers put individual tx-data vectors onto the channel.
+;; - Consumer drains all available items within a 25ms window,
+;;   then flushes them as a single d/transact! call.
+;; - d/transact! (async) provides a second layer of auto-batching
+;;   at the Datahike level (per whilo's advice: memory 20260205231755).
+;;
+;; This eliminates the "Transacting 1 objects" pattern that causes
+;; high CPU on sequential single-entity writes.
+
+(def ^:private coalesce-window-ms
+  "Time window to drain additional items before flushing batch.
+   Balances latency vs batch size. 25ms gives good coalescing
+   without noticeable delay on interactive operations."
+  25)
+
+(def ^:private coalesce-max-batch
+  "Maximum batch size before forcing a flush, even within the window."
+  200)
+
+(defonce ^:private writer-state
+  (atom {:running? false :tx-chan nil :ctrl-chan nil}))
+
+(defonce ^:private writer-metrics
+  (atom {:batches-flushed 0 :items-written 0 :items-dropped 0 :largest-batch 0}))
+
+(defn- flush-batch!
+  "Flush accumulated tx-data as a single transaction."
+  [batch]
+  (when (seq batch)
+    (let [n (count batch)]
+      (try
+        (proto/transact! (ensure-store!) batch)
+        (swap! writer-metrics (fn [m]
+                                (-> m
+                                    (update :batches-flushed inc)
+                                    (update :items-written + n)
+                                    (update :largest-batch max n))))
+        (catch Exception e
+          (log/error "Coalesced batch transact failed, falling back to individual writes"
+                     {:batch-size n :error (.getMessage e)})
+          ;; Fallback: retry items individually so we don't lose data
+          (doseq [item batch]
+            (try
+              (proto/transact! (ensure-store!) [item])
+              (swap! writer-metrics update :items-written inc)
+              (catch Exception e2
+                (log/error "Individual fallback transact also failed"
+                           {:item item :error (.getMessage e2)})
+                (swap! writer-metrics update :items-dropped inc)))))))))
+
+(defn- start-writer-loop!
+  "Start the background write-coalescing consumer loop.
+   Creates fresh tx-chan + ctrl-chan each time (fixes channel death on stop).
+   Returns map with :tx-chan :ctrl-chan :go-chan."
+  []
+  (let [tx-chan   (async/chan 4096)
+        ctrl-chan (async/chan)
+        go-chan   (async/go-loop []
+                    (let [[val port] (async/alts! [ctrl-chan tx-chan])]
+                      (cond
+                       ;; ctrl-chan closed or signaled — graceful shutdown
+                        (= port ctrl-chan)
+                        (log/debug "Writer loop received shutdown signal")
+
+                       ;; tx-chan closed — also done
+                        (nil? val)
+                        (log/debug "Writer loop tx-chan closed")
+
+                        :else
+                        (let [first-item val
+                              batch (loop [batch (into [] (dsl-batch/normalize-tx-datum first-item))
+                                           remaining coalesce-window-ms]
+                                      (if (or (<= remaining 0)
+                                              (>= (count batch) coalesce-max-batch))
+                                        batch
+                                        (let [t0 (System/currentTimeMillis)
+                                              [item port] (async/alts! [ctrl-chan
+                                                                        tx-chan
+                                                                        (async/timeout remaining)])]
+                                          (cond
+                                            (= port ctrl-chan) batch
+                                            (nil? item)        batch
+                                            :else
+                                            (recur (into batch (dsl-batch/normalize-tx-datum item))
+                                                   (- remaining (- (System/currentTimeMillis) t0)))))))]
+                          (flush-batch! batch)
+                          (recur)))))]
+    {:tx-chan tx-chan :ctrl-chan ctrl-chan :go-chan go-chan}))
+
+(defn- ensure-writer!
+  "Ensure the write-coalescing loop is running.
+   Uses locking + double-check to prevent concurrent starts."
+  []
+  (when-not (:running? @writer-state)
+    (locking writer-state
+      (when-not (:running? @writer-state)
+        (let [{:keys [tx-chan ctrl-chan go-chan]} (start-writer-loop!)]
+          (reset! writer-state {:running? true
+                                :tx-chan   tx-chan
+                                :ctrl-chan ctrl-chan
+                                :go-chan   go-chan})
+          (log/debug "Started KG write-coalescing queue"))))))
+
+(defn stop-writer!
+  "Stop the write-coalescing loop. Idempotent — safe to call multiple times."
+  []
+  (locking writer-state
+    (let [{:keys [running? ctrl-chan tx-chan]} @writer-state]
+      (when running?
+        (when ctrl-chan (async/close! ctrl-chan))
+        (when tx-chan (async/close! tx-chan))
+        (reset! writer-state {:running? false :tx-chan nil :ctrl-chan nil})
+        (log/debug "Stopped KG write-coalescing queue")))))
+
+(defn writer-stats
+  "Return writer metrics + running state for observability."
+  []
+  (merge @writer-metrics
+         {:running? (:running? @writer-state)}))
+
+;; =============================================================================
 ;; Backward-Compatible API
 ;; =============================================================================
 
@@ -178,12 +307,36 @@
 
 (defn transact!
   "Transact data to the KG database.
-   When *tx-batch* is bound (via with-tx-batch), accumulates tx-data
-   for a single batched write. Otherwise delegates immediately to the store."
+   Priority:
+     1. *tx-batch* bound (via with-tx-batch) → accumulate for explicit batch flush
+     2. Otherwise → route through write-coalescing queue for automatic batching
+
+   The coalescing queue drains items within a 25ms window and flushes
+   as a single transaction. Combined with d/transact! (async) at the
+   store level, this eliminates the 'Transacting 1 objects' pattern."
   [tx-data]
   (if *tx-batch*
-    (swap! *tx-batch* into (if (map? tx-data) [tx-data] tx-data))
-    (proto/transact! (ensure-store!) tx-data)))
+    (swap! *tx-batch* into (dsl-batch/normalize-tx-datum tx-data))
+    (do
+      (ensure-writer!)
+      (let [tx-chan (:tx-chan @writer-state)]
+        (when-not (and tx-chan (async/put! tx-chan tx-data))
+          ;; Channel full or closed — fallback to sync write
+          (log/warn "Write-coalescing queue put! failed, falling back to sync transact"
+                    {:tx-data-count (if (sequential? tx-data) (count tx-data) 1)})
+          (swap! writer-metrics update :items-dropped
+                 + (if (sequential? tx-data) (count tx-data) 1))
+          (r/rescue nil
+                    (proto/transact! (ensure-store!)
+                                     (dsl-batch/normalize-tx-datum tx-data))))))))
+
+(defn transact-sync!
+  "Synchronous transact — bypasses the coalescing queue.
+   Use ONLY when the caller needs the tx-report return value
+   (e.g., extracting entity IDs from :tx-data).
+   Most callers should use transact! (async coalesced) instead."
+  [tx-data]
+  (proto/transact! (ensure-store!) tx-data))
 
 (defmacro with-tx-batch
   "Collect all transact! calls within body into a single transaction.

--- a/src/hive_mcp/knowledge_graph/disc/crud.clj
+++ b/src/hive_mcp/knowledge_graph/disc/crud.clj
@@ -1,6 +1,7 @@
 (ns hive-mcp.knowledge-graph.disc.crud
   "CRUD operations for disc entities in DataScript."
   (:require [hive-mcp.knowledge-graph.connection :as conn]
+            [hive-mcp.knowledge-graph.protocol :as proto]
             [hive-mcp.knowledge-graph.disc.hash :as hash]
             [hive-mcp.knowledge-graph.disc.volatility :as vol]
             [taoensso.timbre :as log]))
@@ -25,7 +26,8 @@
                   :disc/certainty-beta 2.0
                   :disc/volatility-class volatility
                   :disc/last-observation now}]
-        result (conn/transact! tx-data)]
+        ;; Sync transact — needs tx-report for entity ID extraction
+        result (conn/transact-sync! tx-data)]
     (log/debug "Added/updated disc entity" {:path path :volatility volatility
                                             :initial-certainty (/ initial-alpha (+ initial-alpha 2.0))})
     (-> result :tx-data first :e)))

--- a/src/hive_mcp/knowledge_graph/store/datahike.clj
+++ b/src/hive_mcp/knowledge_graph/store/datahike.clj
@@ -13,6 +13,23 @@
 
 (def ^:private default-db-path "data/kg/datahike")
 
+;; =============================================================================
+;; Addon Norms Registry (OCP — addons register their norm resource paths)
+;; =============================================================================
+
+(defonce ^:private addon-norms-registry
+  (atom []))
+
+(defn register-norms!
+  "Register a classpath resource path for addon Datahike norms.
+   Addons call this during init, before the KG store is first accessed.
+   Norms are applied idempotently via datahike.norm/ensure-norms! on ensure-conn!.
+
+   Example: (register-norms! \"my_addon/norms/kg\")"
+  [resource-path]
+  (swap! addon-norms-registry conj resource-path)
+  (log/info "Registered addon KG norms" {:path resource-path}))
+
 (defn- make-writer-config
   "Build the :writer section of Datahike config.
    Supports :self (default local), :datahike-server (HTTP), and :kabel (WebSocket).
@@ -99,11 +116,16 @@
               (let [conn (d/connect cfg)]
                 (log/info "Applying KG norms" {:path "hive_mcp/norms/kg"})
                 (norm/ensure-norms! conn (io/resource "hive_mcp/norms/kg"))
+                ;; Apply addon-registered norms (OCP: addons own their schema).
+                (doseq [norms-path @addon-norms-registry]
+                  (when-let [resource (io/resource norms-path)]
+                    (log/info "Applying addon KG norms" {:path norms-path})
+                    (rescue nil (norm/ensure-norms! conn resource))))
                 (reset! conn-atom conn))))
     @conn-atom)
 
   (transact! [this tx-data]
-    (d/transact (kg/ensure-conn! this) tx-data))
+    (d/transact! (kg/ensure-conn! this) tx-data))
 
   (query [this q]
     (d/q q (d/db (kg/ensure-conn! this))))

--- a/src/hive_mcp/nrepl/classloader_gc.clj
+++ b/src/hive_mcp/nrepl/classloader_gc.clj
@@ -1,0 +1,205 @@
+(ns hive-mcp.nrepl.classloader-gc
+  "nREPL middleware to prevent DynamicClassLoader proliferation.
+
+   Problem:
+   --------
+   bb-mcp sends stateless evals ({:op \"eval\" :code ...}) without a :session key.
+   nREPL's session middleware creates a NEW session for each such eval, and each
+   session creates a new clojure.lang.DynamicClassLoader. These classloaders hold
+   references to evaluated code, preventing GC. Under bb-mcp's high-volume MCP
+   tool forwarding (every Claude tool call = one nREPL eval), this causes:
+   - 20K+ DynamicClassLoader instances in the heap
+   - GC death spiral as old-gen fills with unreachable classloader graphs
+   - Eventually OOM or sustained full-GC pauses
+
+   Solution:
+   ---------
+   This middleware intercepts session-less eval ops and assigns them to a single
+   shared 'bb-mcp-pooled' session. The shared session reuses one DynamicClassLoader
+   for all bb-mcp evals. Since bb-mcp evals are stateless tool calls (they don't
+   define new classes or need classloader isolation), this is safe.
+
+   Additionally, the shared session's classloader is periodically rotated to allow
+   GC of code compiled in previous cycles. This bounds the maximum classloader
+   retention to one rotation window.
+
+   Tradeoff:
+   ---------
+   - bb-mcp evals share a single classloader -> no per-eval isolation
+   - defn redefinition within bb-mcp evals works (same as normal REPL)
+   - require/import works (delegated to parent classloader)
+   - Normal CIDER sessions are UNAFFECTED (they provide their own :session key)
+
+   Architecture:
+   -------------
+   This middleware sits BEFORE nREPL's session middleware in the stack. When it sees
+   an eval op without a :session, it injects the shared session ID. nREPL's session
+   middleware then finds the existing session instead of creating a new one."
+  (:require [nrepl.middleware :as middleware]
+            [nrepl.transport :as transport]
+            [taoensso.timbre :as log])
+  (:import [clojure.lang DynamicClassLoader]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Shared Session State
+;; =============================================================================
+
+(defonce ^:private shared-session-id
+  (atom nil))
+
+(defonce ^:private session-eval-counter
+  (atom 0))
+
+;; Rotate the shared session after this many evals to bound classloader retention.
+;; Default: 10000 evals. Set to 0 to disable rotation.
+(defonce ^:private classloader-rotation-threshold
+  (atom 10000))
+
+;; =============================================================================
+;; Classloader Counting (for monitoring/testing)
+;; =============================================================================
+
+(defn count-dynamic-classloaders
+  "Count live DynamicClassLoader instances via the current thread's classloader chain.
+   This is an approximation -- actual count requires heap walking.
+   Returns a map with :chain-depth and :thread-context-cl info."
+  []
+  (let [tcl (.getContextClassLoader (Thread/currentThread))]
+    (loop [cl tcl
+           depth 0
+           dcl-count 0]
+      (if (nil? cl)
+        {:chain-depth depth
+         :dynamic-classloader-count dcl-count
+         :thread-context-classloader (str tcl)}
+        (recur (.getParent cl)
+               (inc depth)
+               (if (instance? DynamicClassLoader cl)
+                 (inc dcl-count)
+                 dcl-count))))))
+
+;; =============================================================================
+;; Session Rotation
+;; =============================================================================
+
+(defn- should-rotate?
+  "Check if the shared session should be rotated based on eval count.
+   Returns true if threshold > 0 and counter exceeds threshold."
+  []
+  (let [threshold @classloader-rotation-threshold]
+    (and (pos? threshold)
+         (>= @session-eval-counter threshold))))
+
+(defn- rotate-session!
+  "Force rotation of the shared session by clearing the session ID.
+   The next eval will trigger nREPL's session middleware to create a new session,
+   which becomes the new shared session. The old session (and its classloader)
+   becomes eligible for GC once all in-flight evals complete."
+  []
+  (let [old-id @shared-session-id]
+    (reset! shared-session-id nil)
+    (reset! session-eval-counter 0)
+    (log/info "Rotated bb-mcp shared nREPL session"
+              {:old-session-id old-id
+               :classloader-info (count-dynamic-classloaders)})))
+
+;; =============================================================================
+;; Middleware Implementation
+;; =============================================================================
+
+(defn wrap-shared-classloader
+  "nREPL middleware that pins session-less evals to a shared session.
+
+   When an eval op arrives WITHOUT a :session key (the bb-mcp pattern):
+   1. If we have a shared session ID, inject it into the request
+   2. If not, let nREPL create a new session and capture its ID from the response
+   3. Periodically rotate the shared session to bound classloader retention
+
+   Evals WITH a :session key (CIDER, normal REPL) pass through untouched."
+  [handler]
+  (fn [{:keys [op session] :as msg}]
+    (if (and (= op "eval") (nil? session))
+      ;; Session-less eval: bb-mcp tool forwarding path
+      (let [current-shared @shared-session-id]
+        (if current-shared
+          ;; Reuse existing shared session
+          (do
+            (swap! session-eval-counter inc)
+            ;; Check rotation after incrementing
+            (when (should-rotate?)
+              (rotate-session!))
+            ;; Inject the shared session ID into the request.
+            ;; nREPL's session middleware will find this existing session
+            ;; instead of creating a new one (and a new classloader).
+            (handler (assoc msg :session current-shared)))
+
+          ;; No shared session yet -- let nREPL create one, capture the ID
+          ;; Wrap the transport to intercept the response and capture session ID.
+          (let [original-transport (:transport msg)
+                capturing-transport (reify transport/Transport
+                                      (recv [_] (transport/recv original-transport))
+                                      (recv [_ timeout] (transport/recv original-transport timeout))
+                                      (send [_ response]
+                                        ;; Capture the session ID from the first response
+                                        (when-let [new-session (:session response)]
+                                          (when (compare-and-set! shared-session-id nil new-session)
+                                            (reset! session-eval-counter 1)
+                                            (log/info "Pinned bb-mcp shared nREPL session"
+                                                      {:session-id new-session})))
+                                        (transport/send original-transport response)))]
+            (handler (assoc msg :transport capturing-transport)))))
+
+      ;; Non-eval op or has explicit session: pass through unmodified
+      (handler msg))))
+
+;; =============================================================================
+;; Middleware Descriptor (for nREPL middleware resolution)
+;; =============================================================================
+
+(middleware/set-descriptor! #'wrap-shared-classloader
+                            {:requires #{}
+                             :expects #{"eval" "session"}
+                             :handles {}})
+
+;; =============================================================================
+;; Configuration API
+;; =============================================================================
+
+(defn set-rotation-threshold!
+  "Set the eval count threshold for shared session rotation.
+   Set to 0 to disable rotation (shared session lives forever).
+   Default: 10000."
+  [n]
+  (reset! classloader-rotation-threshold n)
+  (log/info "Set classloader rotation threshold to" n))
+
+(defn status
+  "Get current shared session status for monitoring."
+  []
+  {:shared-session-id @shared-session-id
+   :eval-count @session-eval-counter
+   :rotation-threshold @classloader-rotation-threshold
+   :classloader-info (count-dynamic-classloaders)})
+
+(defn force-rotate!
+  "Force immediate rotation of the shared session.
+   Useful for manual GC pressure relief."
+  []
+  (rotate-session!)
+  (status))
+
+(comment
+  ;; Monitor classloader status
+  (status)
+
+  ;; Force rotation when heap pressure is high
+  (force-rotate!)
+
+  ;; Disable rotation (single classloader forever)
+  (set-rotation-threshold! 0)
+
+  ;; Count classloaders in the chain
+  (count-dynamic-classloaders))

--- a/src/hive_mcp/protocols/vessel.clj
+++ b/src/hive_mcp/protocols/vessel.clj
@@ -1,0 +1,117 @@
+(ns hive-mcp.protocols.vessel
+  "Protocol definitions for host environment vessels.
+
+   A vessel abstracts the headed environment (Emacs, tmux, VS Code, web UI)
+   behind a formal protocol. Vessels provide terminals, editors, delivery
+   channels, REPLs, and — critically — agent context resolution.
+
+   Pattern: Registry (like delivery_channel.clj).
+   Multiple vessels can be active simultaneously (Emacs + tmux, Emacs + Web UI).
+
+   Key addition over ad-hoc context resolution: `resolve-context` gives each
+   vessel ownership of the agent-to-context mapping, replacing implicit fallbacks
+   in messaging.clj and routes.clj.")
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;;; ============================================================================
+;;; IVessel Protocol
+;;; ============================================================================
+
+(defprotocol IVessel
+  "Host environment providing headed capabilities.
+   A vessel is analogous to a window manager (i3, XMonad) — it provides
+   terminals, editor, grid layout, delivery channels, and REPLs.
+
+   Implementations:
+   - EmacsVessel      (vessel/emacs.clj)
+   - NoopVessel       (this file, fallback)
+   - [future: TmuxVessel, WebUIVessel, VSCodeVessel]"
+
+  (vessel-id [this]
+    "Return keyword identifier. Examples: :emacs, :tmux, :web-ui, :vscode")
+
+  (capabilities [this]
+    "Return set of provided capabilities.
+     #{:terminal :editor :grid :delivery :repl}")
+
+  (resolve-context [this agent-id]
+    "Return {:project-id :cwd :session-id} for the given agent.
+     The vessel knows where its agents live — this replaces ad-hoc
+     ctx/current-directory fallbacks. Returns nil for unknown agents.")
+
+  (addon [this capability]
+    "Return the concrete impl for a capability keyword.
+     :terminal -> ITerminalAddon
+     :editor   -> IEditor
+     :delivery -> IDeliveryChannel
+     :grid     -> IGridManager (future)
+     :repl     -> ICiderSession (future)
+     Returns nil when capability is not available.")
+
+  (initialize! [this config]
+    "Initialize the vessel with configuration map. Called during server init.")
+
+  (shutdown! [this]
+    "Shut down the vessel and release resources."))
+
+;;; ============================================================================
+;;; Vessel Registry (Multiple Active Vessels)
+;;; ============================================================================
+
+(defonce ^:private vessel-registry (atom {})) ;; vessel-id -> IVessel
+
+(defn register-vessel!
+  "Register a vessel. Replaces any existing vessel with same id."
+  [vessel]
+  {:pre [(satisfies? IVessel vessel)]}
+  (swap! vessel-registry assoc (vessel-id vessel) vessel)
+  vessel)
+
+(defn unregister-vessel!
+  "Unregister a vessel by id."
+  [id]
+  (swap! vessel-registry dissoc id)
+  nil)
+
+(defn get-vessel
+  "Get a specific vessel by id, or nil."
+  [id]
+  (get @vessel-registry id))
+
+(defn get-vessels
+  "Get all registered vessels as a seq."
+  []
+  (vals @vessel-registry))
+
+(defn clear-vessels!
+  "Clear all registered vessels."
+  []
+  (reset! vessel-registry {}))
+
+(defn resolve-agent-context
+  "Query all registered vessels for agent context.
+   First vessel that returns non-nil wins.
+   Returns {:project-id :cwd :session-id} or nil."
+  [agent-id]
+  (some #(resolve-context % agent-id) (get-vessels)))
+
+;;; ============================================================================
+;;; NoopVessel (Fallback)
+;;; ============================================================================
+
+(defrecord NoopVessel []
+  IVessel
+  (vessel-id [_] :noop)
+  (capabilities [_] #{})
+  (resolve-context [_ _] nil)
+  (addon [_ _] nil)
+  (initialize! [_ _] nil)
+  (shutdown! [_] nil))
+
+(defn noop-vessel
+  "Create a no-op vessel fallback."
+  []
+  (->NoopVessel))

--- a/src/hive_mcp/scheduler/housekeeping.clj
+++ b/src/hive_mcp/scheduler/housekeeping.clj
@@ -10,7 +10,8 @@
    - Completed multi-async batches
    - Event journal old entries
    - Completed SAA states
-   - Drone KG stores for dead drones"
+   - Drone KG stores for dead drones
+   - Bounded atom GC sweep (TTL + capacity eviction)"
   (:require [hive-mcp.dns.result :as result]
             [hive-mcp.config.core :as config]
             [taoensso.timbre :as log])
@@ -78,14 +79,48 @@
          'hive-mcp.agent.saa.orchestrator/clear-completed-states!
          #(%) {:cleaned 0})
 
+        ;; 5. Bounded atom GC sweep
+        ;; Evicts TTL-expired and over-capacity entries from all registered
+        ;; bounded atoms. Prevents GC death spiral from unbounded atom growth.
+        gc-sweep-result
+        (resolve-and-call
+         'hive-mcp.gc.bounded-atom/sweep-all!
+         #(%) {:total-evicted 0 :atom-count 0 :duration-ms 0})
+
+        ;; 6. JVM GC hint — nudge G1GC to collect old gen.
+        ;; G1GC with MaxGCPauseMillis=200 avoids full GC cycles, so old gen
+        ;; fills with long-lived garbage. Periodic hint prevents 97%+ old gen.
+        gc-hint-result
+        (try
+          (let [runtime (Runtime/getRuntime)
+                before-mb (/ (- (.totalMemory runtime) (.freeMemory runtime)) 1048576.0)]
+            (.gc runtime)
+            (let [after-mb (/ (- (.totalMemory runtime) (.freeMemory runtime)) 1048576.0)
+                  freed-mb (- before-mb after-mb)]
+              {:freed-mb (Math/round freed-mb) :before-mb (Math/round before-mb)}))
+          (catch Exception _ {:freed-mb 0}))
+
         elapsed-ms (- (System/currentTimeMillis) start-ms)
         result {:callbacks callback-result
                 :async-batches async-result
                 :event-journal journal-result
                 :saa-states saa-result
+                :gc-sweep gc-sweep-result
+                :gc-hint gc-hint-result
                 :sweep-number sweep-num
                 :duration-ms elapsed-ms
                 :timestamp (java.time.Instant/now)}]
+
+    ;; Log GC sweep stats at info level when entries were evicted
+    (when (pos? (get gc-sweep-result :total-evicted 0))
+      (log/info "Housekeeping: GC sweep evicted"
+                (:total-evicted gc-sweep-result) "entries from"
+                (:atom-count gc-sweep-result) "atoms"))
+
+    ;; Log GC hint results when significant memory was freed
+    (when (> (get gc-hint-result :freed-mb 0) 50)
+      (log/info "Housekeeping: GC hint freed" (:freed-mb gc-hint-result) "MB"
+                "(before:" (:before-mb gc-hint-result) "MB)"))
 
     ;; Update state
     (swap! scheduler-state assoc

--- a/src/hive_mcp/server/core.clj
+++ b/src/hive_mcp/server/core.clj
@@ -101,6 +101,8 @@
     ;; Must run AFTER embedding/memory (extensions may use Chroma).
     ;; Must run BEFORE workflow engine (handlers may use extensions).
     ;; hive-claude auto-discovered here via META-INF manifest (registers :claude terminal)
+    ;; NOTE: Addons self-register capabilities during initialize! lifecycle.
+    ;; E.g. hive-emacs registers EmacsVessel in IVessel registry here.
     (init/load-extensions!)
 
     ;; Phase 5: Channels + Sync
@@ -134,8 +136,13 @@
 
     ;; Phase 6.5: Decay Scheduler (periodic memory/edge/disc decay)
     ;; Must run after config loaded (Phase 5.5) and embedding provider (Phase 4).
-    ;; Daemon thread — dies with JVM, no explicit shutdown needed.
+    ;; Daemon thread -- dies with JVM, no explicit shutdown needed.
     (init/start-decay-scheduler!)
+
+    ;; Phase 6.6: Housekeeping Scheduler (gc-fix-5: periodic GC sweep + cleanup)
+    ;; Runs bounded atom GC sweep + stale resource cleanup every 5 minutes.
+    ;; Daemon thread -- dies with JVM. Also stoppable via init/stop-housekeeping-scheduler!
+    (init/start-housekeeping-scheduler!)
 
     ;; Phase 7: Start MCP server (must be last - blocks on stdio)
     ;; NOTE: routes/build-server-spec must be called AFTER init-embedding-provider!

--- a/src/hive_mcp/server/init.clj
+++ b/src/hive_mcp/server/init.clj
@@ -10,7 +10,8 @@
    - Coordinator registration in DataScript
    - Memory store wiring (IMemoryStore protocol)
    - Channel bridge + swarm sync + registry sync
-   - decay scheduler (periodic memory/edge/disc decay)"
+   - decay scheduler (periodic memory/edge/disc decay)
+   - housekeeping scheduler (periodic GC sweep + stale resource cleanup)"
   (:require [hive-mcp.chroma.core :as chroma]
             [hive-mcp.channel.websocket :as ws-channel]
             [hive-mcp.dns.result :as result]
@@ -296,7 +297,7 @@
 
 (defn start-swarm-sync!
   "Start swarm sync - bridges channel events to logic database.
-   This enables: task-completed → release claims → process queue."
+   This enables: task-completed -> release claims -> process queue."
   []
   (result/rescue nil
                  (sync/start-sync!)
@@ -355,6 +356,7 @@
                  (log/info "Lings registry sync started - lings_available will track elisp lings")))
 
 ;; =============================================================================
+;; Decay Scheduler
 ;; =============================================================================
 
 (defn start-decay-scheduler!
@@ -386,12 +388,43 @@
                    (stop-fn))))
 
 ;; =============================================================================
+;; Housekeeping Scheduler (gc-fix-5)
+;; =============================================================================
+
+(defn start-housekeeping-scheduler!
+  "Start the periodic housekeeping scheduler (gc-fix-5).
+   Runs bounded atom GC sweep + stale resource cleanup every 5 minutes.
+
+   Configure via config.edn :services :housekeeping:
+     {:enabled true :interval-minutes 5}
+
+   Non-fatal: if scheduler fails to start, system continues without it.
+   GC sweep still runs on session wrap/complete as before."
+  []
+  (result/rescue nil
+                 (require 'hive-mcp.scheduler.housekeeping)
+                 (let [start-fn (resolve 'hive-mcp.scheduler.housekeeping/start!)]
+                   (when start-fn
+                     (let [result (start-fn)]
+                       (if (:started result)
+                         (log/info "Housekeeping scheduler started:" result)
+                         (log/info "Housekeeping scheduler not started:" (:reason result))))))))
+
+(defn stop-housekeeping-scheduler!
+  "Stop the periodic housekeeping scheduler. Called during shutdown."
+  []
+  (result/rescue nil
+                 (require 'hive-mcp.scheduler.housekeeping)
+                 (when-let [stop-fn (resolve 'hive-mcp.scheduler.housekeeping/stop!)]
+                   (stop-fn))))
+
+;; =============================================================================
 ;; NATS Initialization
 ;; =============================================================================
 
 (defn init-nats!
   "Initialize NATS client + bridge + backbone + delivery channels for universal event backbone.
-   Startup sequence: NATS connect → set IEventBackbone → register delivery channels → bridge subscribe → callback listener.
+   Startup sequence: NATS connect -> set IEventBackbone -> register delivery channels -> bridge subscribe -> callback listener.
    Opt-in via config: services.nats.enabled = true.
    Non-fatal: system degrades to NoopBackbone + polling if NATS unavailable."
   []
@@ -431,7 +464,7 @@
     (when-let [register! (resolve 'hive-mcp.workflows.forge-belt-defaults/register-forge-belt-defaults!)]
       (register!))
     (catch Throwable e
-      (log/warn "register-forge-belt-defaults! failed — forge-belt extension points will return noop:"
+      (log/warn "register-forge-belt-defaults! failed -- forge-belt extension points will return noop:"
                 (.getMessage e)))))
 
 ;; =============================================================================

--- a/src/hive_mcp/server/routes.clj
+++ b/src/hive_mcp/server/routes.clj
@@ -148,13 +148,24 @@
 
    Key priority:
    1. Explicit project_id/project-id
-   2. Derived from directory parameter via scope/get-current-project-id
-   3. Derived from _caller_cwd (bb-mcp's cwd, injected per-request)
-   4. Derived from ctx/current-directory (request context fallback)
-   5. Derived from server's working directory (System/getProperty user.dir)"
+   2. IVessel resolution (vessel owns agent-to-context mapping)
+   3. Derived from directory parameter via scope/get-current-project-id
+   4. Derived from _caller_cwd (bb-mcp's cwd, injected per-request)
+   5. Derived from ctx/current-directory (request context fallback)
+   6. Derived from server's working directory (System/getProperty user.dir)"
   [args]
   (or (:project_id args)
       (:project-id args)
+      ;; IVessel resolution: query vessels for agent context (formal project-id source)
+      (when-let [agent-id (or (:agent_id args) (:agent-id args) (:_caller_id args))]
+        (ctx/request-memoize
+         [:vessel-project-id agent-id]
+         (fn []
+           (try
+             (require 'hive-mcp.protocols.vessel)
+             (when-let [resolve-fn (resolve 'hive-mcp.protocols.vessel/resolve-agent-context)]
+               (:project-id (resolve-fn agent-id)))
+             (catch Exception _ nil)))))
       ;; Derive from directory if present, with caller-cwd, ctx and user.dir fallbacks
       (when-let [dir (or (:directory args)
                          (:_caller_cwd args)

--- a/src/hive_mcp/server/routes.clj
+++ b/src/hive_mcp/server/routes.clj
@@ -142,9 +142,9 @@
    Returns nil only if no project context available anywhere.
 
    Uses request-level memoization for the expensive scope lookup
-   (require + resolve + .hive-project.edn read). This is called 4x per
-   request (context + 3 piggyback wrappers) with identical args — the
-   cache eliminates 3 redundant scope lookups.
+   (require + resolve + .hive-project.edn read). This is called 5x per
+   request (context + 4 piggyback wrappers) with identical args — the
+   cache eliminates 4 redundant scope lookups.
 
    Key priority:
    1. Explicit project_id/project-id
@@ -156,16 +156,19 @@
   [args]
   (or (:project_id args)
       (:project-id args)
-      ;; IVessel resolution: query vessels for agent context (formal project-id source)
+      ;; IVessel resolution: query vessels for agent context (formal project-id source).
+      ;; Skip bare "coordinator" — it's a generic fallback, not a real agent ID.
+      ;; Vessels return the server's own project for it, poisoning piggyback keys.
       (when-let [agent-id (or (:agent_id args) (:agent-id args) (:_caller_id args))]
-        (ctx/request-memoize
-         [:vessel-project-id agent-id]
-         (fn []
-           (try
-             (require 'hive-mcp.protocols.vessel)
-             (when-let [resolve-fn (resolve 'hive-mcp.protocols.vessel/resolve-agent-context)]
-               (:project-id (resolve-fn agent-id)))
-             (catch Exception _ nil)))))
+        (when-not (= agent-id "coordinator")
+          (ctx/request-memoize
+           [:vessel-project-id agent-id]
+           (fn []
+             (try
+               (require 'hive-mcp.protocols.vessel)
+               (when-let [resolve-fn (resolve 'hive-mcp.protocols.vessel/resolve-agent-context)]
+                 (:project-id (resolve-fn agent-id)))
+               (catch Exception _ nil))))))
       ;; Derive from directory if present, with caller-cwd, ctx and user.dir fallbacks
       (when-let [dir (or (:directory args)
                          (:_caller_cwd args)
@@ -236,8 +239,8 @@
    string keys, but handlers expect keyword keys for destructuring).
 
    Binds *request-cache* BEFORE extracting project-id so the first
-   extract-project-id call is cached for the 3 subsequent calls in
-   the piggyback wrappers (memory, hivemind, async).
+   extract-project-id call is cached for the 4 subsequent calls in
+   the piggyback wrappers (memory, catchup, hivemind, async).
 
    Extracts agent-id, project-id, directory from args and binds
    them via hive-mcp.agent.context/with-request-context.
@@ -264,7 +267,7 @@
     ;; Keywordize args to handle both MCP (string keys) and direct calls (keyword keys)
     (let [args (walk/keywordize-keys args)]
       ;; Bind request cache FIRST so extract-project-id's result is cached
-      ;; for the 3 subsequent piggyback wrappers (saves 3x require+resolve+scope-lookup)
+      ;; for the 4 subsequent piggyback wrappers (saves 4x require+resolve+scope-lookup)
       (binding [ctx/*request-cache* (atom {})]
         (let [agent-id (extract-agent-id args nil)
               project-id (extract-project-id args)
@@ -344,6 +347,41 @@
                      caller-id)
           drain-result (drain-memory-piggyback agent-id project-id)]
       (wrap-memory-piggyback-content content drain-result))))
+
+(defn wrap-handler-catchup-piggyback
+  "Wrap handler to drain hive-knowledge catchup blocks as separate delimiter tags.
+   SRP: Single responsibility - catchup enrichment piggyback delivery only.
+
+   Drains categorized catchup blocks (synthesis, kg-insights, context) queued
+   by the enrichment addon during catchup. Each non-nil category becomes a
+   separate delimited block (---SYNTHESIS---, ---KG-INSIGHTS---, ---CONTEXT---).
+
+   Zero-cost when no blocks pending or extension not registered.
+
+   CURSOR ISOLATION: Uses _caller_id for per-caller alignment with catchup enqueue."
+  [handler]
+  (fn [args]
+    (let [content (handler args)]
+      (if-let [drain-fn (ext/get-extension :cu/piggyback-drain)]
+        (let [project-id (extract-project-id args)
+              caller-id (extract-caller-id args)
+              agent-id (if project-id
+                         (str caller-id "-" project-id)
+                         caller-id)
+              blocks (try (drain-fn agent-id project-id)
+                          (catch Exception e
+                            (log/debug "catchup-piggyback drain failed:" (.getMessage e))
+                            nil))]
+          (if (seq blocks)
+            (reduce-kv
+             (fn [c tag body]
+               (wrap-delimited-block c
+                                     (clojure.string/upper-case (name tag))
+                                     (if (string? body) body (pr-str body))))
+             content
+             blocks)
+            content))
+        content))))
 
 (defn wrap-handler-piggyback
   "Wrap handler to attach hivemind piggyback messages.
@@ -501,22 +539,23 @@
    - wrap-handler-compress: compact:true → compress JSON text (strip verbose fields)
    - wrap-handler-async-piggyback: drains async results (completed futures)
    - wrap-handler-memory-piggyback: drains memory entries (axioms, conventions)
+   - wrap-handler-catchup-piggyback: drains catchup enrichment blocks (synthesis, kg-insights, context)
    - wrap-handler-piggyback: embeds hivemind messages with agent-id extraction
    - wrap-handler-context: binds request context for tool execution
    - wrap-handler-response: builds {:content ...} response
 
    Composition via -> threading enables clear data flow:
-   handler -> retry -> async-intercept -> normalize -> compress -> async-piggyback -> memory-piggyback -> hivemind-piggyback -> context -> response
+   handler -> retry -> async-intercept -> normalize -> compress -> async-piggyback -> memory-piggyback -> catchup-piggyback -> hivemind-piggyback -> context -> response
 
    The async interceptor sits AFTER retry (so it can retry on hot-reload errors)
    but BEFORE normalize (so the ack [{:type text}] passes through the piggyback chain).
 
-   Memory/async/hivemind piggybacks all run in parallel, each appending
+   Memory/async/catchup/hivemind piggybacks all run in parallel, each appending
    their own delimited blocks to content independently.
 
    REQUEST-LEVEL MEMOIZATION: context wrapper binds *request-cache* (atom {})
    before any work. extract-project-id uses ctx/request-memoize to cache its
-   expensive scope lookup — called 4x per request (context + 3 piggyback
+   expensive scope lookup — called 5x per request (context + 4 piggyback
    wrappers) but computed only once. Handlers can also use request-memoize
    for their own per-request caching needs.
 
@@ -537,6 +576,7 @@
                           wrap-handler-compress           ; compact: true → compress JSON text
                           wrap-handler-async-piggyback    ; async results channel
                           wrap-handler-memory-piggyback   ; memory channel (needs ctx bound)
+                          wrap-handler-catchup-piggyback  ; catchup enrichment channel
                           wrap-handler-piggyback          ; hivemind channel (needs ctx bound)
                           wrap-handler-context            ; binds ctx for all piggybacks
                           wrap-handler-response)}

--- a/src/hive_mcp/server/routes.clj
+++ b/src/hive_mcp/server/routes.clj
@@ -365,13 +365,8 @@
       (wrap-memory-piggyback-content content drain-result))))
 
 (defn wrap-handler-catchup-piggyback
-  "Wrap handler to drain hive-knowledge catchup blocks as separate delimiter tags.
-   SRP: Single responsibility - catchup enrichment piggyback delivery only.
-
-   Drains categorized catchup blocks (synthesis, kg-insights, context) queued
-   by the enrichment addon during catchup. Each non-nil category becomes a
-   separate delimited block (---SYNTHESIS---, ---KG-INSIGHTS---, ---CONTEXT---).
-
+  "Drain addon piggyback blocks as separate delimiter tags.
+   Results arrive via piggyback on subsequent calls.
    Zero-cost when no blocks pending or extension not registered.
 
    CURSOR ISOLATION: Uses _caller_id for per-caller alignment with catchup enqueue."

--- a/src/hive_mcp/server/routes.clj
+++ b/src/hive_mcp/server/routes.clj
@@ -17,6 +17,7 @@
             [hive-mcp.dsl.response :as compress]
             [hive-mcp.extensions.registry :as ext]
             [hive-mcp.addons.core :as addons]
+            [hive-dsl.context.identity :as ctx-id]
             [taoensso.timbre :as log]
             [clojure.spec.alpha :as s]
             [clojure.walk :as walk]))
@@ -181,6 +182,22 @@
            ((resolve 'hive-mcp.tools.memory.scope/get-current-project-id) dir))))))
 
 ;; =============================================================================
+;; ADT-Based Identity Extraction
+;; =============================================================================
+
+(defn extract-caller-identity
+  "Extract CallerId ADT from MCP args.
+   Wraps extract-caller-id with ADT coercion."
+  [args]
+  (ctx-id/parse-caller-id (:_caller_id args)))
+
+(defn extract-project-scope
+  "Extract ProjectScope ADT from MCP args.
+   Wraps existing extract-project-id with ADT coercion."
+  [args]
+  (ctx-id/parse-project-scope (extract-project-id args)))
+
+;; =============================================================================
 ;; Composable Handler Wrappers (SRP: Each wrapper single responsibility)
 ;; =============================================================================
 
@@ -340,11 +357,10 @@
   [handler]
   (fn [args]
     (let [content (handler args)
-          project-id (extract-project-id args)
-          caller-id (extract-caller-id args)
-          agent-id (if project-id
-                     (str caller-id "-" project-id)
-                     caller-id)
+          caller (extract-caller-identity args)
+          scope (extract-project-scope args)
+          agent-id (ctx-id/make-piggyback-agent-id caller scope)
+          project-id (ctx-id/project-scope-string scope)
           drain-result (drain-memory-piggyback agent-id project-id)]
       (wrap-memory-piggyback-content content drain-result))))
 
@@ -363,11 +379,10 @@
   (fn [args]
     (let [content (handler args)]
       (if-let [drain-fn (ext/get-extension :cu/piggyback-drain)]
-        (let [project-id (extract-project-id args)
-              caller-id (extract-caller-id args)
-              agent-id (if project-id
-                         (str caller-id "-" project-id)
-                         caller-id)
+        (let [caller (extract-caller-identity args)
+              scope (extract-project-scope args)
+              agent-id (ctx-id/make-piggyback-agent-id caller scope)
+              project-id (ctx-id/project-scope-string scope)
               blocks (try (drain-fn agent-id project-id)
                           (catch Exception e
                             (log/debug "catchup-piggyback drain failed:" (.getMessage e))
@@ -401,11 +416,10 @@
   [handler]
   (fn [args]
     (let [content (handler args)
-          project-id (extract-project-id args)
-          caller-id (extract-caller-id args)
-          agent-id (if project-id
-                     (str caller-id "-" project-id)
-                     caller-id)
+          caller (extract-caller-identity args)
+          scope (extract-project-scope args)
+          agent-id (ctx-id/make-piggyback-agent-id caller scope)
+          project-id (ctx-id/project-scope-string scope)
           piggyback (get-piggyback-messages agent-id project-id)]
       (wrap-piggyback content piggyback))))
 
@@ -428,12 +442,10 @@
   (fn [args]
     (if (:async args)
       (let [task-id (str "atask-" (random-uuid))
-            project-id (extract-project-id args)
-            caller-id (extract-caller-id args)
-            ;; Use caller identity for buffer key alignment with drain wrapper.
-            agent-id (if project-id
-                       (str caller-id "-" project-id)
-                       caller-id)]
+            caller (extract-caller-identity args)
+            scope (extract-project-scope args)
+            agent-id (ctx-id/make-piggyback-agent-id caller scope)
+            project-id (ctx-id/project-scope-string scope)]
         ;; Spawn background execution
         (future
           (try
@@ -480,11 +492,10 @@
   [handler]
   (fn [args]
     (let [content (handler args)
-          project-id (extract-project-id args)
-          caller-id (extract-caller-id args)
-          agent-id (if project-id
-                     (str caller-id "-" project-id)
-                     caller-id)
+          caller (extract-caller-identity args)
+          scope (extract-project-scope args)
+          agent-id (ctx-id/make-piggyback-agent-id caller scope)
+          project-id (ctx-id/project-scope-string scope)
           drain-result (async-buf/drain! agent-id project-id)]
       (wrap-delimited-block content "TOOLRESULT"
                             (when drain-result (pr-str drain-result))))))

--- a/src/hive_mcp/server/transport.clj
+++ b/src/hive_mcp/server/transport.clj
@@ -10,6 +10,7 @@
    - Olympus WebSocket server (Olympus Web UI)
    - Legacy TCP channel (deprecated, backward compat)"
   (:require [nrepl.server :as nrepl-server]
+            [hive-mcp.nrepl.classloader-gc :as classloader-gc]
             [hive-mcp.config.core :as config]
             [hive-mcp.dns.result :as result]
             [hive-mcp.transport.websocket :as ws]
@@ -44,14 +45,19 @@
                                              :env "HIVE_MCP_NREPL_PORT"
                                              :parse parse-long
                                              :default 7910)
-        middleware (try
-                     (require 'cider.nrepl)
-                     (let [mw-var (resolve 'cider.nrepl/cider-middleware)]
-                       (when mw-var @mw-var))
-                     (catch Exception _ nil))
-        handler (if (seq middleware)
-                  (apply nrepl-server/default-handler middleware)
-                  (nrepl-server/default-handler))
+        ;; GC-fix-6: Collect CIDER middleware, then prepend classloader-gc middleware.
+        ;; wrap-shared-classloader pins session-less evals (bb-mcp pattern) to a
+        ;; shared session, preventing DynamicClassLoader proliferation. It must be
+        ;; outermost (first in the middleware vector) so it intercepts before
+        ;; nREPL's session middleware creates a new session per eval.
+        cider-mw (try
+                    (require 'cider.nrepl)
+                    (let [mw-var (resolve 'cider.nrepl/cider-middleware)]
+                      (when mw-var @mw-var))
+                    (catch Exception _ nil))
+        all-middleware (into [#'classloader-gc/wrap-shared-classloader]
+                             (or cider-mw []))
+        handler (apply nrepl-server/default-handler all-middleware)
         server-opts {:port nrepl-port :bind "127.0.0.1" :handler handler}
         max-retries 5
         retry-delay-ms 2000]
@@ -60,7 +66,7 @@
                      (let [server (nrepl-server/start-server server-opts)]
                        (reset! nrepl-server-atom server)
                        (log/info "Embedded nREPL started on port" nrepl-port
-                                 (if middleware "(with CIDER middleware)" "(basic)")
+                                 (if (seq cider-mw) "(with CIDER + classloader-gc middleware)" "(with classloader-gc middleware)")
                                  (when (> attempt 1) (str "(attempt " attempt ")")))
                        server)
                      (catch java.net.BindException e

--- a/src/hive_mcp/telemetry/bounded_atom_metrics.clj
+++ b/src/hive_mcp/telemetry/bounded_atom_metrics.clj
@@ -1,0 +1,349 @@
+(ns hive-mcp.telemetry.bounded-atom-metrics
+  "Prometheus metrics for bounded atoms (gc-fix-7).
+
+   Provides observability into bounded atom sizes, eviction rates,
+   and sweep stats exposed via the existing Prometheus infrastructure.
+
+   Metrics:
+   - Gauge:     hive_bounded_atom_entries{name=\"X\"}     — current entry count
+   - Gauge:     hive_bounded_atom_capacity{name=\"X\"}    — max-entries config
+   - Counter:   hive_bounded_atom_evictions_total{name=\"X\", reason=\"ttl|capacity\"}
+   - Gauge:     hive_bounded_atom_utilization{name=\"X\"} — entries/capacity (0.0-1.0)
+   - Counter:   hive_lifecycle_sweep_total                — number of sweeps run
+   - Gauge:     hive_lifecycle_sweep_last_evicted         — evictions in last sweep
+   - Histogram: hive_lifecycle_sweep_duration_seconds     — sweep latency
+
+   Usage:
+     (require '[hive-mcp.telemetry.bounded-atom-metrics :as bam])
+
+     ;; Create an instrumented bounded atom
+     (def store (bam/instrumented-bounded-atom
+                  {:max-entries 1000 :ttl-ms 300000 :name \"task-cache\"}))
+
+     ;; Or instrument an existing one
+     (bam/instrument! my-existing-batom \"my-store\")
+
+     ;; Metrics auto-update on bput!/sweep! via callbacks"
+  (:require [iapetos.core :as prometheus]
+            [iapetos.export :as export]
+            [hive-dsl.bounded-atom :as ba]
+            [taoensso.timbre :as log]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+
+;; =============================================================================
+;; Metric names (following existing convention: namespace-qualified keywords)
+;; =============================================================================
+
+(def ^:private entries-name       :hive-bounded-atom/entries)
+(def ^:private capacity-name      :hive-bounded-atom/capacity)
+(def ^:private evictions-name     :hive-bounded-atom/evictions-total)
+(def ^:private utilization-name   :hive-bounded-atom/utilization)
+(def ^:private sweep-total-name   :hive-lifecycle/sweep-total)
+(def ^:private sweep-evicted-name :hive-lifecycle/sweep-last-evicted)
+(def ^:private sweep-duration-name :hive-lifecycle/sweep-duration-seconds)
+
+;; =============================================================================
+;; Collector definitions
+;; =============================================================================
+
+(def ^:private entries-collector
+  (prometheus/gauge
+   entries-name
+   {:description "Current entry count per bounded atom"
+    :labels [:name]}))
+
+(def ^:private capacity-collector
+  (prometheus/gauge
+   capacity-name
+   {:description "Max entries capacity per bounded atom"
+    :labels [:name]}))
+
+(def ^:private evictions-collector
+  (prometheus/counter
+   evictions-name
+   {:description "Cumulative evictions per bounded atom by reason"
+    :labels [:name :reason]}))
+
+(def ^:private utilization-collector
+  (prometheus/gauge
+   utilization-name
+   {:description "Utilization ratio (entries/capacity) per bounded atom, 0.0-1.0"
+    :labels [:name]}))
+
+(def ^:private sweep-total-collector
+  (prometheus/counter
+   sweep-total-name
+   {:description "Total number of sweeps executed"}))
+
+(def ^:private sweep-evicted-collector
+  (prometheus/gauge
+   sweep-evicted-name
+   {:description "Number of entries evicted in the last sweep"}))
+
+(def ^:private sweep-duration-collector
+  (prometheus/histogram
+   sweep-duration-name
+   {:description "Sweep execution duration distribution"
+    :buckets [0.0001 0.0005 0.001 0.005 0.01 0.05 0.1 0.5 1.0]}))
+
+;; =============================================================================
+;; Registry — separate from main prometheus registry to avoid coupling
+;; =============================================================================
+
+(defonce registry
+  (delay
+    (-> (prometheus/collector-registry)
+        (prometheus/register
+         entries-collector
+         capacity-collector
+         evictions-collector
+         utilization-collector
+         sweep-total-collector
+         sweep-evicted-collector
+         sweep-duration-collector))))
+
+;; =============================================================================
+;; Helpers
+;; =============================================================================
+
+(defn- reason->str
+  "Convert a reason keyword to a Prometheus-safe label string.
+   :capacity -> \"capacity\", :ttl -> \"ttl\", nil -> \"unknown\"."
+  [reason]
+  (if (keyword? reason)
+    (name reason)
+    (str (or reason "unknown"))))
+
+(defn- name->str
+  "Convert a name (keyword or string) to a Prometheus label string.
+   :my-store -> \"my-store\", \"my-store\" -> \"my-store\"."
+  [n]
+  (if (keyword? n)
+    (name n)
+    (str n)))
+
+;; =============================================================================
+;; Metric update functions
+;; =============================================================================
+
+(defn set-entries!
+  "Set current entry count gauge for a bounded atom."
+  [atom-name entries]
+  (prometheus/set
+   (@registry entries-name {:name (name->str atom-name)})
+   entries))
+
+(defn set-capacity!
+  "Set capacity gauge for a bounded atom."
+  [atom-name capacity]
+  (prometheus/set
+   (@registry capacity-name {:name (name->str atom-name)})
+   capacity))
+
+(defn inc-evictions!
+  "Increment eviction counter for a bounded atom.
+   reason: :ttl, :capacity, or :ttl+capacity"
+  [atom-name count reason]
+  (when (and count (pos? count))
+    (let [n (name->str atom-name)]
+      ;; Split ttl+capacity into individual reason counters
+      (case reason
+        :ttl+capacity
+        (do
+          (prometheus/inc
+           (@registry evictions-name {:name n :reason "ttl"})
+           count)
+          (prometheus/inc
+           (@registry evictions-name {:name n :reason "capacity"})
+           count))
+        ;; Single reason
+        (prometheus/inc
+         (@registry evictions-name {:name n :reason (reason->str reason)})
+         count)))))
+
+(defn set-utilization!
+  "Set utilization gauge for a bounded atom."
+  [atom-name entries capacity]
+  (let [ratio (if (pos? capacity)
+                (/ (double entries) (double capacity))
+                0.0)]
+    (prometheus/set
+     (@registry utilization-name {:name (name->str atom-name)})
+     ratio)))
+
+(defn inc-sweep-total!
+  "Increment the sweep counter."
+  []
+  (prometheus/inc (@registry sweep-total-name)))
+
+(defn set-sweep-last-evicted!
+  "Set the last sweep evicted count gauge."
+  [n]
+  (prometheus/set (@registry sweep-evicted-name) n))
+
+(defn observe-sweep-duration!
+  "Observe sweep duration in seconds."
+  [seconds]
+  (when seconds
+    (prometheus/observe (@registry sweep-duration-name) seconds)))
+
+;; =============================================================================
+;; Callback factories — create on-evict/on-sweep callbacks for bounded atoms
+;; =============================================================================
+
+(defn make-on-evict-callback
+  "Create an :on-evict callback that updates Prometheus metrics.
+
+   Called after evictions during bput!/bounded-swap!/bounded-reset!
+   with {:name, :evicted-count, :reason, :entries}."
+  [atom-name capacity]
+  (fn [{:keys [evicted-count reason entries]}]
+    (let [n (name->str atom-name)]
+      (inc-evictions! n evicted-count reason)
+      (set-entries! n entries)
+      (set-utilization! n entries capacity))))
+
+(defn make-on-sweep-callback
+  "Create an :on-sweep callback that updates Prometheus metrics.
+
+   Called after sweep! with {:name, :evicted-count, :remaining, :duration-ms}."
+  [atom-name capacity]
+  (fn [{:keys [evicted-count remaining duration-ms]}]
+    (let [n (name->str atom-name)]
+      (inc-sweep-total!)
+      (set-sweep-last-evicted! evicted-count)
+      (when duration-ms
+        (observe-sweep-duration! (/ duration-ms 1000.0)))
+      ;; Update per-atom metrics
+      (set-entries! n remaining)
+      (set-utilization! n remaining capacity)
+      (when (pos? evicted-count)
+        (inc-evictions! n evicted-count :ttl)))))
+
+;; =============================================================================
+;; Instrumented bounded atom constructor
+;; =============================================================================
+
+(defn instrumented-bounded-atom
+  "Create a bounded atom with Prometheus metrics instrumentation built in.
+
+   All standard bounded-atom options are supported, plus:
+     :name — required string name for metrics labels
+
+   Metrics auto-update on every bput!/bounded-swap!/bounded-reset!/sweep!.
+
+   Example:
+     (def store (instrumented-bounded-atom
+                  {:max-entries 1000 :ttl-ms 300000 :name \"task-cache\"}))"
+  [{:keys [max-entries name] :as opts}]
+  (assert (some? name) "instrumented bounded atoms require a :name for metrics labels")
+  (let [capacity max-entries
+        on-evict (make-on-evict-callback name capacity)
+        on-sweep (make-on-sweep-callback name capacity)
+        batom (ba/bounded-atom (assoc opts
+                                      :on-evict on-evict
+                                      :on-sweep on-sweep))]
+    ;; Initialize capacity gauge
+    (set-capacity! name capacity)
+    ;; Initialize entries/utilization at 0
+    (set-entries! name 0)
+    (set-utilization! name 0 capacity)
+    batom))
+
+(defn instrument!
+  "Instrument an existing bounded atom with Prometheus metrics.
+
+   Returns a new bounded atom map with metrics callbacks injected.
+   The underlying atom data is preserved — only callbacks are added.
+
+   atom-name: string name for metrics labels
+   batom: existing bounded atom map
+
+   Example:
+     (def store (ba/bounded-atom {:max-entries 100}))
+     (def instrumented (instrument! store \"my-store\"))"
+  [batom atom-name]
+  (let [capacity (get-in batom [:opts :max-entries])
+        on-evict (make-on-evict-callback atom-name capacity)
+        on-sweep (make-on-sweep-callback atom-name capacity)
+        current-entries (ba/bcount batom)]
+    ;; Initialize gauges
+    (set-capacity! atom-name capacity)
+    (set-entries! atom-name current-entries)
+    (set-utilization! atom-name current-entries capacity)
+    ;; Return augmented batom with callbacks
+    (-> batom
+        (assoc :name atom-name)
+        (assoc-in [:opts :on-evict] on-evict)
+        (assoc-in [:opts :on-sweep] on-sweep))))
+
+;; =============================================================================
+;; Snapshot — poll all registered bounded atoms for current metrics
+;; =============================================================================
+
+(defn snapshot-all!
+  "Poll the sweepable registry and update Prometheus gauges for all
+   registered bounded atoms. Useful for periodic scrape or health checks."
+  []
+  (doseq [[name-kw batom] (ba/registered-sweepables)]
+    (let [n (name->str (or (:name batom) name-kw))
+          entries (ba/bcount batom)
+          capacity (get-in batom [:opts :max-entries])]
+      (set-entries! n entries)
+      (set-capacity! n capacity)
+      (set-utilization! n entries capacity))))
+
+;; =============================================================================
+;; Metrics export
+;; =============================================================================
+
+(defn metrics-response
+  "Export bounded atom metrics in Prometheus exposition format.
+   Returns text/plain suitable for /metrics endpoint."
+  []
+  (export/text-format @registry))
+
+(defn init!
+  "Initialize the bounded atom metrics registry.
+   Safe to call multiple times — collectors are idempotent."
+  []
+  (try
+    @registry
+    (log/info "Bounded atom Prometheus metrics initialized")
+    true
+    (catch Exception e
+      (log/error e "Failed to initialize bounded atom metrics")
+      false)))
+
+(comment
+  ;; REPL examples
+
+  ;; Initialize
+  (init!)
+
+  ;; Create instrumented atom
+  (def store (instrumented-bounded-atom
+               {:max-entries 5 :ttl-ms 30000 :name "test-store"}))
+
+  ;; Put some entries
+  (ba/bput! store :k1 "hello")
+  (ba/bput! store :k2 "world")
+
+  ;; Check metrics
+  (println (metrics-response))
+
+  ;; Fill to trigger evictions
+  (dotimes [i 10]
+    (ba/bput! store (keyword (str "k" i)) (str "val-" i)))
+
+  ;; Sweep
+  (ba/sweep! store :test-store)
+
+  ;; Check after sweep
+  (println (metrics-response))
+
+  ;; Snapshot all registered
+  (snapshot-all!))

--- a/src/hive_mcp/tools/agent/kill.clj
+++ b/src/hive_mcp/tools/agent/kill.clj
@@ -5,11 +5,29 @@
             [hive-mcp.agent.ling :as ling]
             [hive-mcp.agent.drone :as drone]
             [hive-mcp.swarm.datascript.queries :as queries]
+            [hive-mcp.swarm.datascript.lings :as ds-lings]
             [hive-mcp.tools.memory.scope :as scope]
             [taoensso.timbre :as log]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defn- kill-via-emacs!
+  "Kill a vterm/swarm ling by delegating to Emacs.
+   Fallback when headless strategy can't reach the Emacs buffer."
+  [agent-id]
+  (try
+    (when-let [eval-fn (requiring-resolve 'hive-mcp.emacs.client/eval-elisp)]
+      (let [elisp (format "(when (fboundp 'hive-mcp-swarm-slaves-kill) (hive-mcp-swarm-slaves-kill \"%s\"))"
+                          agent-id)
+            result (eval-fn elisp)]
+        (log/info "Emacs kill result" {:agent-id agent-id :result result})
+        (when (:success result)
+          (try (ds-lings/remove-slave! agent-id) (catch Exception _))
+          {:killed? true :id agent-id :via :emacs})))
+    (catch Exception e
+      (log/warn "Emacs kill fallback failed" {:agent-id agent-id :error (ex-message e)})
+      nil)))
 
 (defn- kill-one!
   "Kill a single agent, returning {:killed id :result ...} or {:error ... :id id}."
@@ -36,13 +54,21 @@
                         :drone (drone/->drone agent-id {:cwd (:slave/cwd agent-data)
                                                         :parent-id (:slave/parent agent-data)
                                                         :project-id (:slave/project-id agent-data)}))
-                result (proto/kill! agent)]
+                result (proto/kill! agent)
+                ;; Fallback: if headless kill failed, try Emacs for vterm lings
+                result (if (and (not (:killed? result))
+                                (= agent-type :ling))
+                         (or (kill-via-emacs! agent-id) result)
+                         result)]
             (log/info "Kill agent result" {:agent_id agent-id
                                            :result result
                                            :caller-project caller-project-id
                                            :target-project target-project-id})
             {:killed agent-id :result result})))
-      {:error (str "Agent not found: " agent-id) :id agent-id})
+      ;; Not in DataScript — try Emacs-side kill (swarm vterm lings)
+      (if-let [emacs-result (kill-via-emacs! agent-id)]
+        {:killed agent-id :result emacs-result}
+        {:error (str "Agent not found: " agent-id) :id agent-id}))
     (catch Exception e
       (log/error "Failed to kill agent" {:agent_id agent-id :error (ex-message e)})
       {:error (str "Failed to kill agent: " (ex-message e)) :id agent-id})))

--- a/src/hive_mcp/tools/catchup.clj
+++ b/src/hive_mcp/tools/catchup.clj
@@ -74,7 +74,8 @@
   "Native Clojure catchup implementation that queries Chroma directly.
    Returns structured catchup data with proper project scoping.
 
-   Phase 2: Enriches decisions/conventions with KG relationships."
+   If an enrichment addon is registered via :cu/a, it runs
+   fire-and-forget. Results arrive via piggyback on subsequent calls."
   [args]
   (let [directory (:directory args)]
     (log/info "native-catchup: querying Chroma with project scope" {:directory directory})
@@ -126,26 +127,17 @@
               snippets-meta (mapv #(fmt/entry->catchup-meta % 60) snippets)
               expiring-meta (mapv #(fmt/entry->catchup-meta % 80) expiring)
 
-              ;; Addon extension (optional)
-              enrich-fn (ext/get-extension :cu/a)
-              enriched (when enrich-fn
-                         (safe-deref
-                          (pool/with-io
-                            (enrich-fn {:directory directory
-                                        :project-id project-id
-                                        :caller-id (or (:_caller_id args) "coordinator")
-                                        :decisions decisions-base
-                                        :conventions conventions-base
-                                        :sessions sessions-meta
-                                        :axioms axioms
-                                        :principles principles
-                                        :priority-conventions priority-conventions}))
-                          query-timeout-ms nil))
-              decisions-enriched   (or (:decisions enriched) decisions-base)
-              conventions-enriched (or (:conventions enriched) conventions-base)
-              kg-insights          (or (:kg-insights enriched) {})
-              permeation-result    (:permeation enriched)
-              project-tree-scan    (or (:project-tree enriched) {:scanned false})
+              ;; Addon extension: fire-and-forget (async, returns nil immediately).
+              _ (when-let [enrich-fn (ext/get-extension :cu/a)]
+                  (enrich-fn {:directory directory
+                              :project-id project-id
+                              :caller-id (:_caller_id args)
+                              :decisions decisions-base
+                              :conventions conventions-base
+                              :sessions sessions-meta
+                              :axioms axioms
+                              :principles principles
+                              :priority-conventions priority-conventions}))
 
               ;; Memory piggyback: enqueue axioms + priority conventions for
               ;; incremental delivery via ---MEMORY--- blocks on subsequent calls.
@@ -210,13 +202,12 @@
 
           (fmt/build-catchup-response
            {:project-name project-name :project-id project-id
-            :scopes scopes :git-info git-info :permeation permeation-result
+            :scopes scopes :git-info git-info
             :axioms-meta axioms-meta :principles-meta principles-meta
             :priority-meta priority-meta
-            :sessions-meta sessions-meta :decisions-meta decisions-enriched
-            :conventions-meta conventions-enriched :snippets-meta snippets-meta
-            :expiring-meta expiring-meta :kg-insights kg-insights
-            :project-tree-scan project-tree-scan
+            :sessions-meta sessions-meta :decisions-meta decisions-base
+            :conventions-meta conventions-base :snippets-meta snippets-meta
+            :expiring-meta expiring-meta
             :context-refs context-refs}))
         (catch Exception e
           (fmt/catchup-error e))))))

--- a/src/hive_mcp/tools/catchup.clj
+++ b/src/hive_mcp/tools/catchup.clj
@@ -27,6 +27,7 @@
             [hive-mcp.extensions.registry :as ext]
             [hive-mcp.concurrency.pool :as pool]
             [hive-mcp.dns.result :refer [rescue]]
+            [hive-dsl.context.identity :as ctx-id]
             [clojure.data.json :as json]
             [taoensso.timbre :as log]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
@@ -150,15 +151,11 @@
               ;; incremental delivery via ---MEMORY--- blocks on subsequent calls.
               ;; Axioms first (highest priority), then priority conventions.
               ;;
-              ;; CURSOR ISOLATION: Must use the SAME caller identity formula as
-              ;; wrap-handler-memory-piggyback in routes.clj for buffer key alignment.
-              ;; Uses _caller_id (injected by bb-mcp) for per-caller isolation,
-              ;; falls back to "coordinator" for old bb-mcp versions.
-              ;; See extract-caller-id in routes.clj.
-              caller-id (or (:_caller_id args) "coordinator")
-              piggyback-agent-id (if project-id
-                                   (str caller-id "-" project-id)
-                                   caller-id)
+              ;; CURSOR ISOLATION: Uses ctx-id ADTs for canonical identity construction.
+              ;; Guarantees buffer key alignment with routes.clj piggyback wrappers.
+              caller (ctx-id/parse-caller-id (:_caller_id args))
+              scope (ctx-id/parse-project-scope project-id)
+              piggyback-agent-id (ctx-id/make-piggyback-agent-id caller scope)
 
               ;; Cursor hygiene: adopt previous coordinator's cursor position
               ;; so we don't re-read hivemind messages from timestamp 0 after

--- a/src/hive_mcp/tools/catchup.clj
+++ b/src/hive_mcp/tools/catchup.clj
@@ -132,6 +132,7 @@
                           (pool/with-io
                             (enrich-fn {:directory directory
                                         :project-id project-id
+                                        :caller-id (or (:_caller_id args) "coordinator")
                                         :decisions decisions-base
                                         :conventions conventions-base
                                         :sessions sessions-meta

--- a/src/hive_mcp/tools/catchup/format.clj
+++ b/src/hive_mcp/tools/catchup/format.clj
@@ -108,7 +108,11 @@
            axioms-meta principles-meta priority-meta sessions-meta decisions-meta
            conventions-meta snippets-meta expiring-meta kg-insights
            project-tree-scan disc-decay context-refs]}]
-  (let [total-enqueued (+ (count axioms-meta) (count principles-meta) (count priority-meta))]
+  (let [total-enqueued (+ (count axioms-meta) (count principles-meta) (count priority-meta)
+                          (count sessions-meta) (count decisions-meta) (count conventions-meta)
+                          (count snippets-meta) (count expiring-meta)
+                          (if (:situational-synthesis kg-insights) 1 0)
+                          (if (seq (dissoc kg-insights :situational-synthesis)) 1 0))]
     [(make-block "header"
                  {:_block "header"
                   :success true
@@ -126,7 +130,7 @@
                            :expiring (count expiring-meta)}
                   :memory-piggyback
                   (cond-> {:enqueued total-enqueued
-                           :note "Axioms and conventions will arrive via ---MEMORY--- blocks on subsequent tool calls. No manual fetch needed."}
+                           :note "All catchup content (axioms, principles, conventions, decisions, sessions, snippets, synthesis, kg-insights) will arrive via ---MEMORY--- blocks on subsequent tool calls. No manual fetch needed."}
                     (seq context-refs)
                     (assoc :context-refs context-refs
                            :ref-note "Context refs point to ephemeral context-store entries (10min TTL). Future :ref mode can send only refs instead of full content."))})

--- a/src/hive_mcp/tools/catchup/format.clj
+++ b/src/hive_mcp/tools/catchup/format.clj
@@ -130,7 +130,7 @@
                            :expiring (count expiring-meta)}
                   :memory-piggyback
                   (cond-> {:enqueued total-enqueued
-                           :note "All catchup content (axioms, principles, conventions, decisions, sessions, snippets, synthesis, kg-insights) will arrive via ---MEMORY--- blocks on subsequent tool calls. No manual fetch needed."}
+                           :note "Axioms, principles, and priority conventions drain via ---MEMORY--- blocks. Enrichment results arrive via piggyback on subsequent calls."}
                     (seq context-refs)
                     (assoc :context-refs context-refs
                            :ref-note "Context refs point to ephemeral context-store entries (10min TTL). Future :ref mode can send only refs instead of full content."))})

--- a/src/hive_mcp/tools/consolidated/session.clj
+++ b/src/hive_mcp/tools/consolidated/session.clj
@@ -29,6 +29,24 @@
         (log/warn "evict-agent-context! failed for" agent-id ":" (.getMessage e))
         {:evicted 0 :error (.getMessage e)}))))
 
+(defn- trigger-gc-sweep!
+  "Trigger bounded atom GC sweep before crystallization (gc-fix-5).
+   Evicts stale/over-capacity entries to free memory before session wrap.
+   Non-fatal: if sweep fails, session lifecycle continues."
+  []
+  (try
+    (when-let [trigger-fn (requiring-resolve 'hive-mcp.events.handlers.lifecycle/trigger-sweep!)]
+      (let [result (trigger-fn)]
+        (when (and (map? result) (pos? (get result :total-evicted 0)))
+          (log/info "[gc-fix-5] Pre-crystallization GC sweep evicted"
+                    (:total-evicted result) "entries from"
+                    (:atom-count result) "atoms in"
+                    (:duration-ms result) "ms"))
+        result))
+    (catch Exception e
+      (log/warn "[gc-fix-5] GC sweep failed (non-fatal):" (.getMessage e))
+      {:total-evicted 0 :error (.getMessage e)})))
+
 ;; ── Pure Result-returning functions ───────────────────────────────────────────
 
 (defn- keywordize-refs
@@ -125,10 +143,14 @@
 
 (defn handle-wrap
   "Wrap session -- crystallize learnings without commit.
+   Runs GC sweep before crystallization to free memory (gc-fix-5).
    Delegates to crystal/handle-wrap-crystallize which already returns MCP response."
   [{:keys [agent_id directory]}]
   (let [t0 (System/currentTimeMillis)]
     (log/info "session-wrap: START" {:agent agent_id :directory directory})
+    ;; gc-fix-5: Run bounded atom GC sweep before crystallization
+    (let [gc-result (trigger-gc-sweep!)]
+      (log/debug "session-wrap: GC sweep result" gc-result))
     (let [r (rb/try-result :session/wrap-failed
                            #(let [mcp-resp (crystal/handle-wrap-crystallize {:directory directory
                                                                              :agent_id agent_id})
@@ -186,8 +208,12 @@
   (rb/result->mcp (rb/try-result :session/context-reconstruct-failed #(context-reconstruct* params))))
 
 (defn handle-complete
-  "Complete a ling session with context eviction."
+  "Complete a ling session with GC sweep and context eviction.
+   Runs GC sweep before crystallization to free memory (gc-fix-5)."
   [{:keys [agent_id] :as params}]
+  ;; gc-fix-5: Run bounded atom GC sweep before crystallization
+  (let [gc-result (trigger-gc-sweep!)]
+    (log/debug "session-complete: GC sweep result" gc-result))
   (let [result (session-handlers/handle-session-complete params)
         effective-agent (or agent_id
                             (ctx/current-agent-id)

--- a/src/hive_mcp/tools/consolidated/workflow.clj
+++ b/src/hive_mcp/tools/consolidated/workflow.clj
@@ -16,6 +16,7 @@
             [hive-mcp.tools.consolidated.session :as c-session]
             [hive-mcp.tools.consolidated.workflow.forge-ops :as forge-ops]
             [hive-mcp.tools.consolidated.workflow.forge-cycle :as forge-cycle]
+            [hive-mcp.dns.result :as result]
             [hive-mcp.config.core :as config]
             [hive-mcp.server.guards :as guards]
             [taoensso.timbre :as log]))
@@ -127,6 +128,39 @@
                  :message "Forge quenched. Active lings will finish. No new spawns."
                  :state @forge-state}))))
 
+;; ── Multi-Front Coordinator (hive-knowledge extension) ────────────────────
+
+(defn- resolve-multi-front
+  "Lazily resolve hive-knowledge.scheduler.multi-front namespace."
+  [fn-name]
+  (or (requiring-resolve (symbol "hive-knowledge.scheduler.multi-front" fn-name))
+      (throw (ex-info (str "multi-front not available: " fn-name)
+                      {:fn fn-name}))))
+
+(defn handle-multi-front-start
+  "Start multi-front coordination: detect fronts → spawn vterm lings → monitor."
+  [params]
+  (rb/result->mcp
+   (rb/try-result :multi-front/start-failed
+                  #(let [start-fn (resolve-multi-front "start-multi-front!")]
+                     (result/ok (start-fn params))))))
+
+(defn handle-multi-front-status
+  "Get multi-front coordination status with per-front milestone progress."
+  [_params]
+  (rb/result->mcp
+   (rb/try-result :multi-front/status-failed
+                  #(let [status-fn (resolve-multi-front "multi-front-status")]
+                     (result/ok (status-fn))))))
+
+(defn handle-multi-front-stop
+  "Stop multi-front coordination."
+  [_params]
+  (rb/result->mcp
+   (rb/try-result :multi-front/stop-failed
+                  #(let [stop-fn (resolve-multi-front "stop-multi-front!")]
+                     (result/ok (stop-fn))))))
+
 ;; ── Deprecated Aliases ──────────────────────────────────────────────────────
 
 (def handle-forge-strike-fsm
@@ -147,6 +181,10 @@
               :strike-imperative  handle-forge-strike-imperative
               :status             handle-forge-status
               :quench             handle-forge-quench
+              :multi-front        {:start    handle-multi-front-start
+                                   :status   handle-multi-front-status
+                                   :stop     handle-multi-front-stop
+                                   :_handler handle-multi-front-status}
               :_handler           handle-forge-status}})
 
 (def handlers canonical-handlers)
@@ -164,6 +202,9 @@
                                                 "forge strike"
                                                 "forge strike-imperative"
                                                 "forge status" "forge quench"
+                                                "forge multi-front start"
+                                                "forge multi-front status"
+                                                "forge multi-front stop"
                                                 "help"]
                                          :description "Workflow operation to perform"}
                               "commit_msg" {:type "string"

--- a/src/hive_mcp/tools/consolidated/workflow/forge_ops.clj
+++ b/src/hive_mcp/tools/consolidated/workflow/forge_ops.clj
@@ -103,10 +103,28 @@
                      (compare pa pb))))
                tasks))))
 
+(defn- apply-milestone-boundary-filter
+  "Post-filter: exclude tasks from milestones whose prerequisites are incomplete.
+   Config-gated via [:forge :milestone-boundary]. Graceful degradation."
+  [prioritized]
+  (if (config/get-service-value :forge :milestone-boundary :default false)
+    (result/rescue prioritized
+                   (when-let [filter-fn (requiring-resolve
+                                         'hive-knowledge.kanban.milestone/milestone-boundary-filter)]
+                     (let [{:keys [tasks excluded-count reason]} (filter-fn (:tasks prioritized))]
+                       (when (pos? (or excluded-count 0))
+                         (log/info "SURVEY: milestone-boundary excluded" excluded-count "tasks:" reason))
+                       (-> prioritized
+                           (assoc :tasks tasks)
+                           (assoc :count (count tasks))
+                           (update :blocked-count + (or excluded-count 0))))))
+    prioritized))
+
 (defn survey
   "Query kanban for todo tasks, ranked by KG dependencies (vulcan always-on).
    task_ids acts as an ID whitelist, task_filter as a title-prefix filter.
-   Extra keys in opts are passed through to vulcan/prioritize-tasks (OCP)."
+   Extra keys in opts are passed through to vulcan/prioritize-tasks (OCP).
+   When [:forge :milestone-boundary] is true, excludes tasks from blocked milestones."
   [{:keys [directory task_ids task_filter] :as opts}]
   (let [r (result/rescue
            {:tasks [] :count 0}
@@ -117,13 +135,15 @@
                                (filterv #(contains? (set task_ids) (:id %)))
                                (some? task_filter)
                                (filterv #(str/starts-with? (or (:title %) "") task_filter)))
-                 prioritized (vulcan/prioritize-tasks tasks #{} (dissoc opts :directory :task_ids :task_filter))]
-             (log/info "SURVEY: ready" (:count prioritized)
-                       "blocked" (:blocked-count prioritized)
+                 prioritized (vulcan/prioritize-tasks tasks #{} (dissoc opts :directory :task_ids :task_filter))
+                 ;; Post-filter: milestone boundary enforcement (OCP)
+                 filtered    (apply-milestone-boundary-filter prioritized)]
+             (log/info "SURVEY: ready" (:count filtered)
+                       "blocked" (:blocked-count filtered)
                        "of" (count all-tasks) "total"
                        (when (seq task_ids) (str "(id-whitelist: " (count task_ids) ")"))
                        (when task_filter (str "(filter: " (pr-str task_filter) ")")))
-             prioritized))]
+             filtered))]
     (cond-> r
       (::result/error (meta r))
       (assoc :error (get-in (meta r) [::result/error :message])))))

--- a/src/hive_mcp/tools/consolidated/workflow/spawn.clj
+++ b/src/hive_mcp/tools/consolidated/workflow/spawn.clj
@@ -287,22 +287,107 @@
    :active-before (:active-total active-counts)
    :max-slots (or max-slots 10)})
 
+;; ── Orchestrator Mode ──────────────────────────────────────────────────────
+
+(defn- build-orchestrator-prompt
+  "Build the structured prompt for an orchestrator ling.
+   Bundles all tasks with their pre-gathered context refs."
+  [tasks context-result directory]
+  (let [task-lines (mapv (fn [task]
+                           (let [ctx    (get context-result (:id task))
+                                 summary (or (:summary ctx) "")]
+                             (str "### Task: " (or (:title task) (:id task)) "\n"
+                                  "ID: " (:id task) "\n"
+                                  (when-let [desc (:description task)]
+                                    (str "Description: " desc "\n"))
+                                  (when (seq summary)
+                                    (str "Context:\n" summary "\n"))
+                                  (when-let [refs (:ctx-refs ctx)]
+                                    (str "Context refs: " (pr-str refs) "\n"))
+                                  (when-let [kg-ids (:kg-node-ids ctx)]
+                                    (str "KG seeds: " (pr-str (take 5 kg-ids)) "\n")))))
+                         tasks)]
+    (str "You are the kanban orchestrator for this milestone.\n\n"
+         "## Tasks (" (count tasks) " total)\n\n"
+         (clojure.string/join "\n" task-lines)
+         "\n## Instructions\n"
+         "1. For each task above, spawn a Task subagent (max 3 parallel)\n"
+         "2. Each subagent implements the task using hive MCP tools\n"
+         "3. Collect results, then: kanban batch-update to mark done\n"
+         "4. Check kanban status for milestone progress\n"
+         "5. Loop if more tasks remain\n\n"
+         "Working directory: " (or directory "auto") "\n"
+         "NEVER spawn lings or call forge-strike. Use Task subagents ONLY.\n")))
+
+(defn- spawn-orchestrator!
+  "Spawn a single orchestrator ling with all tasks bundled.
+   The orchestrator uses Task subagents for parallelism."
+  [{:keys [tasks directory model context-result]}]
+  (let [effective-dir  (or directory (ctx/current-directory) (System/getProperty "user.dir"))
+        agent-name     (str "forja-orch-" (System/currentTimeMillis))
+        prompt         (build-orchestrator-prompt tasks context-result effective-dir)]
+    (log/info "SPARK[orchestrator]: spawning 1 orchestrator for" (count tasks) "tasks")
+    (let [spawn-result (spawn/handle-spawn
+                        {:type    "ling"
+                         :name    agent-name
+                         :cwd     effective-dir
+                         :presets ["orchestrator" "ling" "mcp-first"]
+                         :model   model})
+          parsed       (parse-spawn-result spawn-result agent-name)
+          agent-id     (:agent-id parsed)
+          ready-mode   (or (:spawn-mode parsed) :claude)
+          ready        (ready/wait-for-ling-ready agent-id ready-mode)]
+      (if (or (:ready? ready) (:slave ready))
+        (let [dispatch-result (dispatch/handle-dispatch
+                               {:agent_id agent-id
+                                :prompt   prompt})]
+          (if (:isError dispatch-result)
+            (do
+              (log/error "SPARK[orchestrator]: dispatch failed" {:agent agent-id})
+              {:spawned [] :failed [{:agent-id agent-id :error "dispatch failed"}]
+               :count 0 :mode :orchestrator})
+            (do
+              (log/info "SPARK[orchestrator]: dispatched" (count tasks) "tasks to" agent-id)
+              ;; Mark all tasks as inprogress
+              (doseq [task tasks]
+                (result/rescue nil
+                               (c-kanban/handle-kanban {:command    "update"
+                                                        :task_id    (:id task)
+                                                        :new_status "inprogress"
+                                                        :directory  effective-dir})))
+              {:spawned [{:agent-id agent-id :task-count (count tasks)
+                          :mode :orchestrator :spawned true}]
+               :failed  []
+               :count   1
+               :mode    :orchestrator})))
+        (do
+          (log/error "SPARK[orchestrator]: ling readiness timeout" {:agent agent-id})
+          {:spawned [] :failed [{:agent-id agent-id :error "readiness timeout"}]
+           :count 0 :mode :orchestrator})))))
+
 ;; ── Spark! Orchestrator ─────────────────────────────────────────────────────
 
 (defn spark!
   "Spawn lings or dispatch drones for ready tasks.
    Routes: :drone (wave all), :claude (default Emacs), :vterm, :headless/:agent-sdk/:openrouter,
-   :mixed (default, classify + split)."
+   :orchestrator (single ling + Task subagents), :mixed (default, classify + split)."
   [{:keys [directory max_slots presets tasks spawn_mode spawn-mode model
-           preset seeds ctx_refs kg_node_ids]}]
+           preset seeds ctx_refs kg_node_ids context-result]}]
   (let [model                (budget-route-model model)
         effective-spawn-mode (keyword (or spawn_mode spawn-mode :mixed))
         drone-params         {:directory directory :tasks tasks :model model
                               :preset (or preset (first presets) "drone-worker")
                               :seeds seeds :ctx_refs ctx_refs :kg_node_ids kg_node_ids
                               :max_slots max_slots}]
-    (if (= :drone effective-spawn-mode)
+    (cond
+      (= :orchestrator effective-spawn-mode)
+      (spawn-orchestrator! {:tasks tasks :directory directory :model model
+                            :context-result context-result})
+
+      (= :drone effective-spawn-mode)
       (drone/dispatch-drone-tasks! drone-params)
+
+      :else
       (let [{:keys [drone-tasks ling-tasks]}
             (if (= :mixed effective-spawn-mode)
               (drone/classify-and-split-tasks tasks)

--- a/src/hive_mcp/tools/diff/batch.clj
+++ b/src/hive_mcp/tools/diff/batch.clj
@@ -5,7 +5,8 @@
             [hive-mcp.tools.diff.auto-approve :as auto-approve]
             [hive-mcp.tools.diff.handlers :as handlers]
             [clojure.data.json :as json]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bget bkeys]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -14,7 +15,7 @@
   "Get all pending diffs from multiple drones for batch review."
   ([] (batch-review-diffs nil))
   ([drone-ids]
-   (let [all-diffs (vals @state/pending-diffs)
+   (let [all-diffs (mapv :data (vals @(:atom state/pending-diffs)))
          filtered (if (seq drone-ids)
                     (filter #(contains? (set drone-ids) (:drone-id %)) all-diffs)
                     all-diffs)]
@@ -39,7 +40,7 @@
    (let [diffs (batch-review-diffs drone-ids)
          categorized (for [d diffs
                            :let [check (auto-approve/auto-approve-diff?
-                                        (get @state/pending-diffs (:id d))
+                                        (bget state/pending-diffs (:id d))
                                         rules)]]
                        (assoc d :auto-check check))
          auto-approvable (filter #(get-in % [:auto-check :approved]) categorized)

--- a/src/hive_mcp/tools/diff/handlers.clj
+++ b/src/hive_mcp/tools/diff/handlers.clj
@@ -8,7 +8,8 @@
             [hive-mcp.agent.context :as ctx]
             [clojure.string :as str]
             [clojure.java.io :as io]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bput! bget bounded-swap! bkeys]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -36,7 +37,7 @@
           (try
             (let [resolved-path (:resolved-path path-result)
                   proposal (compute/create-diff-proposal (assoc params :file_path resolved-path))]
-              (swap! state/pending-diffs assoc (:id proposal) proposal)
+              (bput! state/pending-diffs (:id proposal) proposal)
               (log/info "Diff proposed" {:id (:id proposal)
                                          :file resolved-path
                                          :original-path file_path
@@ -56,7 +57,8 @@
   [{:keys [drone_id]}]
   (log/debug "list_proposed_diffs called" {:drone_id drone_id})
   (try
-    (let [all-diffs (vals @state/pending-diffs)
+    (let [;; Iterate raw bounded-atom entries, extracting :data from each
+          all-diffs (mapv :data (vals @(:atom state/pending-diffs)))
           filtered (if (str/blank? drone_id)
                      all-diffs
                      (filter #(= drone_id (:drone-id %)) all-diffs))
@@ -84,20 +86,20 @@
       (log/warn "apply_diff missing diff_id")
       (mcp-error-json "Missing required field: diff_id"))
 
-    (not (contains? @state/pending-diffs diff_id))
+    (nil? (bget state/pending-diffs diff_id))
     (do
       (log/warn "apply_diff diff not found" {:diff_id diff_id})
       (mcp-error-json (str "Diff not found: " diff_id)))
 
     :else
-    (let [{:keys [file-path old-content new-content]} (get @state/pending-diffs diff_id)
+    (let [{:keys [file-path old-content new-content]} (bget state/pending-diffs diff_id)
           file-exists? (.exists (io/file file-path))
           creating-new-file? (and (str/blank? old-content) (not file-exists?))]
       (cond
         (str/blank? new-content)
         (do
           (log/warn "apply_diff blocked: empty new_content" {:diff_id diff_id :file file-path})
-          (swap! state/pending-diffs dissoc diff_id)
+          (bounded-swap! state/pending-diffs dissoc diff_id)
           (mcp-error-json "Cannot apply diff: new_content is empty or whitespace-only. This typically indicates the LLM returned an empty response."))
 
         creating-new-file?
@@ -106,7 +108,7 @@
             (when (and parent (not (.exists parent)))
               (.mkdirs parent)))
           (spit file-path new-content)
-          (swap! state/pending-diffs dissoc diff_id)
+          (bounded-swap! state/pending-diffs dissoc diff_id)
           (log/info "New file created" {:id diff_id :file file-path})
           (mcp-json {:id diff_id
                      :status "applied"
@@ -139,7 +141,7 @@
               :else
               (do
                 (spit file-path (str/replace-first current-content old-content new-content))
-                (swap! state/pending-diffs dissoc diff_id)
+                (bounded-swap! state/pending-diffs dissoc diff_id)
                 (log/info "Diff applied" {:id diff_id :file file-path})
                 (mcp-json {:id diff_id
                            :status "applied"
@@ -159,14 +161,14 @@
       (log/warn "reject_diff missing diff_id")
       (mcp-error-json "Missing required field: diff_id"))
 
-    (not (contains? @state/pending-diffs diff_id))
+    (nil? (bget state/pending-diffs diff_id))
     (do
       (log/warn "reject_diff diff not found" {:diff_id diff_id})
       (mcp-error-json (str "Diff not found: " diff_id)))
 
     :else
-    (let [{:keys [file-path drone-id]} (get @state/pending-diffs diff_id)]
-      (swap! state/pending-diffs dissoc diff_id)
+    (let [{:keys [file-path drone-id]} (bget state/pending-diffs diff_id)]
+      (bounded-swap! state/pending-diffs dissoc diff_id)
       (log/info "Diff rejected" {:id diff_id :file file-path :reason reason})
       (mcp-json {:id diff_id
                  :status "rejected"
@@ -183,11 +185,11 @@
     (str/blank? diff_id)
     (mcp-error-json "Missing required field: diff_id")
 
-    (not (contains? @state/pending-diffs diff_id))
+    (nil? (bget state/pending-diffs diff_id))
     (mcp-error-json (str "Diff not found: " diff_id))
 
     :else
-    (let [diff (get @state/pending-diffs diff_id)
+    (let [diff (bget state/pending-diffs diff_id)
           formatted-diff (compute/format-hunks-as-unified (:hunks diff) (:file-path diff))]
       (mcp-json (-> diff
                     (update :created-at str)

--- a/src/hive_mcp/tools/diff/state.clj
+++ b/src/hive_mcp/tools/diff/state.clj
@@ -2,7 +2,9 @@
   "Diff state management: atoms, error helpers, TDD status."
   (:require [hive-mcp.server.guards :as guards]
             [clojure.data.json :as json]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bounded-atom bput! bget bounded-swap!
+                                           bclear! register-sweepable!]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -14,7 +16,13 @@
    :text (json/write-str {:error error-message})
    :isError true})
 
-(defonce pending-diffs (atom {}))
+;; gc-fix-3: pending-diffs — LRU eviction, 200 entries, 30min TTL
+;; Diffs are short-lived proposals; stale ones waste memory.
+(defonce pending-diffs
+  (bounded-atom {:max-entries 200
+                 :ttl-ms 1800000    ;; 30 minutes
+                 :eviction-policy :lru}))
+(register-sweepable! pending-diffs :pending-diffs)
 
 (def default-auto-approve-rules
   "Default rules for auto-approving diff proposals."
@@ -33,16 +41,17 @@
   []
   (guards/when-not-coordinator
    "clear-pending-diffs! called"
-   (reset! pending-diffs {})))
+   (bclear! pending-diffs)))
 
 (defn update-diff-tdd-status!
   "Update a diff's TDD status after drone runs tests/lint."
   [diff-id tdd-status]
-  (when (contains? @pending-diffs diff-id)
-    (swap! pending-diffs update diff-id
-           (fn [diff]
-             (update diff :tdd-status
-                     (fn [existing]
-                       (merge existing tdd-status)))))
+  (when (bget pending-diffs diff-id)
+    (let [current (bget pending-diffs diff-id)]
+      (when current
+        (bput! pending-diffs diff-id
+               (update current :tdd-status
+                       (fn [existing]
+                         (merge existing tdd-status))))))
     (log/info "Updated diff TDD status" {:diff-id diff-id :tdd-status tdd-status})
-    (get @pending-diffs diff-id)))
+    (bget pending-diffs diff-id)))

--- a/src/hive_mcp/tools/diff/wave.clj
+++ b/src/hive_mcp/tools/diff/wave.clj
@@ -6,7 +6,8 @@
             [hive-mcp.tools.diff.handlers :as handlers]
             [clojure.data.json :as json]
             [clojure.string :as str]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bkeys]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -14,7 +15,7 @@
 (defn get-wave-diffs
   "Get all pending diffs for a specific wave-id."
   [wave-id]
-  (->> (vals @state/pending-diffs)
+  (->> (mapv :data (vals @(:atom state/pending-diffs)))
        (filter #(= wave-id (:wave-id %)))
        (vec)))
 

--- a/src/hive_mcp/tools/memory/decay.clj
+++ b/src/hive_mcp/tools/memory/decay.clj
@@ -50,7 +50,7 @@
 ;; Side-Effecting Decay
 ;; =============================================================================
 
-(defn- apply-decay!
+(defn apply-decay!
   "Apply staleness decay to a single entry. Returns decay result or nil."
   [entry opts]
   (when (crystal/decay-candidate? entry opts)

--- a/src/hive_mcp/tools/multi_async.clj
+++ b/src/hive_mcp/tools/multi_async.clj
@@ -19,7 +19,9 @@
    Design decision: Phase 3 of Multi DSL plan (20260211212019-b8499942)"
   (:require [hive-mcp.channel.context-store :as ctx]
             [hive-mcp.dns.result :as result]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bounded-atom bput! bget bounded-swap!
+                                           bclear! bkeys register-sweepable!]]))
 
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
@@ -41,10 +43,15 @@
 ;; the future reference + metadata locally. Completed results are stored
 ;; in context-store for cross-agent access and TTL-based auto-eviction.
 
+;; gc-fix-3: batches — LRU eviction, 100 entries, 30min TTL
+;; Batch entries include future refs; stale completed batches waste memory.
 (defonce ^{:doc "Registry of async batches.
   {batch-id -> {:future, :status, :ops, :created-at, :result-ctx-id, :error}}"}
   batches
-  (atom {}))
+  (bounded-atom {:max-entries 100
+                 :ttl-ms 1800000    ;; 30 minutes
+                 :eviction-policy :lru}))
+(register-sweepable! batches :batches)
 
 ;; =============================================================================
 ;; ID Generation
@@ -97,10 +104,12 @@
                       (let [ctx-id (ctx/context-put! batch-result
                                                      :tags #{"async-batch" (str "batch:" batch-id)}
                                                      :ttl-ms ttl-ms)]
-                        (swap! batches update batch-id assoc
-                               :status        "completed"
-                               :result-ctx-id ctx-id
-                               :completed-at  (now-ms))
+                        (when-let [current (bget batches batch-id)]
+                          (bput! batches batch-id
+                                 (assoc current
+                                        :status        "completed"
+                                        :result-ctx-id ctx-id
+                                        :completed-at  (now-ms))))
                         (log/info "[multi-async] Batch completed" batch-id "ctx-id:" ctx-id)
                         ctx-id)))
 
@@ -108,10 +117,12 @@
   "Mark a batch as failed with error details.
    Called from within the batch future on exception."
   [batch-id error-msg]
-  (swap! batches update batch-id assoc
-         :status       "failed"
-         :error        error-msg
-         :completed-at (now-ms))
+  (when-let [current (bget batches batch-id)]
+    (bput! batches batch-id
+           (assoc current
+                  :status       "failed"
+                  :error        error-msg
+                  :completed-at (now-ms))))
   (log/error "[multi-async] Batch failed" batch-id "error:" error-msg))
 
 ;; =============================================================================
@@ -150,10 +161,10 @@
                            ;; Only mark as failed if not already cancelled
                            ;; (future-cancel triggers InterruptedException which
                            ;;  would overwrite "cancelled" status without this guard)
-                           (when (= "running" (:status (get @batches batch-id)))
+                           (when (= "running" (:status (bget batches batch-id)))
                              (fail-batch! batch-id (ex-message e)))
                            nil)))]
-      (swap! batches assoc batch-id (make-batch-entry fut ops-count created-at))
+      (bput! batches batch-id (make-batch-entry fut ops-count created-at))
       (log/info "[multi-async] Batch dispatched" batch-id "ops:" ops-count)
       {:batch-id   batch-id
        :status     "running"
@@ -178,7 +189,7 @@
    {:status \"expired\"   :batch-id ... :message \"...\"}
    {:status \"not-found\" :batch-id ...}"
   [batch-id]
-  (if-let [entry (get @batches batch-id)]
+  (if-let [entry (bget batches batch-id)]
     (case (:status entry)
       "running"
       {:status     "running"
@@ -221,15 +232,16 @@
   "List all tracked async batches with their status.
    Returns a vector of batch summary maps (without :future refs)."
   []
-  (mapv (fn [[batch-id {:keys [status ops created-at completed-at error]}]]
-          (cond-> {:batch-id   batch-id
-                   :status     status
-                   :ops        ops
-                   :created-at created-at}
-            completed-at      (assoc :completed-at completed-at)
-            (= "running" status) (assoc :elapsed-ms (- (now-ms) created-at))
-            error             (assoc :error error)))
-        @batches))
+  (mapv (fn [[batch-id entry]]
+          (let [data (:data entry)]
+            (cond-> {:batch-id   batch-id
+                     :status     (:status data)
+                     :ops        (:ops data)
+                     :created-at (:created-at data)}
+              (:completed-at data)        (assoc :completed-at (:completed-at data))
+              (= "running" (:status data)) (assoc :elapsed-ms (- (now-ms) (:created-at data)))
+              (:error data)               (assoc :error (:error data)))))
+        @(:atom batches)))
 
 ;; =============================================================================
 ;; Public API: Cancel
@@ -243,13 +255,14 @@
    {:cancelled false :batch-id ... :reason \"not-running\"} — terminal state
    {:cancelled false :batch-id ... :reason \"not-found\"}   — invalid id"
   [batch-id]
-  (if-let [entry (get @batches batch-id)]
+  (if-let [entry (bget batches batch-id)]
     (if (= "running" (:status entry))
       (do
         (future-cancel (:future entry))
-        (swap! batches update batch-id assoc
-               :status       "cancelled"
-               :completed-at (now-ms))
+        (bput! batches batch-id
+               (assoc entry
+                      :status       "cancelled"
+                      :completed-at (now-ms)))
         (log/info "[multi-async] Batch cancelled" batch-id)
         {:cancelled true :batch-id batch-id})
       {:cancelled false :batch-id batch-id :reason "not-running"})
@@ -264,23 +277,27 @@
    expired from context-store. Returns count of entries purged from registry."
   []
   (let [terminal #{"completed" "failed" "cancelled"}
+        raw-entries @(:atom batches)
         to-purge (filterv (fn [[_id entry]]
-                            (and (terminal (:status entry))
-                                 (if-let [ctx-id (:result-ctx-id entry)]
-                                   (nil? (ctx/context-get ctx-id))
-                                   true)))
-                          @batches)
+                            (let [data (:data entry)]
+                              (and (terminal (:status data))
+                                   (if-let [ctx-id (:result-ctx-id data)]
+                                     (nil? (ctx/context-get ctx-id))
+                                     true))))
+                          raw-entries)
         ids      (mapv first to-purge)]
     (when (seq ids)
-      (swap! batches #(apply dissoc % ids))
+      (bounded-swap! batches #(apply dissoc % ids))
       (log/info "[multi-async] GC purged" (count ids) "terminal batches"))
     (count ids)))
 
 (defn reset-all!
   "Cancel all in-flight futures and clear batch registry. For testing."
   []
-  (doseq [[_ {:keys [future]}] @batches]
-    (when (and future (not (future-done? future)))
-      (future-cancel future)
-      (try (deref future 100 nil) (catch Exception _))))
-  (reset! batches {}))
+  (doseq [[_ entry] @(:atom batches)]
+    (let [data (:data entry)
+          fut (:future data)]
+      (when (and fut (not (future-done? fut)))
+        (future-cancel fut)
+        (try (deref fut 100 nil) (catch Exception _)))))
+  (bclear! batches))

--- a/src/hive_mcp/tools/swarm/health.clj
+++ b/src/hive_mcp/tools/swarm/health.clj
@@ -11,7 +11,9 @@
             [hive-mcp.tools.core :refer [mcp-json mcp-error]]
             [hive-mcp.telemetry.prometheus :as prom]
             [clojure.core.async :as async :refer [go-loop timeout]]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bounded-atom bput! bget bounded-swap!
+                                           bclear! register-sweepable!]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -62,9 +64,21 @@
   "Maximum retry attempts before escalation to ling."
   3)
 
-(defonce drone-heartbeats (atom {}))
+;; Drone heartbeats — LRU eviction, 200 entries, 5min TTL.
+;; Heartbeats are time-sensitive ephemeral data; stale entries waste memory.
+(defonce drone-heartbeats
+  (bounded-atom {:max-entries 200
+                 :ttl-ms 300000     ;; 5 minutes
+                 :eviction-policy :lru}))
+(register-sweepable! drone-heartbeats :drone-heartbeats)
 
-(defonce retry-queue (atom []))
+;; Retry queue — keyed by task string, FIFO eviction.
+;; TTL 30min prevents stale retries accumulating.
+(defonce retry-queue
+  (bounded-atom {:max-entries 100
+                 :ttl-ms 1800000      ;; 30 minutes
+                 :eviction-policy :fifo}))
+(register-sweepable! retry-queue :retry-queue)
 
 (defonce monitor-running? (atom false))
 
@@ -75,18 +89,17 @@
   [drone-id & [{:keys [wave-id task files status refresh-claims?]
                 :or {refresh-claims? true}}]]
   (let [now (System/currentTimeMillis)
-        had-files? (boolean (seq (get-in @drone-heartbeats [drone-id :files])))]
-    (swap! drone-heartbeats update drone-id
-           (fn [current]
-             (merge (or current {})
-                    {:last-beat now
-                     :status (or status :active)}
-                    (when wave-id {:wave-id wave-id})
-                    (when task {:task task})
-                    (when files {:files files}))))
+        had-files? (boolean (seq (:files (bget drone-heartbeats drone-id))))]
+    (bput! drone-heartbeats drone-id
+           (merge (or (bget drone-heartbeats drone-id) {})
+                  {:last-beat now
+                   :status (or status :active)}
+                  (when wave-id {:wave-id wave-id})
+                  (when task {:task task})
+                  (when files {:files files})))
     (when (and refresh-claims? (or files had-files?))
       (result/rescue nil
-                     (when-let [claim-files (or files (get-in @drone-heartbeats [drone-id :files]))]
+                     (when-let [claim-files (or files (:files (bget drone-heartbeats drone-id)))]
                        (doseq [f claim-files]
                          (lings/refresh-claim! f)))))
     (log/debug "Heartbeat recorded:" drone-id)))
@@ -94,18 +107,22 @@
 (defn clear-heartbeat!
   "Remove heartbeat tracking for a drone."
   [drone-id]
-  (swap! drone-heartbeats dissoc drone-id)
+  (bounded-swap! drone-heartbeats dissoc drone-id)
   (log/debug "Heartbeat cleared:" drone-id))
 
 (defn get-heartbeat
   "Get heartbeat info for a specific drone."
   [drone-id]
-  (get @drone-heartbeats drone-id))
+  (bget drone-heartbeats drone-id))
 
 (defn get-all-heartbeats
-  "Get all active drone heartbeats."
+  "Get all active drone heartbeats.
+   Returns a map of drone-id -> heartbeat-data (unwrapped from bounded-atom entries)."
   []
-  @drone-heartbeats)
+  (reduce-kv (fn [acc k entry]
+               (assoc acc k (:data entry)))
+             {}
+             @(:atom drone-heartbeats)))
 
 (defn refresh-drone-claims!
   "Refresh claim timestamps for a drone's files."
@@ -116,11 +133,10 @@
         (result/rescue nil (lings/refresh-claim! f))))))
 
 (defn queue-for-retry!
-  "Queue a failed task for retry with attempt tracking."
+  "Queue a failed task for retry with attempt tracking.
+   Uses task string as key in bounded map atom."
   [{:keys [drone-id task files wave-id]}]
-  (let [existing (->> @retry-queue
-                      (filter #(= (:task %) task))
-                      first)
+  (let [existing (bget retry-queue task)
         attempt (if existing
                   (inc (:attempt existing))
                   1)]
@@ -129,40 +145,47 @@
         (log/error "Max retries reached for task, escalating to ling"
                    {:drone-id drone-id :task task :attempts attempt})
         (prom/inc-events-total! :drone/retry-escalated :error)
-        (swap! retry-queue #(vec (remove (fn [t] (= (:task t) task)) %)))
+        (bounded-swap! retry-queue dissoc task)
         {:escalated true :attempts attempt})
       (do
-        (swap! retry-queue
-               (fn [q]
-                 (let [filtered (vec (remove #(= (:task %) task) q))]
-                   (conj filtered
-                         {:drone-id drone-id
-                          :task task
-                          :files files
-                          :wave-id wave-id
-                          :attempt attempt
-                          :queued-at (System/currentTimeMillis)}))))
+        (bput! retry-queue task
+               {:drone-id drone-id
+                :task task
+                :files files
+                :wave-id wave-id
+                :attempt attempt
+                :queued-at (System/currentTimeMillis)})
         (log/info "Queued task for retry" {:drone-id drone-id :attempt attempt :task (subs task 0 (min 50 (count task)))})
         (prom/inc-events-total! :drone/retry-queued :info)
         {:queued true :attempts attempt}))))
 
 (defn get-retry-queue
-  "Get current retry queue."
+  "Get current retry queue as a vector, sorted by queued-at (FIFO order)."
   []
-  @retry-queue)
+  (->> @(:atom retry-queue)
+       vals
+       (map :data)
+       (sort-by :queued-at)
+       vec))
 
 (defn pop-retry-task!
-  "Pop the next task from the retry queue (FIFO)."
+  "Pop the oldest task from the retry queue (FIFO by queued-at)."
   []
-  (let [task (first @retry-queue)]
-    (when task
-      (swap! retry-queue #(vec (rest %)))
-      task)))
+  (let [entries @(:atom retry-queue)
+        oldest (when (seq entries)
+                 (->> entries
+                      (sort-by (fn [[_ entry]] (get-in entry [:data :queued-at])))
+                      first))]
+    (when oldest
+      (let [[task-key entry] oldest
+            task-data (:data entry)]
+        (bounded-swap! retry-queue dissoc task-key)
+        task-data))))
 
 (defn clear-retry-queue!
   "Clear the retry queue."
   []
-  (reset! retry-queue [])
+  (bclear! retry-queue)
   (log/info "Retry queue cleared"))
 
 (defn- classify-drone-health
@@ -188,7 +211,7 @@
   "Check health of all tracked drones, returns map with :active :alert :stuck."
   []
   (let [now (System/currentTimeMillis)
-        heartbeats @drone-heartbeats
+        heartbeats (get-all-heartbeats)
         classified (reduce-kv
                     (fn [acc drone-id {:keys [last-beat wave-id task]}]
                       (let [health (classify-drone-health last-beat now)]
@@ -271,7 +294,9 @@
 
     (doseq [{:keys [drone-id elapsed-ms]} alert]
       (log/warn "Drone alert - no progress for" (/ elapsed-ms 1000) "seconds:" drone-id)
-      (swap! drone-heartbeats assoc-in [drone-id :status] :alert))
+      ;; Update status within bounded-atom — read-modify-write via bput!
+      (when-let [current (bget drone-heartbeats drone-id)]
+        (bput! drone-heartbeats drone-id (assoc current :status :alert))))
 
     (doseq [{:keys [drone-id wave-id elapsed-ms]} stuck]
       (log/error "Drone stuck - auto-recovering after" (/ elapsed-ms 1000) "seconds:" drone-id)
@@ -313,11 +338,11 @@
                          (if wave-id
                            (filterv #(= wave-id (:wave-id %)) drones)
                            drones))
-        queue @retry-queue
+        queue (get-retry-queue)
         filtered-queue (if wave-id
                          (filterv #(= wave-id (:wave-id %)) queue)
                          queue)]
-    {:total-drones (count @drone-heartbeats)
+    {:total-drones (count @(:atom drone-heartbeats))
      :active (filter-by-wave active)
      :alert (filter-by-wave alert)
      :stuck (filter-by-wave stuck)
@@ -411,7 +436,7 @@
                 {:message "action must be 'start' or 'stop'"})))
 
 (defn- retry-queue-status* [_]
-  (let [queue @retry-queue]
+  (let [queue (get-retry-queue)]
     (result/ok {:queue-length (count queue)
                 :tasks (mapv #(-> %
                                   (select-keys [:drone-id :attempt :wave-id :queued-at])

--- a/src/hive_mcp/tools/swarm/lifecycle.clj
+++ b/src/hive_mcp/tools/swarm/lifecycle.clj
@@ -10,7 +10,8 @@
             [hive-mcp.agent.context :as ctx]
             [clojure.string :as str]
             [taoensso.timbre :as log]
-            [hive-mcp.telemetry.prometheus :as prom]))
+            [hive-mcp.telemetry.prometheus :as prom]
+            [hive-dsl.bounded-atom :refer [bclear!]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -171,7 +172,7 @@
                   killed (filter :success results)
                   failed (remove :success results)]
               (when (every? :success results)
-                (reset! hivemind/agent-registry {}))
+                (bclear! hivemind/agent-registry))
               (prom/set-lings-active! (max 0 (- (count slave-ids) (count killed))))
               (core/mcp-success {:killed (count killed)
                                  :failed (count failed)

--- a/src/hive_mcp/tools/swarm/validated_wave.clj
+++ b/src/hive_mcp/tools/swarm/validated_wave.clj
@@ -7,7 +7,9 @@
             [hive-mcp.events.core :as ev]
             [clojure.data.json :as json]
             [clojure.string :as str]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [hive-dsl.bounded-atom :refer [bounded-atom bput! bget bounded-swap!
+                                           bclear! register-sweepable!]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -199,13 +201,19 @@
                                                      :fix-task-count (count fix-tasks)}]))
               (recur fix-tasks (inc iteration) updated-history))))))))
 
-(defonce ^:private validated-wave-sessions (atom {}))
+;; gc-fix-3: validated-wave-sessions — LRU eviction, 50 entries, 1hr TTL
+;; Wave sessions are ephemeral; old completed sessions waste memory.
+(defonce ^:private validated-wave-sessions
+  (bounded-atom {:max-entries 50
+                 :ttl-ms 3600000    ;; 1 hour
+                 :eviction-policy :lru}))
+(register-sweepable! validated-wave-sessions :validated-wave-sessions)
 
 (defn execute-validated-wave-async!
   "Execute a validated wave asynchronously, returning a session-id for polling."
   [tasks opts]
   (let [session-id (str "vw-" (java.util.UUID/randomUUID))]
-    (swap! validated-wave-sessions assoc session-id
+    (bput! validated-wave-sessions session-id
            {:session-id session-id
             :status :running
             :task-count (count tasks)
@@ -213,13 +221,13 @@
     (future
       (try
         (let [result (execute-validated-wave! tasks opts)]
-          (swap! validated-wave-sessions assoc session-id
+          (bput! validated-wave-sessions session-id
                  (merge result
                         {:session-id session-id
                          :completed-at (System/currentTimeMillis)})))
         (catch Exception e
           (log/error e "Async validated wave failed" {:session-id session-id})
-          (swap! validated-wave-sessions assoc session-id
+          (bput! validated-wave-sessions session-id
                  {:session-id session-id
                   :status :failed
                   :error (.getMessage e)
@@ -231,7 +239,7 @@
   "Execute a review wave asynchronously, returning a session-id for polling."
   [tasks opts]
   (let [session-id (str "rw-" (java.util.UUID/randomUUID))]
-    (swap! validated-wave-sessions assoc session-id
+    (bput! validated-wave-sessions session-id
            {:session-id session-id
             :status :running
             :mode :review
@@ -240,13 +248,13 @@
     (future
       (try
         (let [result (execute-review-wave! tasks opts)]
-          (swap! validated-wave-sessions assoc session-id
+          (bput! validated-wave-sessions session-id
                  (merge result
                         {:session-id session-id
                          :completed-at (System/currentTimeMillis)})))
         (catch Exception e
           (log/error e "Async review wave failed" {:session-id session-id})
-          (swap! validated-wave-sessions assoc session-id
+          (bput! validated-wave-sessions session-id
                  {:session-id session-id
                   :status :failed
                   :error (.getMessage e)
@@ -257,13 +265,14 @@
 (defn get-validated-wave-session
   "Get session state for an async validated wave execution."
   [session-id]
-  (get @validated-wave-sessions session-id))
+  (bget validated-wave-sessions session-id))
 
 (defn list-validated-wave-sessions
   "List all validated wave sessions."
   []
-  (->> (vals @validated-wave-sessions)
-       (mapv #(select-keys % [:session-id :status :task-count :started-at :completed-at]))
+  (->> (vals @(:atom validated-wave-sessions))
+       (mapv (fn [entry]
+               (select-keys (:data entry) [:session-id :status :task-count :started-at :completed-at])))
        (sort-by :started-at)))
 
 (defn execute-review-wave!

--- a/src/hive_mcp/workflows/catchup_session.clj
+++ b/src/hive_mcp/workflows/catchup_session.clj
@@ -81,6 +81,7 @@
   (:require [hive.events.fsm :as fsm]
             [hive-mcp.dns.result :as result]
             [hive-mcp.concurrency.pool :as pool]
+            [hive-dsl.context.identity :as ctx-id]
             [taoensso.timbre :as log]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
@@ -360,8 +361,9 @@
         context-refs      (store-context-categories (:context-store-fn resources)
                                                     data project-id 600000)
         piggyback-entries (into (vec (:axioms data)) (:priority-conventions data))
-        caller-id         (or (:_caller_id data) "coordinator")
-        piggyback-id      (if project-id (str caller-id "-" project-id) caller-id)]
+        piggyback-id      (ctx-id/make-piggyback-agent-id
+                           (ctx-id/parse-caller-id (:_caller_id data))
+                           (ctx-id/parse-project-scope project-id))]
     ;; Cursor hygiene: adopt previous cursor + clean up stale state
     (when-let [cursor-adopt-fn (:cursor-adopt-fn resources)]
       (try (cursor-adopt-fn piggyback-id project-id) (catch Exception _)))

--- a/src/hive_mcp/workflows/forge_belt_defaults.clj
+++ b/src/hive_mcp/workflows/forge_belt_defaults.clj
@@ -9,6 +9,7 @@
    2. load-extensions! can overwrite with custom implementations
       ext/register! is idempotent — last write wins."
   (:require [hive-mcp.extensions.registry :as ext]
+            [hive-mcp.config.core :as config]
             [hive.events.fsm :as fsm]
             [taoensso.timbre :as log]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
@@ -54,6 +55,17 @@
         failed  (seq (get-in data [:spark-result :failed]))]
     (and (zero? spawned) (some? failed))))
 
+(defn- context-gather-enabled?*
+  "fb/q7: Check if context-gather phase is enabled via config.
+   Config key: [:forge :context-gather] — default false."
+  [_data]
+  (boolean (config/get-service-value :forge :context-gather :default false)))
+
+(defn- context-gather-disabled?*
+  "fb/q8: Inverse of q7 — skip context-gather when disabled."
+  [data]
+  (not (context-gather-enabled?* data)))
+
 ;; =============================================================================
 ;; Handlers (h1-h7) — Call resources ops, stay decoupled from workflow.clj
 ;; =============================================================================
@@ -95,6 +107,31 @@
            :phase ::spark
            :survey-result result)))
 
+(defn- handle-context-gather*
+  "fb/h3.5: Gather context for surveyed tasks via batch-context-for-tasks.
+   Config-gated — only runs when [:forge :context-gather] is true.
+   Stores result in :context-result for spark to use."
+  [resources data]
+  (let [tasks     (get-in data [:survey-result :tasks] [])
+        task-ids  (mapv :id tasks)
+        directory (:directory resources)
+        result    (try
+                    (when-let [batch-fn (requiring-resolve
+                                         'hive-knowledge.kanban.context-for-task/batch-context-for-tasks)]
+                      (let [scope-fn  (:scope-fn resources)
+                            scope     (when (and scope-fn directory) (scope-fn directory))]
+                        (batch-fn {:tasks      tasks
+                                   :scope      scope
+                                   :file-hints []})))
+                    (catch Exception e
+                      (log/warn "context-gather failed, proceeding without context:" (.getMessage e))
+                      nil))]
+    (log/info "CONTEXT-GATHER:" (count task-ids) "tasks →"
+              (if result (str (count result) " contexts") "skipped"))
+    (assoc data
+           :phase ::spark
+           :context-result result)))
+
 (defn- handle-spark*
   "fb/h4: Spawn lings or dispatch drones via agent-ops.
    When spawn-mode is :drone, delegates to :drone-dispatch-fn.
@@ -105,7 +142,8 @@
         {:keys [update-fn]} kanban-ops
         {:keys [max-slots presets spawn-mode model
                 preset seeds ctx-refs kg-node-ids]} config
-        tasks (get-in data [:survey-result :tasks] [])
+        tasks          (get-in data [:survey-result :tasks] [])
+        context-result (:context-result data)
         result (if (and (= :drone spawn-mode) drone-dispatch-fn)
                  (drone-dispatch-fn
                   (cond-> {:directory directory
@@ -124,12 +162,13 @@
                            :dispatch-fn    dispatch-fn
                            :wait-ready-fn  wait-ready-fn
                            :update-fn      update-fn}
-                    spawn-mode   (assoc :spawn-mode spawn-mode)
-                    model        (assoc :model model)
-                    preset       (assoc :preset preset)
-                    seeds        (assoc :seeds seeds)
-                    ctx-refs     (assoc :ctx_refs ctx-refs)
-                    kg-node-ids  (assoc :kg_node_ids kg-node-ids))))]
+                    spawn-mode     (assoc :spawn-mode spawn-mode)
+                    model          (assoc :model model)
+                    preset         (assoc :preset preset)
+                    seeds          (assoc :seeds seeds)
+                    ctx-refs       (assoc :ctx_refs ctx-refs)
+                    kg-node-ids    (assoc :kg_node_ids kg-node-ids)
+                    context-result (assoc :context-result context-result))))]
     (-> data
         (assoc :phase ::cycle-complete
                :spark-result result
@@ -179,18 +218,18 @@
 
 ;; =============================================================================
 ;; FSM Spec — State graph:
-;;   ::start → ::smite → ::survey →─┬─ ::end   (no tasks — kanban exhausted)
-;;                                   └─ ::spark →─┬─ ::end   (single-shot)
-;;                                                 ├─ ::halt  (quenched)
-;;                                                 ├─ ::end   (all sparked failed)
-;;                                                 ├─ ::start (continuous, loop)
-;;                                                 └─ ::end   (fallback)
+;;   ::start → ::smite → ::survey →─┬─ ::end (no tasks)
+;;                                   └─ ::context-gather (if enabled) →─ ::spark
+;;                                   └─ ::spark (if context-gather disabled)
+;;                                        →─┬─ ::end   (single-shot)
+;;                                           ├─ ::halt  (quenched)
+;;                                           ├─ ::end   (all sparked failed)
+;;                                           ├─ ::start (continuous, loop)
+;;                                           └─ ::end   (fallback)
 ;;
-;; Mixed results: when some lings succeed and some fail:
-;;   - single-shot: goes to ::end, outcome = :partial, success = true
-;;   - continuous:  loops via ::start (next survey picks up remaining tasks)
-;;   - all-failed:  goes to ::end even in continuous mode (no point looping)
-;;   - no-tasks:    exits from ::survey when kanban has 0 todo tasks
+;; Optional ::context-gather state (config-gated via [:forge :context-gather]):
+;;   Gathers zero-LLM-token context for surveyed tasks before spawning.
+;;   When disabled, survey dispatches directly to ::spark (original behavior).
 ;; =============================================================================
 
 (def ^:private forge-belt-spec
@@ -202,8 +241,12 @@
                  :dispatches [[::survey (constantly true)]]}
 
     ::survey    {:handler    handle-survey*
-                 :dispatches [[::fsm/end no-tasks?*]
-                              [::spark   (constantly true)]]}
+                 :dispatches [[::fsm/end         no-tasks?*]
+                              [::context-gather  context-gather-enabled?*]
+                              [::spark           (constantly true)]]}
+
+    ::context-gather {:handler    handle-context-gather*
+                      :dispatches [[::spark (constantly true)]]}
 
     ::spark     {:handler    handle-spark*
                  :dispatches [[::fsm/end   single-shot?*]
@@ -263,21 +306,24 @@
    Called at startup before load-extensions! so extensions can override."
   []
   (ext/register-many!
-   {;; Predicates (q1-q6)
+   {;; Predicates (q1-q8)
     :fb/q1 quenched?*
     :fb/q2 has-tasks?*
     :fb/q3 no-tasks?*
     :fb/q4 continuous?*
     :fb/q5 single-shot?*
     :fb/q6 spark-all-failed?*
-    ;; Handlers (h1-h7)
-    :fb/h1 handle-start*
-    :fb/h2 handle-smite*
-    :fb/h3 handle-survey*
-    :fb/h4 handle-spark*
-    :fb/h5 handle-end*
-    :fb/h6 handle-halt*
-    :fb/h7 handle-error*
+    :fb/q7 context-gather-enabled?*
+    :fb/q8 context-gather-disabled?*
+    ;; Handlers (h1-h7 + h3.5)
+    :fb/h1   handle-start*
+    :fb/h2   handle-smite*
+    :fb/h3   handle-survey*
+    :fb/h3.5 handle-context-gather*
+    :fb/h4   handle-spark*
+    :fb/h5   handle-end*
+    :fb/h6   handle-halt*
+    :fb/h7   handle-error*
     ;; Subscriptions (s1-s2)
     :fb/s1 on-smite-count-change*
     :fb/s2 on-spark-count-change*
@@ -287,4 +333,4 @@
     :fb/strike  run-single-strike*
     :fb/cont    run-continuous-belt*})
 
-  (log/info "Registered forge belt defaults (19 :fb/* extension points)"))
+  (log/info "Registered forge belt defaults (22 :fb/* extension points)"))

--- a/test/hive_mcp/events/deregistration_test.clj
+++ b/test/hive_mcp/events/deregistration_test.clj
@@ -1,0 +1,252 @@
+(ns hive-mcp.events.deregistration-test
+  "Tests for E1: Handler deregistration API for hive-event.
+
+   Validates:
+   - unreg-event removes event handlers
+   - unreg-fx removes effect handlers
+   - unreg-cofx removes coeffect handlers
+   - Deregistering non-existent IDs returns false, no error
+   - registered-events / registered-effects / registered-coeffects inspection
+   - handler-registry-status shape
+   - with-clean-registry isolates test state"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-mcp.events.core :as ev]))
+
+;; =============================================================================
+;; Test fixture: Use with-clean-registry for each test
+;; =============================================================================
+
+(defn clean-registry-fixture [f]
+  (ev/with-clean-registry
+    (f)))
+
+(use-fixtures :each clean-registry-fixture)
+
+;; =============================================================================
+;; E1: unreg-event tests
+;; =============================================================================
+
+(deftest unreg-event-removes-handler
+  (testing "Register then unreg-event: handler no longer fires"
+    (ev/reg-event :test/removable
+                  []
+                  (fn [_coeffects _event]
+                    {:log {:level :info :message "should not fire"}}))
+    (is (true? (ev/handler-registered? :test/removable))
+        "Handler should be registered")
+    (is (true? (ev/unreg-event :test/removable))
+        "unreg-event should return true when handler found")
+    (is (false? (ev/handler-registered? :test/removable))
+        "Handler should no longer be registered")
+    ;; Dispatching should now throw
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"No handler registered"
+                          (ev/dispatch [:test/removable {:data "test"}])))))
+
+(deftest unreg-event-returns-false-for-nonexistent
+  (testing "Unreg non-existent event: returns false, no error"
+    (is (false? (ev/unreg-event :test/does-not-exist))
+        "Should return false for non-existent event")))
+
+(deftest unreg-event-idempotent
+  (testing "Unregistering the same event twice returns false on second call"
+    (ev/reg-event :test/once-only
+                  []
+                  (fn [_ _] {}))
+    (is (true? (ev/unreg-event :test/once-only)))
+    (is (false? (ev/unreg-event :test/once-only))
+        "Second unreg should return false")))
+
+;; =============================================================================
+;; E1: unreg-fx tests
+;; =============================================================================
+
+(deftest unreg-fx-removes-effect-handler
+  (testing "Register then unreg-fx: effect no longer executes"
+    (let [executed (atom false)]
+      (ev/reg-fx :test/removable-fx
+                 (fn [_] (reset! executed true)))
+      (is (fn? (ev/get-fx-handler :test/removable-fx))
+          "Handler should be registered")
+      (is (true? (ev/unreg-fx :test/removable-fx))
+          "unreg-fx should return true when handler found")
+      (is (nil? (ev/get-fx-handler :test/removable-fx))
+          "Handler should be nil after removal")
+      (is (false? @executed)
+          "Effect should never have fired"))))
+
+(deftest unreg-fx-returns-false-for-nonexistent
+  (testing "Unreg non-existent fx: returns false, no error"
+    (is (false? (ev/unreg-fx :test/no-such-fx))
+        "Should return false for non-existent fx")))
+
+;; =============================================================================
+;; E1: unreg-cofx tests
+;; =============================================================================
+
+(deftest unreg-cofx-removes-coeffect-handler
+  (testing "Register then unreg-cofx: coeffect handler removed"
+    (ev/reg-cofx :test/removable-cofx
+                 (fn [coeffects]
+                   (assoc coeffects :test-val 42)))
+    (is (fn? (ev/get-cofx-handler :test/removable-cofx))
+        "Cofx handler should be registered")
+    (is (true? (ev/unreg-cofx :test/removable-cofx))
+        "unreg-cofx should return true when handler found")
+    (is (nil? (ev/get-cofx-handler :test/removable-cofx))
+        "Cofx handler should be nil after removal")))
+
+(deftest unreg-cofx-returns-false-for-nonexistent
+  (testing "Unreg non-existent cofx: returns false, no error"
+    (is (false? (ev/unreg-cofx :test/no-such-cofx))
+        "Should return false for non-existent cofx")))
+
+;; =============================================================================
+;; E1: Inspection API — registered-events
+;; =============================================================================
+
+(deftest registered-events-returns-correct-set
+  (testing "registered-events returns set of all registered event IDs"
+    (is (= #{} (ev/registered-events))
+        "Should be empty in clean registry")
+    (ev/reg-event :test/alpha [] (fn [_ _] {}))
+    (ev/reg-event :test/beta  [] (fn [_ _] {}))
+    (ev/reg-event :test/gamma [] (fn [_ _] {}))
+    (is (= #{:test/alpha :test/beta :test/gamma}
+           (ev/registered-events))
+        "Should contain all three registered events")))
+
+(deftest registered-events-reflects-unreg
+  (testing "registered-events updates after unreg-event"
+    (ev/reg-event :test/stay    [] (fn [_ _] {}))
+    (ev/reg-event :test/go-away [] (fn [_ _] {}))
+    (is (= #{:test/stay :test/go-away} (ev/registered-events)))
+    (ev/unreg-event :test/go-away)
+    (is (= #{:test/stay} (ev/registered-events))
+        "Should only contain :test/stay after unreg")))
+
+;; =============================================================================
+;; E1: Inspection API — registered-effects
+;; =============================================================================
+
+(deftest registered-effects-returns-correct-set
+  (testing "registered-effects returns set of registered fx IDs"
+    (ev/reg-fx :test/fx-alpha (fn [_] nil))
+    (ev/reg-fx :test/fx-beta  (fn [_] nil))
+    (let [fxs (ev/registered-effects)]
+      (is (set? fxs) "Should return a set")
+      (is (contains? fxs :test/fx-alpha))
+      (is (contains? fxs :test/fx-beta)))))
+
+;; =============================================================================
+;; E1: Inspection API — registered-coeffects
+;; =============================================================================
+
+(deftest registered-coeffects-returns-correct-set
+  (testing "registered-coeffects returns set of registered cofx IDs"
+    (ev/reg-cofx :test/cofx-alpha (fn [c] c))
+    (ev/reg-cofx :test/cofx-beta  (fn [c] c))
+    (let [cofxs (ev/registered-coeffects)]
+      (is (set? cofxs) "Should return a set")
+      (is (contains? cofxs :test/cofx-alpha))
+      (is (contains? cofxs :test/cofx-beta)))))
+
+;; =============================================================================
+;; E1: Inspection API — handler-registry-status
+;; =============================================================================
+
+(deftest handler-registry-status-shape
+  (testing "handler-registry-status returns correct shape"
+    (ev/reg-event :test/evt-1 [] (fn [_ _] {}))
+    (ev/reg-event :test/evt-2 [] (fn [_ _] {}))
+    (ev/reg-fx :test/fx-1 (fn [_] nil))
+    (ev/reg-cofx :test/cofx-1 (fn [c] c))
+    (let [status (ev/handler-registry-status)]
+      (is (map? status) "Should return a map")
+      (is (= 2 (:event-count status)) "Should count 2 events")
+      (is (pos? (:fx-count status)) "Should have at least 1 fx")
+      (is (pos? (:cofx-count status)) "Should have at least 1 cofx")
+      (is (vector? (:events status)) "Events should be a vector")
+      (is (vector? (:effects status)) "Effects should be a vector")
+      (is (vector? (:coeffects status)) "Coeffects should be a vector")
+      ;; Verify events are sorted
+      (is (= (sort (:events status)) (seq (:events status)))
+          "Events should be sorted")
+      ;; Verify our registrations are present
+      (is (some #{:test/evt-1} (:events status)))
+      (is (some #{:test/evt-2} (:events status)))
+      (is (some #{:test/fx-1} (:effects status)))
+      (is (some #{:test/cofx-1} (:coeffects status))))))
+
+;; =============================================================================
+;; E1: with-clean-registry isolation
+;; =============================================================================
+
+(deftest with-clean-registry-isolates-state
+  (testing "with-clean-registry provides isolation and restores state"
+    ;; Register something in the outer (test fixture) registry
+    (ev/reg-event :test/outer [] (fn [_ _] {}))
+    (is (ev/handler-registered? :test/outer))
+    ;; Inner block should not see outer registrations (our fixture already
+    ;; gives us a clean registry, so we nest another)
+    (ev/with-clean-registry
+      (is (not (ev/handler-registered? :test/outer))
+          "Inner block should not see outer event handler")
+      (ev/reg-event :test/inner [] (fn [_ _] {}))
+      (is (ev/handler-registered? :test/inner)
+          "Inner registration should be visible inside block"))
+    ;; After block, outer should be restored, inner should be gone
+    (is (ev/handler-registered? :test/outer)
+        "Outer handler should be restored after block")
+    (is (not (ev/handler-registered? :test/inner))
+        "Inner handler should not leak out")))
+
+;; =============================================================================
+;; E1: Thread-safety smoke test
+;; =============================================================================
+
+(deftest unreg-event-thread-safety
+  (testing "Concurrent register/unreg does not throw"
+    (let [ids (mapv #(keyword "test" (str "concurrent-" %)) (range 100))]
+      ;; Register all
+      (doseq [id ids]
+        (ev/reg-event id [] (fn [_ _] {})))
+      ;; Concurrently unreg from multiple threads
+      (let [futures (mapv (fn [id]
+                            (future (ev/unreg-event id)))
+                          ids)
+            results (mapv deref futures)]
+        (is (every? true? results)
+            "All concurrent unreg calls should succeed")
+        (is (empty? (ev/registered-events))
+            "All events should be unregistered")))))
+
+;; =============================================================================
+;; E1: Integration — register, dispatch, unreg, dispatch fails
+;; =============================================================================
+
+(deftest full-lifecycle-register-dispatch-unreg
+  (testing "Full lifecycle: register -> dispatch -> unreg -> dispatch throws"
+    (let [fx-log (atom [])]
+      ;; Register effect and event
+      (ev/reg-fx :test/track (fn [data] (swap! fx-log conj data)))
+      (ev/reg-event :test/lifecycle
+                    []
+                    (fn [_coeffects event]
+                      {:test/track {:event-id (first event)
+                                    :data (second event)}}))
+      ;; Dispatch should work
+      (ev/dispatch [:test/lifecycle {:step "first"}])
+      (is (= 1 (count @fx-log))
+          "Effect should have fired once")
+      (is (= {:event-id :test/lifecycle :data {:step "first"}}
+             (first @fx-log)))
+      ;; Unreg event
+      (ev/unreg-event :test/lifecycle)
+      ;; Dispatch should now throw
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"No handler registered"
+                            (ev/dispatch [:test/lifecycle {:step "second"}])))
+      ;; Effect count unchanged
+      (is (= 1 (count @fx-log))
+          "Effect should not have fired again"))))

--- a/test/hive_mcp/events/file_claim_integration_test.clj
+++ b/test/hive_mcp/events/file_claim_integration_test.clj
@@ -8,7 +8,7 @@
    Tests the FULL flow from release-claim! through the event system
    to hivemind notification:
 
-   release-claim! → :claim/file-released → query waiting → :claim/notify-waiting → targeted shout
+   release-claim! -> :claim/file-released -> query waiting -> :claim/notify-waiting -> targeted shout
 
    These tests verify the complete integration, not just individual handlers.
 
@@ -26,7 +26,8 @@
             [hive-mcp.swarm.datascript :as ds]
             [hive-mcp.swarm.datascript.connection :as conn]
             [hive-mcp.hivemind.core :as hivemind]
-            [hive-mcp.hivemind.state :as hm-state]))
+            [hive-mcp.hivemind.state :as hm-state]
+            [hive-dsl.bounded-atom :refer [bounded-atom bget bcount bclear!]]))
 
 ;; =============================================================================
 ;; Test Fixtures
@@ -38,7 +39,10 @@
    reset-conn!/clear-agent-registry! are guarded by when-not-coordinator."
   [f]
   (let [test-conn (conn/create-conn)
-        test-registry (atom {})]
+        ;; gc-fix-3: use bounded-atom for test registry to match production API
+        test-registry (bounded-atom {:max-entries 100
+                                     :ttl-ms 7200000
+                                     :eviction-policy :lru})]
     (with-redefs [conn/get-conn (fn [] test-conn)
                   conn/ensure-conn (fn [] test-conn)
                   hm-state/agent-registry test-registry]
@@ -71,7 +75,9 @@
 (defn get-agent-messages
   "Get messages for an agent from hivemind registry."
   [agent-id]
-  (get-in @hivemind/agent-registry [agent-id :messages]))
+  ;; bounded-atom: use bget to access wrapped entry data
+  (let [agent-data (bget hivemind/agent-registry agent-id)]
+    (:messages agent-data)))
 
 (defn find-file-available-message
   "Find a :file-available message for a specific file in agent's messages."
@@ -141,7 +147,8 @@
     (wait-for-async)
 
     ;; Assert: No agents should have file-available messages
-    (is (empty? @hivemind/agent-registry)
+    ;; bounded-atom: use bcount instead of (count @...)
+    (is (= 0 (bcount hivemind/agent-registry))
         "No agents should receive notifications when no one is waiting")))
 
 (deftest no-waiting-lings-completed-tasks-ignored

--- a/test/hive_mcp/events/handlers/lifecycle_test.clj
+++ b/test/hive_mcp/events/handlers/lifecycle_test.clj
@@ -1,0 +1,383 @@
+(ns hive-mcp.events.handlers.lifecycle-test
+  "Tests for :lifecycle/sweep event handler and bounded atom sweep.
+
+   gc-fix-4: validates sweep dispatches correctly, stats are accurate,
+   and sweep is idempotent."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-mcp.events.handlers.lifecycle :as lifecycle]
+            [hive-mcp.events.effects.lifecycle :as lifecycle-effects]
+            [hive-mcp.gc.bounded-atom :as batom]
+            [hive-mcp.events.core :as ev]))
+
+;; =============================================================================
+;; Fixtures
+;; =============================================================================
+
+(defn clean-registry-fixture
+  "Reset bounded atom registry and lifecycle state before each test."
+  [f]
+  (batom/reset-registry!)
+  (lifecycle-effects/reset-state!)
+  (f)
+  (batom/reset-registry!)
+  (lifecycle-effects/reset-state!))
+
+(use-fixtures :each clean-registry-fixture)
+
+;; =============================================================================
+;; Helper: Create test bounded atoms
+;; =============================================================================
+
+(defn- make-test-atom
+  "Create a test atom with timestamped entries and register it.
+   Returns the atom."
+  [id max-entries entries]
+  (let [now (System/currentTimeMillis)
+        a   (atom (into {}
+                        (map-indexed
+                         (fn [i entry]
+                           [(str "key-" i)
+                            (merge {:created-at (- now (* i 1000))}
+                                   entry)])
+                         entries)))]
+    (batom/register! id
+      {:name        (name id)
+       :atom-ref    a
+       :max-entries max-entries
+       :ttl-ms      5000  ; 5 second TTL for testing
+       :count-fn    (fn [aref] (count @aref))
+       :evict-fn    (fn [aref {:keys [max-entries ttl-ms now-ms]}]
+                      (let [before (count @aref)
+                            ;; Evict expired entries
+                            _ (when ttl-ms
+                                (swap! aref
+                                       (fn [m]
+                                         (into {}
+                                               (remove (fn [[_k v]]
+                                                         (< (:created-at v)
+                                                            (- now-ms ttl-ms))))
+                                               m))))
+                            ;; Evict over-capacity (keep newest)
+                            _ (when (> (count @aref) max-entries)
+                                (swap! aref
+                                       (fn [m]
+                                         (into {}
+                                               (take max-entries
+                                                     (sort-by (fn [[_k v]] (- (:created-at v)))
+                                                              m))))))
+                            after (count @aref)]
+                        (- before after)))})
+    a))
+
+;; =============================================================================
+;; Handler Tests
+;; =============================================================================
+
+(deftest handle-lifecycle-sweep-produces-correct-effects
+  (testing ":lifecycle/sweep handler produces :lifecycle/sweep-fx and :log effects"
+    (let [coeffects {}
+          event     [:lifecycle/sweep {}]
+          result    (lifecycle/handle-lifecycle-sweep coeffects event)]
+      (is (contains? result :lifecycle/sweep-fx)
+          "Should produce :lifecycle/sweep-fx effect")
+      (is (contains? result :log)
+          "Should produce :log effect")
+      (is (= :info (get-in result [:log :level]))
+          "Log level should be :info"))))
+
+(deftest handle-lifecycle-sweep-passes-atom-ids
+  (testing ":lifecycle/sweep passes atom-ids filter to effect"
+    (let [event  [:lifecycle/sweep {:atom-ids [:my-atom :other-atom]}]
+          result (lifecycle/handle-lifecycle-sweep {} event)]
+      (is (= [:my-atom :other-atom]
+             (get-in result [:lifecycle/sweep-fx :atom-ids]))
+          "Should pass atom-ids to effect"))))
+
+(deftest handle-lifecycle-sweep-nil-atom-ids-for-sweep-all
+  (testing ":lifecycle/sweep with empty data sweeps all"
+    (let [event  [:lifecycle/sweep {}]
+          result (lifecycle/handle-lifecycle-sweep {} event)]
+      (is (nil? (get-in result [:lifecycle/sweep-fx :atom-ids]))
+          "atom-ids should be nil for sweep-all"))))
+
+;; =============================================================================
+;; Bounded Atom Registry Tests
+;; =============================================================================
+
+(deftest register-and-deregister-bounded-atom
+  (testing "Can register and deregister bounded atoms"
+    (let [a (atom {})]
+      (batom/register! :test-atom
+        {:atom-ref    a
+         :max-entries 100
+         :count-fn    (fn [aref] (count @aref))
+         :evict-fn    (fn [_aref _opts] 0)})
+      (is (batom/registered? :test-atom))
+      (is (contains? (batom/registered-ids) :test-atom))
+
+      (batom/deregister! :test-atom)
+      (is (not (batom/registered? :test-atom))))))
+
+(deftest register-is-idempotent
+  (testing "Re-registering with same id overwrites cleanly"
+    (let [a1 (atom {})
+          a2 (atom {})]
+      (batom/register! :test-atom
+        {:atom-ref a1 :max-entries 100
+         :count-fn (fn [aref] (count @aref))
+         :evict-fn (fn [_aref _opts] 0)})
+      (batom/register! :test-atom
+        {:atom-ref a2 :max-entries 200
+         :count-fn (fn [aref] (count @aref))
+         :evict-fn (fn [_aref _opts] 0)})
+      (is (= 200 (:max-entries (batom/get-spec :test-atom)))
+          "Should have updated max-entries"))))
+
+;; =============================================================================
+;; Sweep Stats Accuracy Tests
+;; =============================================================================
+
+(deftest sweep-empty-registry-returns-empty-stats
+  (testing "Sweep with no registered atoms returns empty stats"
+    (let [result (batom/sweep-all!)]
+      (is (= 0 (:total-evicted result)))
+      (is (= [] (:per-atom result)))
+      (is (= 0 (:atom-count result)))
+      (is (number? (:duration-ms result))))))
+
+(deftest sweep-with-no-evictions-returns-zero
+  (testing "Sweep with atoms under capacity and within TTL returns zero evictions"
+    (make-test-atom :fresh-atom 100 [{:value "a"} {:value "b"}])
+    (let [result (batom/sweep-all!)]
+      (is (= 0 (:total-evicted result)))
+      (is (= 1 (:atom-count result)))
+      (is (= 1 (count (:per-atom result))))
+      (let [atom-stats (first (:per-atom result))]
+        (is (= :fresh-atom (:atom-id atom-stats)))
+        (is (= "fresh-atom" (:name atom-stats)))
+        (is (= 0 (:evicted atom-stats)))
+        (is (= 2 (:remaining atom-stats)))))))
+
+(deftest sweep-evicts-over-capacity-entries
+  (testing "Sweep evicts entries when over max-entries capacity"
+    (let [a (atom {})]
+      ;; Add 10 entries
+      (doseq [i (range 10)]
+        (swap! a assoc (str "key-" i)
+               {:created-at (- (System/currentTimeMillis) (* i 100))
+                :value      i}))
+      ;; Register with max 5
+      (batom/register! :over-cap
+        {:atom-ref    a
+         :max-entries 5
+         :count-fn    (fn [aref] (count @aref))
+         :evict-fn    (fn [aref {:keys [max-entries]}]
+                        (let [before (count @aref)]
+                          (when (> before max-entries)
+                            (swap! aref
+                                   (fn [m]
+                                     (into {}
+                                           (take max-entries
+                                                 (sort-by (fn [[_k v]] (- (:created-at v)))
+                                                          m))))))
+                          (- before (count @aref))))})
+      (let [result (batom/sweep-all!)]
+        (is (= 5 (:total-evicted result))
+            "Should evict 5 entries (10 - 5 max)")
+        (is (= 5 (count @a))
+            "Atom should have 5 entries remaining")))))
+
+(deftest sweep-evicts-expired-entries
+  (testing "Sweep evicts TTL-expired entries"
+    (let [now (System/currentTimeMillis)
+          a   (atom {"fresh"   {:created-at now :value "new"}
+                     "stale-1" {:created-at (- now 10000) :value "old1"}
+                     "stale-2" {:created-at (- now 20000) :value "old2"}})]
+      (batom/register! :ttl-test
+        {:atom-ref    a
+         :max-entries 100
+         :ttl-ms      5000
+         :count-fn    (fn [aref] (count @aref))
+         :evict-fn    (fn [aref {:keys [ttl-ms now-ms]}]
+                        (let [before (count @aref)]
+                          (when ttl-ms
+                            (swap! aref
+                                   (fn [m]
+                                     (into {}
+                                           (remove (fn [[_k v]]
+                                                     (< (:created-at v)
+                                                        (- now-ms ttl-ms))))
+                                           m))))
+                          (- before (count @aref))))})
+      (let [result (batom/sweep-all!)]
+        (is (= 2 (:total-evicted result))
+            "Should evict 2 expired entries")
+        (is (= 1 (count @a))
+            "Only fresh entry should remain")
+        (is (contains? @a "fresh")
+            "Fresh entry should survive")))))
+
+(deftest sweep-stats-multi-atom
+  (testing "Sweep collects per-atom stats from multiple registered atoms"
+    (let [now (System/currentTimeMillis)
+          a1  (atom {"k1" {:created-at now}
+                     "k2" {:created-at (- now 20000)}})
+          a2  (atom (into {} (map (fn [i] [(str "e-" i) {:created-at now}])
+                                  (range 8))))]
+      ;; a1: TTL eviction (1 stale)
+      (batom/register! :atom-a
+        {:name     "atom-alpha"
+         :atom-ref a1
+         :max-entries 100
+         :ttl-ms   5000
+         :count-fn (fn [aref] (count @aref))
+         :evict-fn (fn [aref {:keys [ttl-ms now-ms]}]
+                     (let [before (count @aref)]
+                       (swap! aref
+                              (fn [m]
+                                (into {} (remove (fn [[_k v]]
+                                                   (< (:created-at v)
+                                                      (- now-ms ttl-ms)))
+                                                 m))))
+                       (- before (count @aref))))})
+      ;; a2: capacity eviction (8 entries, max 3)
+      (batom/register! :atom-b
+        {:name     "atom-beta"
+         :atom-ref a2
+         :max-entries 3
+         :count-fn (fn [aref] (count @aref))
+         :evict-fn (fn [aref {:keys [max-entries]}]
+                     (let [before (count @aref)]
+                       (when (> before max-entries)
+                         (swap! aref
+                                (fn [m]
+                                  (into {} (take max-entries m)))))
+                       (- before (count @aref))))})
+
+      (let [result  (batom/sweep-all!)
+            by-id   (into {} (map (fn [s] [(:atom-id s) s]) (:per-atom result)))]
+        (is (= 6 (:total-evicted result))
+            "Total: 1 (TTL) + 5 (capacity) = 6")
+        (is (= 2 (:atom-count result)))
+        ;; atom-a
+        (is (= 1 (:evicted (get by-id :atom-a))))
+        (is (= 1 (:remaining (get by-id :atom-a))))
+        (is (= "atom-alpha" (:name (get by-id :atom-a))))
+        ;; atom-b
+        (is (= 5 (:evicted (get by-id :atom-b))))
+        (is (= 3 (:remaining (get by-id :atom-b))))
+        (is (= "atom-beta" (:name (get by-id :atom-b))))))))
+
+;; =============================================================================
+;; Idempotency Tests
+;; =============================================================================
+
+(deftest sweep-is-idempotent
+  (testing "Calling sweep twice does not double-evict"
+    (let [now (System/currentTimeMillis)
+          a   (atom {"fresh" {:created-at now}
+                     "stale" {:created-at (- now 20000)}})]
+      (batom/register! :idem-test
+        {:atom-ref    a
+         :max-entries 100
+         :ttl-ms      5000
+         :count-fn    (fn [aref] (count @aref))
+         :evict-fn    (fn [aref {:keys [ttl-ms now-ms]}]
+                        (let [before (count @aref)]
+                          (when ttl-ms
+                            (swap! aref
+                                   (fn [m]
+                                     (into {}
+                                           (remove (fn [[_k v]]
+                                                     (< (:created-at v)
+                                                        (- now-ms ttl-ms))))
+                                           m))))
+                          (- before (count @aref))))})
+
+      ;; First sweep: evicts 1 stale entry
+      (let [r1 (batom/sweep-all!)]
+        (is (= 1 (:total-evicted r1)))
+        (is (= 1 (count @a))))
+
+      ;; Second sweep: nothing to evict
+      (let [r2 (batom/sweep-all!)]
+        (is (= 0 (:total-evicted r2))
+            "Second sweep should evict nothing")
+        (is (= 1 (count @a))
+            "Atom should still have 1 entry")))))
+
+;; =============================================================================
+;; Error Handling Tests
+;; =============================================================================
+
+(deftest sweep-handles-failing-evict-fn
+  (testing "Sweep catches errors from individual atoms without stopping"
+    (let [good-atom (atom {"k1" {:created-at (System/currentTimeMillis)}})]
+      ;; Register an atom with a failing evict-fn
+      (batom/register! :bad-atom
+        {:atom-ref    (atom {})
+         :max-entries 1
+         :count-fn    (fn [_] 0)
+         :evict-fn    (fn [_ _] (throw (Exception. "eviction boom")))})
+      ;; Register a good atom
+      (batom/register! :good-atom
+        {:atom-ref    good-atom
+         :max-entries 100
+         :count-fn    (fn [aref] (count @aref))
+         :evict-fn    (fn [_ _] 0)})
+
+      (let [result (batom/sweep-all!)
+            by-id  (into {} (map (fn [s] [(:atom-id s) s]) (:per-atom result)))]
+        (is (= 2 (:atom-count result))
+            "Should still process both atoms")
+        (is (some? (:error (get by-id :bad-atom)))
+            "Bad atom should have error")
+        (is (nil? (:error (get by-id :good-atom)))
+            "Good atom should not have error")))))
+
+;; =============================================================================
+;; Integration: Full dispatch via event system
+;; =============================================================================
+
+(deftest full-dispatch-integration
+  (testing "Full event dispatch cycle: :lifecycle/sweep -> :lifecycle/sweep-fx"
+    (ev/with-clean-registry
+      ;; Register handler and effect
+      (lifecycle/reset-registration!)
+      (lifecycle/register-handlers!)
+      (ev/reg-fx :lifecycle/sweep-fx
+                 (fn [data]
+                   ;; Use the real sweep
+                   (batom/sweep-all!)))
+      ;; Also register :log effect to avoid warnings
+      (ev/reg-fx :log (fn [_] nil))
+
+      ;; Setup: register a bounded atom with stale entries
+      (let [now (System/currentTimeMillis)
+            a   (atom {"fresh" {:created-at now}
+                       "old"   {:created-at (- now 30000)}})]
+        (batom/register! :dispatch-test
+          {:atom-ref    a
+           :max-entries 100
+           :ttl-ms      5000
+           :count-fn    (fn [aref] (count @aref))
+           :evict-fn    (fn [aref {:keys [ttl-ms now-ms]}]
+                          (let [before (count @aref)]
+                            (when ttl-ms
+                              (swap! aref
+                                     (fn [m]
+                                       (into {}
+                                             (remove (fn [[_k v]]
+                                                       (< (:created-at v)
+                                                          (- now-ms ttl-ms))))
+                                             m))))
+                            (- before (count @aref))))})
+
+        ;; Dispatch the sweep event
+        (ev/dispatch [:lifecycle/sweep {}])
+
+        ;; Verify the sweep happened
+        (is (= 1 (count @a))
+            "Stale entry should have been evicted via event dispatch")
+        (is (contains? @a "fresh")
+            "Fresh entry should survive")))))

--- a/test/hive_mcp/events/metrics_test.clj
+++ b/test/hive_mcp/events/metrics_test.clj
@@ -1,28 +1,34 @@
 (ns hive-mcp.events.metrics-test
-  "Tests for metrics interceptor - POC-15.
+  "Tests for metrics interceptor - POC-15 + E2 bounded metrics buffer.
 
    Validates:
    - Per-event-type dispatch counting
    - Handler execution time measurement
-   - get-metrics and reset-metrics! functions"
+   - get-metrics and reset-metrics! functions
+   - Bounded timings buffers (FIFO eviction)
+   - Configurable buffer limits
+   - Buffer metadata in get-metrics
+   - Dropped counter tracking"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [hive-mcp.events.core :as ev]
             [hive-mcp.telemetry.prometheus :as prom]))
 
 ;; =============================================================================
-;; Test fixture: Reset metrics before each test
+;; Test fixture: Reset metrics and config before each test
 ;; =============================================================================
 
 (defn reset-metrics-fixture [f]
   (ev/reset-metrics!)
+  (ev/configure-metrics! {:max-timings 1000 :max-timings-per-type 200})
   (f)
-  (ev/reset-metrics!))
+  (ev/reset-metrics!)
+  (ev/configure-metrics! {:max-timings 1000 :max-timings-per-type 200}))
 
 (use-fixtures :each reset-metrics-fixture)
 
 ;; =============================================================================
-;; POC-15: Metrics interceptor tests
+;; POC-15: Metrics interceptor tests (original, preserved)
 ;; =============================================================================
 
 (deftest metrics-interceptor-exists
@@ -41,7 +47,11 @@
       (is (contains? m :errors) "Should have :errors")
       (is (contains? m :avg-dispatch-ms) "Should have :avg-dispatch-ms")
       (is (contains? m :avg-by-type) "Should have :avg-by-type")
-      (is (contains? m :timings-count) "Should have :timings-count"))))
+      (is (contains? m :timings-count) "Should have :timings-count")
+      ;; E2: buffer metadata
+      (is (contains? m :timings-buffer-size) "Should have :timings-buffer-size")
+      (is (contains? m :timings-buffer-capacity) "Should have :timings-buffer-capacity")
+      (is (contains? m :timings-dropped) "Should have :timings-dropped"))))
 
 (deftest reset-metrics-clears-all-counters
   (testing "reset-metrics! clears all metrics to initial state"
@@ -54,7 +64,10 @@
         (is (= 0 (:effects-executed after)))
         (is (= 0 (:errors after)))
         (is (= 0 (:timings-count after)))
-        (is (= {} (:avg-by-type after)))))))
+        (is (= {} (:avg-by-type after)))
+        ;; E2: dropped counter resets too
+        (is (= 0 (:timings-dropped after))
+            "reset-metrics! should clear dropped counter")))))
 
 (deftest metrics-interceptor-tracks-total-count
   (testing "metrics interceptor increments total event count"
@@ -129,8 +142,10 @@
           ":slow-event should have higher average time than :fast-event"))))
 
 (deftest metrics-interceptor-rolling-window
-  (testing "metrics uses rolling window of 100 samples"
+  (testing "metrics uses bounded rolling window (default 1000 global, 200 per-type)"
     (ev/reset-metrics!)
+    ;; Use small limits for this test
+    (ev/configure-metrics! {:max-timings 100 :max-timings-per-type 100})
     (let [before-fn (:before ev/metrics)
           after-fn (:after ev/metrics)
           ;; Dispatch 150 events
@@ -219,3 +234,254 @@
           "request-duration-seconds histogram present")
       (is (str/includes? metrics "tool=\"event-dispatch-prom-duration-test\"")
           "tool label with event-dispatch prefix recorded"))))
+
+;; =============================================================================
+;; E2: Bounded metrics buffer tests
+;; =============================================================================
+
+(deftest timings-capped-at-configured-max
+  (testing "global :timings vector is capped at :max-timings"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 50 :max-timings-per-type 200})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      (dotimes [_ 80]
+        (let [ctx {:coeffects {:event [:cap-test {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (let [m (ev/get-metrics)]
+        (is (= 50 (:timings-count m))
+            "Global timings should be capped at 50")
+        (is (= 50 (:timings-buffer-size m))
+            "Buffer size should match timings count")
+        (is (= 50 (:timings-buffer-capacity m))
+            "Buffer capacity should reflect configured max")))))
+
+(deftest per-type-timings-capped-at-configured-max
+  (testing "per-type timings are capped at :max-timings-per-type"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 5000 :max-timings-per-type 30})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      (dotimes [_ 60]
+        (let [ctx {:coeffects {:event [:type-cap-test {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (let [m (ev/get-metrics)
+            type-timings (get-in m [:timings-by-type :type-cap-test])]
+        (is (= 30 (count type-timings))
+            "Per-type timings should be capped at 30")
+        ;; Global should have all 60 since cap is 5000
+        (is (= 60 (:timings-count m))
+            "Global timings should have all 60 (cap is 5000)")))))
+
+(deftest oldest-timings-dropped-first-fifo
+  (testing "oldest timings are dropped first (FIFO order preserved)"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 5 :max-timings-per-type 5})
+    (let [;; We need to inject known timing values directly to test FIFO order.
+          ;; Use the metrics atom directly via the var for testing.
+          metrics-atom (var-get #'hive-mcp.events.core/*metrics)]
+      ;; Manually set up timings with known values [1.0 2.0 3.0 4.0 5.0]
+      (swap! metrics-atom assoc
+             :timings [1.0 2.0 3.0 4.0 5.0]
+             :timings-by-type {:test-event [1.0 2.0 3.0 4.0 5.0]})
+      ;; Now dispatch one more event through the interceptor to add a new timing
+      (let [before-fn (:before ev/metrics)
+            after-fn (:after ev/metrics)
+            ctx {:coeffects {:event [:test-event {}]}
+                 :effects {}
+                 :queue []
+                 :stack []}
+            ctx-after (-> ctx before-fn after-fn)
+            m (ev/get-metrics)
+            global-timings (:timings m)
+            type-timings (get-in m [:timings-by-type :test-event])]
+        ;; Oldest (1.0) should be gone, newest should be at the end
+        (is (= 5 (count global-timings))
+            "Global timings should remain at cap 5")
+        (is (= 5 (count type-timings))
+            "Per-type timings should remain at cap 5")
+        ;; First element should no longer be 1.0 (it was dropped)
+        (is (not= 1.0 (first global-timings))
+            "Oldest timing (1.0) should have been evicted from global")
+        (is (= 2.0 (first global-timings))
+            "Second-oldest (2.0) should now be first in global")
+        (is (not= 1.0 (first type-timings))
+            "Oldest timing (1.0) should have been evicted from per-type")
+        (is (= 2.0 (first type-timings))
+            "Second-oldest (2.0) should now be first in per-type")))))
+
+(deftest averages-correct-on-bounded-window
+  (testing "averages are computed correctly on the bounded window"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 5 :max-timings-per-type 5})
+    (let [metrics-atom (var-get #'hive-mcp.events.core/*metrics)]
+      ;; Set known timing values
+      (swap! metrics-atom assoc
+             :timings [10.0 20.0 30.0 40.0 50.0]
+             :timings-by-type {:avg-event [10.0 20.0 30.0 40.0 50.0]}
+             :events-dispatched 5)
+      (let [m (ev/get-metrics)]
+        (is (= 30.0 (:avg-dispatch-ms m))
+            "Average should be (10+20+30+40+50)/5 = 30.0")
+        (is (= 30.0 (get-in m [:avg-by-type :avg-event]))
+            "Per-type average should be 30.0")))))
+
+(deftest configure-metrics-changes-limits
+  (testing "configure-metrics! changes buffer limits"
+    (ev/reset-metrics!)
+    ;; Set small limits
+    (ev/configure-metrics! {:max-timings 10 :max-timings-per-type 5})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      ;; Fill beyond limits
+      (dotimes [_ 20]
+        (let [ctx {:coeffects {:event [:config-test {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (let [m (ev/get-metrics)]
+        (is (= 10 (:timings-count m))
+            "Global timings should be capped at new limit 10")
+        (is (= 10 (:timings-buffer-capacity m))
+            "Capacity should reflect new limit")
+        (is (= 5 (count (get-in m [:timings-by-type :config-test])))
+            "Per-type timings should be capped at new limit 5")))))
+
+(deftest get-metrics-includes-buffer-metadata
+  (testing "get-metrics includes buffer size, capacity, and dropped count"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 10 :max-timings-per-type 200})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      ;; Dispatch 15 events to cause 5 drops in global timings
+      (dotimes [_ 15]
+        (let [ctx {:coeffects {:event [:meta-test {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (let [m (ev/get-metrics)]
+        (is (= 10 (:timings-buffer-size m))
+            "Buffer size should be 10 (at capacity)")
+        (is (= 10 (:timings-buffer-capacity m))
+            "Buffer capacity should be 10")
+        (is (pos? (:timings-dropped m))
+            "Dropped count should be positive after overflow")
+        ;; 15 events dispatched, global cap is 10, so 5 global drops.
+        ;; Per-type cap is 200, so 0 type drops.
+        (is (= 5 (:timings-dropped m))
+            "Should have dropped exactly 5 timings from global buffer")))))
+
+(deftest timings-dropped-accumulates
+  (testing "timings-dropped counter accumulates across multiple overflows"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 5 :max-timings-per-type 3})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      ;; First batch: 10 events
+      (dotimes [_ 10]
+        (let [ctx {:coeffects {:event [:accum-test {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (let [m1 (ev/get-metrics)
+            dropped-1 (:timings-dropped m1)]
+        ;; 10 events, global cap 5 -> 5 global drops
+        ;; 10 events, per-type cap 3 -> 7 per-type drops
+        ;; Total: 12 drops
+        (is (= 12 dropped-1)
+            "Should have 12 drops after first batch (5 global + 7 per-type)")
+
+        ;; Second batch: 5 more events
+        (dotimes [_ 5]
+          (let [ctx {:coeffects {:event [:accum-test {}]}
+                     :effects {}
+                     :queue []
+                     :stack []}]
+            (-> ctx before-fn after-fn)))
+        (let [m2 (ev/get-metrics)
+              dropped-2 (:timings-dropped m2)]
+          ;; 5 more events, both buffers already full
+          ;; 5 global drops + 5 per-type drops = 10 more
+          (is (= (+ dropped-1 10) dropped-2)
+              "Dropped counter should accumulate across batches"))))))
+
+(deftest reset-metrics-clears-dropped-counter
+  (testing "reset-metrics! clears the dropped counter"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 5 :max-timings-per-type 5})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      ;; Cause some drops
+      (dotimes [_ 20]
+        (let [ctx {:coeffects {:event [:reset-drop-test {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (is (pos? (:timings-dropped (ev/get-metrics)))
+          "Should have drops before reset")
+      ;; Reset
+      (ev/reset-metrics!)
+      (let [m (ev/get-metrics)]
+        (is (= 0 (:timings-dropped m))
+            "Dropped counter should be 0 after reset")
+        (is (= 0 (:timings-count m))
+            "Timings should be empty after reset")
+        (is (= {} (:timings-by-type m))
+            "Per-type timings should be empty after reset")))))
+
+(deftest timings-remain-vectors
+  (testing "bounded timings remain persistent vectors (not lazy seqs)"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 5 :max-timings-per-type 5})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      ;; Overflow the buffers
+      (dotimes [_ 10]
+        (let [ctx {:coeffects {:event [:vec-test {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (let [m (ev/get-metrics)]
+        (is (vector? (:timings m))
+            "Global timings should be a vector after overflow")
+        (is (vector? (get-in m [:timings-by-type :vec-test]))
+            "Per-type timings should be a vector after overflow")))))
+
+(deftest multiple-event-types-bounded-independently
+  (testing "different event types have independent per-type bounds"
+    (ev/reset-metrics!)
+    (ev/configure-metrics! {:max-timings 5000 :max-timings-per-type 10})
+    (let [before-fn (:before ev/metrics)
+          after-fn (:after ev/metrics)]
+      ;; Dispatch 20 of type-a, 5 of type-b
+      (dotimes [_ 20]
+        (let [ctx {:coeffects {:event [:type-a {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (dotimes [_ 5]
+        (let [ctx {:coeffects {:event [:type-b {}]}
+                   :effects {}
+                   :queue []
+                   :stack []}]
+          (-> ctx before-fn after-fn)))
+      (let [m (ev/get-metrics)]
+        (is (= 10 (count (get-in m [:timings-by-type :type-a])))
+            "type-a should be capped at 10")
+        (is (= 5 (count (get-in m [:timings-by-type :type-b])))
+            "type-b should have all 5 (under cap)")
+        ;; Global should have all 25 since cap is 5000
+        (is (= 25 (:timings-count m))
+            "Global timings should have all 25")))))

--- a/test/hive_mcp/gc/gc_sweep_integration_test.clj
+++ b/test/hive_mcp/gc/gc_sweep_integration_test.clj
@@ -1,0 +1,263 @@
+(ns hive-mcp.gc.gc-sweep-integration-test
+  "gc-fix-5: Tests for GC sweep integration with crystal/session lifecycle
+   and periodic housekeeping scheduler.
+
+   Tests cover:
+   1. Sweep is callable from session wrap path (trigger-gc-sweep!)
+   2. Housekeeping sweep includes GC sweep results
+   3. Sweep on session wrap with registered bounded atoms evicts stale entries
+   4. Housekeeping scheduler start/stop lifecycle
+   5. Sweep stats are logged at :info level"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-mcp.gc.bounded-atom :as batom]
+            [hive-mcp.scheduler.housekeeping :as housekeeping]
+            [hive-mcp.events.handlers.lifecycle :as lifecycle]
+            [hive-mcp.events.effects.lifecycle :as lifecycle-effects]
+            [hive-mcp.events.core :as ev]))
+
+;; =============================================================================
+;; Fixtures
+;; =============================================================================
+
+(defn clean-fixture
+  "Reset bounded atom registry, lifecycle state, and stop housekeeping scheduler."
+  [f]
+  (batom/reset-registry!)
+  (lifecycle-effects/reset-state!)
+  (housekeeping/stop!)
+  (try
+    (f)
+    (finally
+      (batom/reset-registry!)
+      (lifecycle-effects/reset-state!)
+      (housekeeping/stop!))))
+
+(use-fixtures :each clean-fixture)
+
+;; =============================================================================
+;; Helpers
+;; =============================================================================
+
+(defn- make-test-atom-with-stale
+  "Create a test atom with a mix of fresh and stale entries.
+   Returns the atom."
+  [id max-entries ttl-ms fresh-count stale-count]
+  (let [now (System/currentTimeMillis)
+        fresh-entries (map (fn [i] [(str "fresh-" i) {:created-at now :value i}])
+                          (range fresh-count))
+        stale-entries (map (fn [i] [(str "stale-" i) {:created-at (- now (* 2 ttl-ms)) :value i}])
+                          (range stale-count))
+        a (atom (into {} (concat fresh-entries stale-entries)))]
+    (batom/register! id
+      {:name        (name id)
+       :atom-ref    a
+       :max-entries max-entries
+       :ttl-ms      ttl-ms
+       :count-fn    (fn [aref] (count @aref))
+       :evict-fn    (fn [aref {:keys [max-entries ttl-ms now-ms]}]
+                      (let [before (count @aref)]
+                        ;; Evict expired entries
+                        (when ttl-ms
+                          (swap! aref
+                                 (fn [m]
+                                   (into {}
+                                         (remove (fn [[_k v]]
+                                                   (< (:created-at v)
+                                                      (- now-ms ttl-ms))))
+                                         m))))
+                        ;; Evict over-capacity (keep newest)
+                        (when (> (count @aref) max-entries)
+                          (swap! aref
+                                 (fn [m]
+                                   (into {}
+                                         (take max-entries
+                                               (sort-by (fn [[_k v]] (- (:created-at v)))
+                                                        m))))))
+                        (- before (count @aref))))})
+    a))
+
+;; =============================================================================
+;; Test: Direct sweep-all! works as expected
+;; =============================================================================
+
+(deftest sweep-all-evicts-stale-entries
+  (testing "sweep-all! evicts stale entries from registered bounded atoms"
+    (let [a (make-test-atom-with-stale :test-cache 100 5000 3 2)]
+      (is (= 5 (count @a)) "Should start with 5 entries")
+      (let [result (batom/sweep-all!)]
+        (is (= 2 (:total-evicted result)) "Should evict 2 stale entries")
+        (is (= 3 (count @a)) "Should have 3 fresh entries remaining")
+        (is (= 1 (:atom-count result)) "Should report 1 atom swept")))))
+
+;; =============================================================================
+;; Test: trigger-sweep! dispatches through event system
+;; =============================================================================
+
+(deftest trigger-sweep-dispatches-via-events
+  (testing "trigger-sweep! dispatches :lifecycle/sweep event correctly"
+    (ev/with-clean-registry
+      ;; Register handler and effect
+      (lifecycle/reset-registration!)
+      (lifecycle/register-handlers!)
+      (ev/reg-fx :lifecycle/sweep-fx
+                 (fn [_data]
+                   (batom/sweep-all!)))
+      (ev/reg-fx :log (fn [_] nil))
+
+      ;; Set up bounded atom with stale entries
+      (let [a (make-test-atom-with-stale :trigger-test 100 5000 2 3)]
+        (is (= 5 (count @a)) "Should start with 5 entries")
+
+        ;; Trigger sweep via the convenience function
+        (lifecycle/trigger-sweep!)
+
+        ;; Verify sweep happened
+        (is (= 2 (count @a)) "Should have 2 fresh entries after sweep")))))
+
+;; =============================================================================
+;; Test: Housekeeping sweep includes GC sweep
+;; =============================================================================
+
+(deftest housekeeping-sweep-includes-gc-sweep
+  (testing "housekeeping-sweep! includes bounded atom GC sweep results"
+    (let [a (make-test-atom-with-stale :hk-test 100 5000 2 4)]
+      (is (= 6 (count @a)) "Should start with 6 entries")
+
+      (let [result (housekeeping/housekeeping-sweep!)]
+        ;; The gc-sweep key should be present in housekeeping results
+        (is (contains? result :gc-sweep) "Should have :gc-sweep in result")
+
+        ;; GC sweep should have evicted the stale entries
+        (let [gc (get result :gc-sweep)]
+          (is (= 4 (:total-evicted gc)) "GC sweep should evict 4 stale entries")
+          (is (= 1 (:atom-count gc)) "Should report 1 atom swept"))
+
+        ;; Atom should only have fresh entries
+        (is (= 2 (count @a)) "Should have 2 fresh entries remaining")
+
+        ;; Other housekeeping results should also be present
+        (is (contains? result :callbacks) "Should have :callbacks")
+        (is (contains? result :async-batches) "Should have :async-batches")
+        (is (contains? result :event-journal) "Should have :event-journal")
+        (is (contains? result :saa-states) "Should have :saa-states")
+        (is (pos? (:sweep-number result)) "Should have positive sweep number")
+        (is (>= (:duration-ms result) 0) "Should have non-negative duration")))))
+
+;; =============================================================================
+;; Test: Housekeeping sweep is idempotent for GC
+;; =============================================================================
+
+(deftest housekeeping-gc-sweep-idempotent
+  (testing "Running housekeeping twice doesn't double-evict GC entries"
+    (let [a (make-test-atom-with-stale :idem-hk 100 5000 3 2)]
+      ;; First sweep: evicts 2 stale
+      (let [r1 (housekeeping/housekeeping-sweep!)]
+        (is (= 2 (get-in r1 [:gc-sweep :total-evicted])))
+        (is (= 3 (count @a))))
+
+      ;; Second sweep: nothing to evict
+      (let [r2 (housekeeping/housekeeping-sweep!)]
+        (is (= 0 (get-in r2 [:gc-sweep :total-evicted]))
+            "Second sweep should evict nothing")
+        (is (= 3 (count @a))
+            "Atom should still have 3 entries")))))
+
+;; =============================================================================
+;; Test: Housekeeping scheduler lifecycle
+;; =============================================================================
+
+(deftest housekeeping-scheduler-start-stop
+  (testing "Housekeeping scheduler can be started and stopped cleanly"
+    (let [start-result (housekeeping/start!)]
+      (if (:started start-result)
+        (do
+          (is (true? (:running? (housekeeping/status)))
+              "Should report running after start")
+          (let [stop-result (housekeeping/stop!)]
+            (is (true? (:stopped stop-result))
+                "Should report stopped")
+            (is (false? (:running? (housekeeping/status)))
+                "Should report not-running after stop")))
+        ;; If disabled via config, that's OK
+        (is (string? (:reason start-result))
+            "Should have reason when not started")))))
+
+(deftest housekeeping-scheduler-start-idempotent
+  (testing "Starting housekeeping scheduler twice returns already-running"
+    (let [r1 (housekeeping/start!)]
+      (when (:started r1)
+        (let [r2 (housekeeping/start!)]
+          (is (false? (:started r2)))
+          (is (= "already-running" (:reason r2))))))))
+
+(deftest housekeeping-stop-when-not-running
+  (testing "Stopping when not running is safe"
+    (let [result (housekeeping/stop!)]
+      (is (false? (:stopped result)))
+      (is (= "not-running" (:reason result))))))
+
+;; =============================================================================
+;; Test: Housekeeping status introspection
+;; =============================================================================
+
+(deftest housekeeping-status-shows-gc-sweep-results
+  (testing "Status shows last sweep result including GC sweep data"
+    (make-test-atom-with-stale :status-test 100 5000 1 1)
+    (housekeeping/housekeeping-sweep!)
+
+    (let [status (housekeeping/status)]
+      (is (pos? (:sweep-count status)) "Should have sweep count > 0")
+      (is (some? (:last-run status)) "Should have last-run timestamp")
+      (is (some? (:last-result status)) "Should have last-result")
+      (is (contains? (:last-result status) :gc-sweep)
+          "Last result should contain :gc-sweep"))))
+
+;; =============================================================================
+;; Test: GC sweep handles empty registry gracefully
+;; =============================================================================
+
+(deftest housekeeping-gc-sweep-empty-registry
+  (testing "Housekeeping GC sweep with no registered atoms returns zero stats"
+    (let [result (housekeeping/housekeeping-sweep!)
+          gc (:gc-sweep result)]
+      (is (= 0 (:total-evicted gc)) "Should evict nothing with empty registry")
+      (is (= 0 (:atom-count gc)) "Should report 0 atoms"))))
+
+;; =============================================================================
+;; Test: GC sweep error isolation
+;; =============================================================================
+
+(deftest housekeeping-gc-sweep-error-isolation
+  (testing "GC sweep error in one atom doesn't crash housekeeping"
+    ;; Register a failing atom
+    (batom/register! :bad-atom
+      {:atom-ref    (atom {})
+       :max-entries 1
+       :count-fn    (fn [_] 0)
+       :evict-fn    (fn [_ _] (throw (Exception. "boom")))})
+    ;; Register a good atom with stale entries
+    (make-test-atom-with-stale :good-atom 100 5000 1 1)
+
+    (let [result (housekeeping/housekeeping-sweep!)
+          gc (:gc-sweep result)]
+      ;; Sweep should complete (not crash)
+      (is (map? gc) "GC sweep should return a map")
+      (is (= 2 (:atom-count gc)) "Should have processed both atoms")
+      ;; The good atom's stale entry should be evicted
+      (is (pos? (:total-evicted gc))
+          "Should have evicted at least from the good atom"))))
+
+;; =============================================================================
+;; Test: Multiple atoms swept in single housekeeping pass
+;; =============================================================================
+
+(deftest housekeeping-sweeps-multiple-atoms
+  (testing "Housekeeping GC sweep handles multiple bounded atoms"
+    (let [a1 (make-test-atom-with-stale :cache-1 100 5000 2 3)
+          a2 (make-test-atom-with-stale :cache-2 100 5000 1 2)
+          result (housekeeping/housekeeping-sweep!)
+          gc (:gc-sweep result)]
+      (is (= 5 (:total-evicted gc)) "Should evict 3+2=5 stale entries total")
+      (is (= 2 (:atom-count gc)) "Should report 2 atoms swept")
+      (is (= 2 (count @a1)) "cache-1 should have 2 fresh entries")
+      (is (= 1 (count @a2)) "cache-2 should have 1 fresh entry"))))

--- a/test/hive_mcp/hivemind_ling_test.clj
+++ b/test/hive_mcp/hivemind_ling_test.clj
@@ -9,7 +9,8 @@
    
    Each test is independent with state reset between tests."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [hive-mcp.hivemind.core :as hivemind]))
+            [hive-mcp.hivemind.core :as hivemind]
+            [hive-dsl.bounded-atom :refer [bget bcount bclear!]]))
 
 ;;; Test fixtures
 
@@ -100,10 +101,9 @@
     ;; After marking - should not appear in pending
     (is (= {} (hivemind/get-pending-ling-results)))
 
-    ;; But the entry still exists in the atom (verify via direct access)
-    (let [ling-results-var (resolve 'hive-mcp.hivemind.core/ling-results)
-          all-results @@ling-results-var]
-      (is (true? (:reviewed? (get all-results "agent-1")))))))
+    ;; But the entry still exists in the atom (verify via bget)
+    (let [all-data (bget hivemind/ling-results "agent-1")]
+      (is (true? (:reviewed? all-data))))))
 
 (deftest mark-ling-reviewed!-idempotent-test
   (testing "mark-ling-reviewed! is idempotent"
@@ -112,8 +112,7 @@
     (hivemind/mark-ling-reviewed! "agent-1") ; Second call
 
     ;; Should still be reviewed, no error
-    (let [ling-results-var (resolve 'hive-mcp.hivemind.core/ling-results)
-          entry (get @@ling-results-var "agent-1")]
+    (let [entry (bget hivemind/ling-results "agent-1")]
       (is (true? (:reviewed? entry))))))
 
 (deftest mark-ling-reviewed!-nonexistent-agent-test
@@ -121,10 +120,12 @@
     ;; Should not throw
     (hivemind/mark-ling-reviewed! "nonexistent-agent")
 
-    ;; Creates entry with nil values but reviewed? true
-    (let [ling-results-var (resolve 'hive-mcp.hivemind.core/ling-results)
-          entry (get @@ling-results-var "nonexistent-agent")]
-      (is (true? (:reviewed? entry))))))
+    ;; mark-ling-reviewed! only updates if bget finds existing entry,
+    ;; so nonexistent agent should have nil result
+    (let [entry (bget hivemind/ling-results "nonexistent-agent")]
+      ;; With bounded-atom, mark-ling-reviewed! checks bget first and only
+      ;; updates if entry exists. So entry should be nil for nonexistent agent.
+      (is (nil? entry)))))
 
 ;;; clear-ling-results! tests
 
@@ -139,8 +140,7 @@
 
     ;; Verify empty
     (is (= {} (hivemind/get-pending-ling-results)))
-    (let [ling-results-var (resolve 'hive-mcp.hivemind.core/ling-results)]
-      (is (= {} @@ling-results-var)))))
+    (is (= 0 (bcount hivemind/ling-results)))))
 
 (deftest clear-ling-results!-idempotent-test
   (testing "clear-ling-results! is idempotent"
@@ -151,7 +151,7 @@
 ;;; Integration/workflow tests
 
 (deftest ling-workflow-full-cycle-test
-  (testing "Full ling workflow: record → get-pending → review → clear"
+  (testing "Full ling workflow: record -> get-pending -> review -> clear"
     ;; 1. Record multiple results
     (hivemind/record-ling-result! "ling-tdd" {:status "success" :tests-passed 10})
     (hivemind/record-ling-result! "ling-docs" {:status "success" :docs-updated 3})
@@ -172,8 +172,7 @@
 
     ;; 5. Clear at session end
     (hivemind/clear-ling-results!)
-    (let [ling-results-var (resolve 'hive-mcp.hivemind.core/ling-results)]
-      (is (= {} @@ling-results-var)))))
+    (is (= 0 (bcount hivemind/ling-results)))))
 
 (deftest ling-result-preserves-complex-data-test
   (testing "record-ling-result! preserves complex nested data"

--- a/test/hive_mcp/hivemind_messages_test.clj
+++ b/test/hive_mcp/hivemind_messages_test.clj
@@ -8,7 +8,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.data.json :as json]
             [hive-mcp.hivemind.core :as hivemind]
-            [hive-mcp.channel.piggyback :as piggyback]))
+            [hive-mcp.channel.piggyback :as piggyback]
+            [hive-dsl.bounded-atom :refer [bclear!]]))
 
 ;;; Test fixtures
 
@@ -16,9 +17,9 @@
   "Fixture to ensure clean agent-registry state between tests."
   [f]
   ;; Reset agent-registry
-  (reset! @(resolve 'hive-mcp.hivemind.core/agent-registry) {})
+  (bclear! @(resolve 'hive-mcp.hivemind.core/agent-registry))
   (f)
-  (reset! @(resolve 'hive-mcp.hivemind.core/agent-registry) {}))
+  (bclear! @(resolve 'hive-mcp.hivemind.core/agent-registry)))
 
 (use-fixtures :each reset-hivemind-state)
 

--- a/test/hive_mcp/hivemind_spawn_registration_test.clj
+++ b/test/hive_mcp/hivemind_spawn_registration_test.clj
@@ -16,7 +16,8 @@
             [clojure.data.json :as json]
             [hive-mcp.hivemind.core :as hivemind]
             [hive-mcp.swarm.datascript :as ds]
-            [hive-mcp.tools.swarm.registry :as swarm-registry]))
+            [hive-mcp.tools.swarm.registry :as swarm-registry]
+            [hive-dsl.bounded-atom :refer [bclear!]]))
 
 ;;; Test fixtures
 
@@ -27,11 +28,11 @@
   ;; ADR-002: Reset DataScript (primary registry)
   (ds/reset-conn!)
   ;; Reset hivemind agent-registry
-  (reset! @(resolve 'hive-mcp.hivemind.core/agent-registry) {})
+  (bclear! @(resolve 'hive-mcp.hivemind.core/agent-registry))
   ;; Note: lings-registry removed in ADR-002 migration - DataScript is primary
   (f)
   (ds/reset-conn!)
-  (reset! @(resolve 'hive-mcp.hivemind.core/agent-registry) {}))
+  (bclear! @(resolve 'hive-mcp.hivemind.core/agent-registry)))
 
 (use-fixtures :each reset-all-registries)
 

--- a/test/hive_mcp/knowledge_graph/connection_writer_test.clj
+++ b/test/hive_mcp/knowledge_graph/connection_writer_test.clj
@@ -1,0 +1,228 @@
+(ns hive-mcp.knowledge-graph.connection-writer-test
+  "Tests for the write-coalescing queue lifecycle and integration.
+
+   Uses DataScript backend for speed. Each test gets a fresh store
+   and a stopped writer to avoid cross-test interference."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [clojure.string :as string]
+            [clojure.core.async :as async]
+            [hive-mcp.knowledge-graph.connection :as conn]
+            [hive-mcp.knowledge-graph.protocol :as proto]
+            [hive-mcp.knowledge-graph.store.fixtures :as fixtures])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; =============================================================================
+;; Fixtures
+;; =============================================================================
+
+(defn writer-fixture
+  "Fixture that ensures writer is stopped before and after each test.
+   Combined with datascript-fixture for a fresh store."
+  [f]
+  (fixtures/datascript-fixture
+   (fn []
+     (conn/stop-writer!)
+     (try
+       (f)
+       (finally
+         (conn/stop-writer!))))))
+
+(use-fixtures :each writer-fixture)
+
+;; =============================================================================
+;; Lifecycle Tests
+;; =============================================================================
+
+(deftest stop-writer-idempotent-test
+  (testing "calling stop-writer! twice does not throw"
+    (conn/stop-writer!)
+    (conn/stop-writer!)
+    (is (not (:running? (conn/writer-stats))))))
+
+(deftest start-stop-roundtrip-test
+  (testing "writer can be started, stopped, and restarted (Bug #1)"
+    ;; First start via transact!
+    (conn/transact! [{:kg-edge/id "round-1"
+                      :kg-edge/from "a"
+                      :kg-edge/to "b"
+                      :kg-edge/relation :implements
+                      :kg-edge/confidence 1.0}])
+    (is (:running? (conn/writer-stats)))
+
+    ;; Stop
+    (conn/stop-writer!)
+    (is (not (:running? (conn/writer-stats))))
+
+    ;; Restart — should work on fresh channels
+    (conn/transact! [{:kg-edge/id "round-2"
+                      :kg-edge/from "c"
+                      :kg-edge/to "d"
+                      :kg-edge/relation :implements
+                      :kg-edge/confidence 1.0}])
+    (is (:running? (conn/writer-stats)))
+
+    ;; Give queue time to flush
+    (Thread/sleep 100)
+
+    ;; Both writes should have landed
+    (let [results (conn/query '[:find ?id
+                                :where [?e :kg-edge/id ?id]])]
+      (is (contains? (set (map first results)) "round-2")))))
+
+(deftest writer-stats-observability-test
+  (testing "writer-stats returns metrics and running state (Bug #5)"
+    (let [stats-before (conn/writer-stats)]
+      (is (contains? stats-before :running?))
+      (is (contains? stats-before :batches-flushed))
+      (is (contains? stats-before :items-written))
+      (is (contains? stats-before :items-dropped))
+      (is (contains? stats-before :largest-batch))
+
+      ;; Trigger a write
+      (conn/transact! [{:kg-edge/id "stats-test"
+                        :kg-edge/from "a"
+                        :kg-edge/to "b"
+                        :kg-edge/relation :implements
+                        :kg-edge/confidence 1.0}])
+      (Thread/sleep 100)
+
+      (let [stats-after (conn/writer-stats)]
+        (is (:running? stats-after))
+        (is (pos? (:batches-flushed stats-after)))
+        (is (pos? (:items-written stats-after)))))))
+
+;; =============================================================================
+;; Data Flow Tests
+;; =============================================================================
+
+(deftest transact-via-queue-reaches-db-test
+  (testing "data sent through queue ends up in the database"
+    (conn/transact! [{:kg-edge/id "queue-test"
+                      :kg-edge/from "x"
+                      :kg-edge/to "y"
+                      :kg-edge/relation :implements
+                      :kg-edge/confidence 0.9}])
+    ;; Wait for async flush
+    (Thread/sleep 100)
+
+    (let [results (conn/query '[:find ?id
+                                :where [?e :kg-edge/id ?id]])]
+      (is (= #{["queue-test"]} (set results))))))
+
+(deftest transact-sync-bypasses-queue-test
+  (testing "transact-sync! bypasses queue and returns immediately"
+    (let [result (conn/transact-sync!
+                  [{:kg-edge/id "sync-test"
+                    :kg-edge/from "a"
+                    :kg-edge/to "b"
+                    :kg-edge/relation :implements
+                    :kg-edge/confidence 1.0}])]
+      ;; No sleep needed — sync is immediate
+      (is (some? result))
+      (let [results (conn/query '[:find ?id
+                                  :where [?e :kg-edge/id ?id]])]
+        (is (= #{["sync-test"]} (set results)))))))
+
+(deftest coalescing-batches-multiple-transacts-test
+  (testing "20 rapid writes coalesce into fewer than 20 batches"
+    (let [before-batches (:batches-flushed (conn/writer-stats))]
+      (dotimes [i 20]
+        (conn/transact! [{:kg-edge/id (str "coalesce-" i)
+                          :kg-edge/from (str "from-" i)
+                          :kg-edge/to (str "to-" i)
+                          :kg-edge/relation :implements
+                          :kg-edge/confidence 0.5}]))
+      ;; Wait for all flushes
+      (Thread/sleep 200)
+
+      (let [after-batches (:batches-flushed (conn/writer-stats))
+            batch-count (- after-batches before-batches)]
+        (is (< batch-count 20)
+            (str "Expected coalescing: " batch-count " batches for 20 writes"))
+        ;; Verify all data landed
+        (let [results (conn/query '[:find ?id
+                                    :where [?e :kg-edge/id ?id]])]
+          (is (= 20 (count (filter #(string/starts-with? (first %) "coalesce-")
+                                   results)))))))))
+
+(deftest with-tx-batch-bypasses-queue-test
+  (testing "with-tx-batch goes through synchronous path"
+    (conn/with-tx-batch
+      (conn/transact! [{:kg-edge/id "batch-1"
+                        :kg-edge/from "a"
+                        :kg-edge/to "b"
+                        :kg-edge/relation :implements
+                        :kg-edge/confidence 1.0}])
+      (conn/transact! [{:kg-edge/id "batch-2"
+                        :kg-edge/from "c"
+                        :kg-edge/to "d"
+                        :kg-edge/relation :implements
+                        :kg-edge/confidence 1.0}]))
+    ;; No sleep needed — with-tx-batch is synchronous
+    (let [results (conn/query '[:find ?id
+                                :where [?e :kg-edge/id ?id]])]
+      (is (= #{["batch-1"] ["batch-2"]} (set results))))))
+
+;; =============================================================================
+;; Normalization Tests
+;; =============================================================================
+
+(deftest vector-datum-normalization-test
+  (testing "[:db/add ...] through queue normalizes correctly (Bug #4)"
+    (conn/transact-sync! [{:kg-edge/id "norm-target"
+                           :kg-edge/from "a"
+                           :kg-edge/to "b"
+                           :kg-edge/relation :implements
+                           :kg-edge/confidence 0.5}])
+    (let [eid (ffirst (conn/query '[:find ?e
+                                    :where [?e :kg-edge/id "norm-target"]]))]
+      ;; Send a vector datum through the queue
+      (conn/transact! [:db/add eid :kg-edge/confidence 0.99])
+      (Thread/sleep 100)
+
+      (let [updated (conn/query '[:find ?c
+                                  :where
+                                  [?e :kg-edge/id "norm-target"]
+                                  [?e :kg-edge/confidence ?c]])]
+        (is (= #{[0.99]} (set updated)))))))
+
+;; =============================================================================
+;; Concurrency Tests
+;; =============================================================================
+
+(deftest concurrent-ensure-writer-test
+  (testing "10 threads calling transact! concurrently — all writes survive (Bug #2)"
+    (let [n-threads 10
+          writes-per-thread 5
+          latch (CountDownLatch. n-threads)
+          errors (atom [])]
+      ;; Launch threads
+      (dotimes [t n-threads]
+        (.start
+         (Thread.
+          (fn []
+            (try
+              (.await latch)
+              (dotimes [i writes-per-thread]
+                (conn/transact! [{:kg-edge/id (str "concurrent-" t "-" i)
+                                  :kg-edge/from (str "from-" t)
+                                  :kg-edge/to (str "to-" t "-" i)
+                                  :kg-edge/relation :implements
+                                  :kg-edge/confidence 0.5}]))
+              (catch Exception e
+                (swap! errors conj (.getMessage e)))))))
+        (.countDown latch))
+
+      ;; Wait for all threads to complete
+      (Thread/sleep 500)
+
+      (is (empty? @errors) (str "Errors during concurrent writes: " @errors))
+
+      ;; Verify all writes landed (some may have gone sync fallback)
+      (let [results (conn/query '[:find ?id
+                                  :where [?e :kg-edge/id ?id]])
+            concurrent-ids (filter #(string/starts-with? (first %) "concurrent-")
+                                   results)]
+        (is (= (* n-threads writes-per-thread) (count concurrent-ids))
+            (str "Expected " (* n-threads writes-per-thread)
+                 " writes, got " (count concurrent-ids)))))))

--- a/test/hive_mcp/make_tool_test.clj
+++ b/test/hive_mcp/make_tool_test.clj
@@ -9,14 +9,15 @@
             [clojure.string :as str]
             [hive-mcp.server.routes :as routes]
             [hive-mcp.hivemind.core :as hivemind]
-            [hive-mcp.channel.piggyback :as piggyback]))
+            [hive-mcp.channel.piggyback :as piggyback]
+            [hive-dsl.bounded-atom :refer [bclear!]]))
 
 ;; =============================================================================
 ;; Test Fixtures
 ;; =============================================================================
 
 (defn reset-state-fixture [f]
-  (reset! hivemind/agent-registry {})
+  (bclear! hivemind/agent-registry)
   (piggyback/reset-all-cursors!)
   (f))
 

--- a/test/hive_mcp/meta_piggyback_test.clj
+++ b/test/hive_mcp/meta_piggyback_test.clj
@@ -9,14 +9,15 @@
             [hive-mcp.server.routes :as routes]
             [hive-mcp.tools.core :as tools-core]
             [hive-mcp.channel.piggyback :as piggyback]
-            [hive-mcp.hivemind.core :as hivemind]))
+            [hive-mcp.hivemind.core :as hivemind]
+            [hive-dsl.bounded-atom :refer [bclear!]]))
 
 ;; =============================================================================
 ;; Test Fixtures
 ;; =============================================================================
 
 (defn reset-state-fixture [f]
-  (reset! hivemind/agent-registry {})
+  (bclear! hivemind/agent-registry)
   (piggyback/reset-all-cursors!)
   (f))
 

--- a/test/hive_mcp/nrepl/classloader_gc_test.clj
+++ b/test/hive_mcp/nrepl/classloader_gc_test.clj
@@ -1,0 +1,214 @@
+(ns hive-mcp.nrepl.classloader-gc-test
+  "Tests for the DynamicClassLoader mitigation middleware.
+
+   Validates that:
+   1. Session-less evals get pinned to a shared session
+   2. Evals with explicit sessions pass through unmodified
+   3. Non-eval ops pass through unmodified
+   4. Session rotation occurs at the configured threshold
+   5. The status API reports correct state"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-mcp.nrepl.classloader-gc :as classloader-gc]))
+
+;; =============================================================================
+;; Test Helpers
+;; =============================================================================
+
+(def ^:private captured-messages (atom []))
+
+(defn- make-mock-transport
+  "Create a mock transport that records sent messages."
+  []
+  (reify nrepl.transport/Transport
+    (recv [_] nil)
+    (recv [_ _timeout] nil)
+    (send [_ response]
+      (swap! captured-messages conj response))))
+
+(defn- make-recording-handler
+  "Create a handler that records messages passed to it and sends a response
+   with the session from the message."
+  []
+  (let [received (atom [])]
+    {:handler (fn [{:keys [session transport] :as msg}]
+                (swap! received conj msg)
+                ;; Simulate nREPL responding with the session ID
+                (when transport
+                  (nrepl.transport/send transport
+                                        {:session (or session "auto-created-session-123")
+                                         :status ["done"]
+                                         :value "nil"})))
+     :received received}))
+
+;; Reset shared state between tests
+(use-fixtures :each
+  (fn [f]
+    ;; Reset the shared session ID atom via force-rotate
+    (classloader-gc/force-rotate!)
+    (reset! captured-messages [])
+    (f)
+    (classloader-gc/force-rotate!)
+    (reset! captured-messages [])))
+
+;; =============================================================================
+;; Core Middleware Behavior
+;; =============================================================================
+
+(deftest session-less-eval-captures-shared-session-test
+  (testing "First session-less eval captures the session ID for reuse"
+    (let [{:keys [handler received]} (make-recording-handler)
+          middleware (classloader-gc/wrap-shared-classloader handler)
+          transport (make-mock-transport)]
+      ;; First session-less eval
+      (middleware {:op "eval" :code "(+ 1 2)" :transport transport})
+
+      ;; The handler should have received a message (without :session initially,
+      ;; but wrapped with capturing transport)
+      (is (= 1 (count @received))
+          "handler received the message")
+
+      ;; After the first eval, the status should show the captured session
+      (let [status (classloader-gc/status)]
+        (is (= "auto-created-session-123" (:shared-session-id status))
+            "shared session ID captured from response")
+        (is (= 1 (:eval-count status))
+            "eval counter is 1")))))
+
+(deftest session-less-eval-reuses-shared-session-test
+  (testing "Subsequent session-less evals inject the shared session ID"
+    (let [{:keys [handler received]} (make-recording-handler)
+          middleware (classloader-gc/wrap-shared-classloader handler)
+          transport (make-mock-transport)]
+      ;; First eval: captures session
+      (middleware {:op "eval" :code "(+ 1 2)" :transport transport})
+
+      ;; Second eval: should inject the shared session
+      (middleware {:op "eval" :code "(+ 3 4)" :transport transport})
+
+      (is (= 2 (count @received))
+          "handler received both messages")
+
+      ;; The second message should have the shared session injected
+      (let [second-msg (nth @received 1)]
+        (is (= "auto-created-session-123" (:session second-msg))
+            "shared session ID injected into second eval"))
+
+      ;; Eval count should be 2
+      (is (= 2 (:eval-count (classloader-gc/status)))
+          "eval counter is 2"))))
+
+(deftest explicit-session-passes-through-test
+  (testing "Evals with explicit :session pass through unmodified"
+    (let [{:keys [handler received]} (make-recording-handler)
+          middleware (classloader-gc/wrap-shared-classloader handler)
+          transport (make-mock-transport)]
+      ;; Eval with explicit session (CIDER pattern)
+      (middleware {:op "eval" :code "(+ 1 2)" :session "cider-session-abc" :transport transport})
+
+      (is (= 1 (count @received))
+          "handler received the message")
+
+      ;; The session should be unchanged
+      (let [msg (first @received)]
+        (is (= "cider-session-abc" (:session msg))
+            "explicit session preserved")))))
+
+(deftest non-eval-ops-pass-through-test
+  (testing "Non-eval ops pass through without session manipulation"
+    (let [{:keys [handler received]} (make-recording-handler)
+          middleware (classloader-gc/wrap-shared-classloader handler)
+          transport (make-mock-transport)]
+      ;; Non-eval op
+      (middleware {:op "describe" :transport transport})
+
+      (is (= 1 (count @received))
+          "handler received the message")
+
+      ;; No session should be injected
+      (let [msg (first @received)]
+        (is (nil? (:session msg))
+            "no session injected for non-eval ops")))))
+
+(deftest clone-op-passes-through-test
+  (testing "Clone op (used by CIDER) passes through without session manipulation"
+    (let [{:keys [handler received]} (make-recording-handler)
+          middleware (classloader-gc/wrap-shared-classloader handler)
+          transport (make-mock-transport)]
+      (middleware {:op "clone" :transport transport})
+
+      (is (= 1 (count @received))
+          "handler received the clone message")
+      (is (nil? (:session (first @received)))
+          "no session injected for clone op"))))
+
+;; =============================================================================
+;; Session Rotation
+;; =============================================================================
+
+(deftest session-rotation-at-threshold-test
+  (testing "Shared session rotates after reaching eval threshold"
+    (classloader-gc/set-rotation-threshold! 3)
+    (let [{:keys [handler received]} (make-recording-handler)
+          middleware (classloader-gc/wrap-shared-classloader handler)
+          transport (make-mock-transport)]
+      ;; First eval: captures session
+      (middleware {:op "eval" :code "1" :transport transport})
+      (is (= "auto-created-session-123" (:shared-session-id (classloader-gc/status))))
+
+      ;; Evals 2 and 3: still using same session
+      (middleware {:op "eval" :code "2" :transport transport})
+      (middleware {:op "eval" :code "3" :transport transport})
+
+      ;; After eval 3, rotation should have happened (counter >= threshold)
+      ;; The session should be nil (cleared by rotation)
+      (let [status (classloader-gc/status)]
+        (is (nil? (:shared-session-id status))
+            "session rotated after reaching threshold")
+        (is (= 0 (:eval-count status))
+            "eval counter reset after rotation")))
+    ;; Restore default threshold
+    (classloader-gc/set-rotation-threshold! 10000)))
+
+;; =============================================================================
+;; Status API
+;; =============================================================================
+
+(deftest status-reports-correct-state-test
+  (testing "Status API reports classloader info"
+    (let [status (classloader-gc/status)]
+      (is (contains? status :shared-session-id))
+      (is (contains? status :eval-count))
+      (is (contains? status :rotation-threshold))
+      (is (contains? status :classloader-info))
+      (is (contains? (:classloader-info status) :chain-depth))
+      (is (contains? (:classloader-info status) :dynamic-classloader-count)))))
+
+(deftest force-rotate-clears-session-test
+  (testing "force-rotate! clears the shared session"
+    (let [{:keys [handler]} (make-recording-handler)
+          middleware (classloader-gc/wrap-shared-classloader handler)
+          transport (make-mock-transport)]
+      ;; Establish a shared session
+      (middleware {:op "eval" :code "(+ 1 2)" :transport transport})
+      (is (some? (:shared-session-id (classloader-gc/status)))
+          "session established before rotate")
+
+      ;; Force rotate
+      (classloader-gc/force-rotate!)
+
+      (is (nil? (:shared-session-id (classloader-gc/status)))
+          "session cleared after force-rotate")
+      (is (= 0 (:eval-count (classloader-gc/status)))
+          "eval counter reset after force-rotate"))))
+
+;; =============================================================================
+;; Classloader Counting
+;; =============================================================================
+
+(deftest count-dynamic-classloaders-returns-valid-map-test
+  (testing "count-dynamic-classloaders returns expected structure"
+    (let [info (classloader-gc/count-dynamic-classloaders)]
+      (is (map? info))
+      (is (nat-int? (:chain-depth info)))
+      (is (nat-int? (:dynamic-classloader-count info)))
+      (is (string? (:thread-context-classloader info))))))

--- a/test/hive_mcp/prompt_forwarding_test.clj
+++ b/test/hive_mcp/prompt_forwarding_test.clj
@@ -11,16 +11,17 @@
    This is the architectural guarantee that prompts are visible to coordinator."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [hive-mcp.hivemind.core :as hivemind]
-            [hive-mcp.swarm.sync :as sync]))
+            [hive-mcp.swarm.sync :as sync]
+            [hive-dsl.bounded-atom :refer [bclear!]]))
 
 ;;; Test fixtures
 
 (defn reset-prompts-fixture
   "Reset pending-swarm-prompts between tests."
   [f]
-  (reset! @(resolve 'hive-mcp.hivemind.core/pending-swarm-prompts) {})
+  (bclear! @(resolve 'hive-mcp.hivemind.core/pending-swarm-prompts))
   (f)
-  (reset! @(resolve 'hive-mcp.hivemind.core/pending-swarm-prompts) {}))
+  (bclear! @(resolve 'hive-mcp.hivemind.core/pending-swarm-prompts)))
 
 (use-fixtures :each reset-prompts-fixture)
 

--- a/test/hive_mcp/server/hivemind_piggyback_e2e_test.clj
+++ b/test/hive_mcp/server/hivemind_piggyback_e2e_test.clj
@@ -1,9 +1,9 @@
 (ns hive-mcp.server.hivemind-piggyback-e2e-test
-  "End-to-end tests for hivemind shout → piggyback delivery pipeline.
+  "End-to-end tests for hivemind shout -> piggyback delivery pipeline.
 
-   Verifies the full path: shout! stores in agent-registry →
-   all-hivemind-messages reads from it → piggyback/get-messages
-   returns them → wrap-handler-piggyback appends ---HIVEMIND--- blocks.
+   Verifies the full path: shout! stores in agent-registry ->
+   all-hivemind-messages reads from it -> piggyback/get-messages
+   returns them -> wrap-handler-piggyback appends ---HIVEMIND--- blocks.
 
    These tests complement piggyback_middleware_test.clj (which uses
    mock message sources) by testing the real hivemind integration.
@@ -14,7 +14,8 @@
             [hive-mcp.server.routes :as routes]
             [hive-mcp.hivemind.core :as hivemind]
             [hive-mcp.channel.piggyback :as pb]
-            [hive-mcp.agent.context :as ctx]))
+            [hive-mcp.agent.context :as ctx]
+            [hive-dsl.bounded-atom :refer [bput! bget bclear!]]))
 
 ;; =============================================================================
 ;; Constants
@@ -32,13 +33,13 @@
   (let [original-source @pb/message-source-fn]
     ;; Reset state
     (pb/reset-all-cursors!)
-    (reset! hivemind/agent-registry {})
+    (bclear! hivemind/agent-registry)
     ;; Re-register the real message source (tests may have overwritten it)
     (pb/register-message-source! original-source)
     (f)
     ;; Cleanup
     (pb/reset-all-cursors!)
-    (reset! hivemind/agent-registry {})
+    (bclear! hivemind/agent-registry)
     ;; Restore original source
     (pb/register-message-source! original-source)))
 
@@ -69,13 +70,14 @@
         msg {:event-type event-type
              :message message
              :timestamp now
-             :project-id (or project-id "global")}]
-    (swap! hivemind/agent-registry update agent-id
-           (fn [agent]
-             (let [messages (or (:messages agent) [])
-                   new-messages (vec (take-last 10 (conj messages msg)))]
-               {:messages new-messages
-                :last-seen now})))))
+             :project-id (or project-id "global")}
+        current (or (bget hivemind/agent-registry agent-id)
+                    {:messages [] :last-seen nil})
+        messages (or (:messages current) [])
+        new-messages (vec (take-last 10 (conj messages msg)))]
+    (bput! hivemind/agent-registry agent-id
+           {:messages new-messages
+            :last-seen now})))
 
 (defn- call-with-context
   "Call a wrapped handler with proper request context binding.
@@ -86,7 +88,7 @@
     (wrapped (assoc args :directory test-dir))))
 
 ;; =============================================================================
-;; End-to-End Tests: Shout → Piggyback Delivery
+;; End-to-End Tests: Shout -> Piggyback Delivery
 ;; =============================================================================
 
 (deftest e2e-ling-shout-delivered-to-coordinator-via-piggyback-test
@@ -94,7 +96,7 @@
     ;; Step 1: Ling shouts (store directly in registry, bypassing DataScript)
     (shout-directly! "swarm-test-ling-1" :progress "Found the bug!" test-project)
 
-    ;; Step 2: Coordinator calls any tool → piggyback should include the shout
+    ;; Step 2: Coordinator calls any tool -> piggyback should include the shout
     (let [wrapped (routes/wrap-handler-piggyback dummy-handler)
           result (call-with-context wrapped {})]
       (is (some? (extract-hivemind-block result))
@@ -214,8 +216,9 @@
       (Thread/sleep 2)) ; Ensure unique timestamps
 
     ;; Agent-registry should have only last 10
-    (let [stored-count (count (get-in @hivemind/agent-registry
-                                       ["ling-rapid" :messages]))]
+    ;; bounded-atom: bget returns unwrapped :data
+    (let [agent-data (bget hivemind/agent-registry "ling-rapid")
+          stored-count (count (:messages agent-data))]
       (is (= 10 stored-count)
           "Ring buffer should keep only last 10 messages"))
 

--- a/test/hive_mcp/state_sync_test.clj
+++ b/test/hive_mcp/state_sync_test.clj
@@ -10,7 +10,8 @@
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [hive-mcp.hivemind.core :as hivemind]
             [hive-mcp.swarm.datascript :as ds]
-            [hive-mcp.tools.swarm :as swarm]))
+            [hive-mcp.tools.swarm :as swarm]
+            [hive-dsl.bounded-atom :refer [bget bclear!]]))
 
 ;; =============================================================================
 ;; Test Fixtures - Reset state between tests
@@ -19,11 +20,11 @@
 (defn reset-state-fixture [f]
   ;; ADR-002: Reset DataScript as primary registry
   (ds/reset-conn!)
-  (reset! hivemind/agent-registry {})
+  (bclear! hivemind/agent-registry)
   ;; Note: lings-registry moved to DataScript, no separate atom
   (f)
   (ds/reset-conn!)
-  (reset! hivemind/agent-registry {}))
+  (bclear! hivemind/agent-registry))
 
 (use-fixtures :each reset-state-fixture)
 
@@ -40,7 +41,7 @@
     (hivemind/shout! "slave-abc-123" :started {:task "Test task" :message "Starting"})
 
     ;; Then: The hivemind agent registry should contain this agent
-    (is (contains? @hivemind/agent-registry "slave-abc-123")
+    (is (some? (bget hivemind/agent-registry "slave-abc-123"))
         "Agent should be registered in hivemind after shout")))
 
 ;; =============================================================================

--- a/test/hive_mcp/swarm_channel_test.clj
+++ b/test/hive_mcp/swarm_channel_test.clj
@@ -3,7 +3,8 @@
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [hive-mcp.tools.swarm :as swarm]
             [hive-mcp.tools.swarm.channel :as swarm-channel]
-            [hive-mcp.channel.core :as ch]))
+            [hive-mcp.channel.core :as ch]
+            [hive-dsl.bounded-atom :refer [bput!]]))
 
 ;; =============================================================================
 ;; Test Fixtures
@@ -35,7 +36,7 @@
 (deftest event-journal-clear-test
   (testing "Event journal can be cleared"
     ;; Manually add an entry via the private atom in swarm.channel
-    (swap! @#'swarm-channel/event-journal assoc "test-task" {:status "completed"})
+    (bput! @#'swarm-channel/event-journal "test-task" {:status "completed"})
     (is (some? (swarm/check-event-journal "test-task")))
     (swarm/clear-event-journal!)
     (is (nil? (swarm/check-event-journal "test-task")))))
@@ -54,12 +55,12 @@
     (swarm/start-channel-subscriptions!)
     (Thread/sleep 100)
 
-    ;; Verify subscriptions are active via private atom in swarm.channel
-    (is (seq @@#'swarm-channel/channel-subscriptions))
+    ;; Verify subscriptions are active via bounded-atom in swarm.channel
+    (is (seq @(:atom @#'swarm-channel/channel-subscriptions)))
 
     ;; Stop subscriptions
     (swarm/stop-channel-subscriptions!)
-    (is (empty? @@#'swarm-channel/channel-subscriptions))))
+    (is (empty? @(:atom @#'swarm-channel/channel-subscriptions)))))
 
 ;; =============================================================================
 ;; Push Event Integration Tests
@@ -119,7 +120,7 @@
 (deftest collect-finds-journal-entry-immediately-test
   (testing "handle-swarm-collect finds journal entry without polling"
     ;; Pre-populate the journal (simulating event arrival)
-    (swap! @#'swarm-channel/event-journal assoc "instant-task"
+    (bput! @#'swarm-channel/event-journal "instant-task"
            {:status "completed"
             :result "instant result"
             :slave-id "fast-slave"

--- a/test/hive_mcp/telemetry/bounded_atom_metrics_test.clj
+++ b/test/hive_mcp/telemetry/bounded_atom_metrics_test.clj
@@ -1,0 +1,336 @@
+(ns hive-mcp.telemetry.bounded-atom-metrics-test
+  "Tests for bounded atom Prometheus metrics (gc-fix-7).
+
+   Validates:
+   1. Metrics registry initialization
+   2. Instrumented bounded atom auto-updates on bput!/eviction
+   3. Sweep metrics (counter, gauge, histogram)
+   4. instrument! for existing atoms
+   5. snapshot-all! polling
+   6. Export format validation"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [hive-dsl.bounded-atom :as ba]
+            [hive-mcp.telemetry.bounded-atom-metrics :as bam]))
+
+;;; =============================================================================
+;;; Test Fixtures
+;;; =============================================================================
+
+(defn init-metrics-fixture
+  "Initialize metrics registry and clear sweep registry before each test."
+  [f]
+  (bam/init!)
+  (reset! @#'ba/sweepable-registry {})
+  (f)
+  (reset! @#'ba/sweepable-registry {}))
+
+(use-fixtures :each init-metrics-fixture)
+
+;;; =============================================================================
+;;; Registry Initialization Tests
+;;; =============================================================================
+
+(deftest test-init-idempotent
+  (testing "init! can be called multiple times safely"
+    (is (true? (bam/init!)) "First init succeeds")
+    (is (true? (bam/init!)) "Second init succeeds (idempotent)")))
+
+(deftest test-registry-exists
+  (testing "Registry is a delay that can be dereferenced"
+    (is (delay? bam/registry) "Registry is a delay")
+    (is (some? @bam/registry) "Registry can be dereferenced")))
+
+;;; =============================================================================
+;;; Instrumented Bounded Atom Tests
+;;; =============================================================================
+
+(deftest test-instrumented-atom-initial-metrics
+  (testing "instrumented-bounded-atom sets initial capacity and zero entries"
+    (let [_store (bam/instrumented-bounded-atom
+                   {:max-entries 100 :name "test-initial"})]
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "hive_bounded_atom_capacity")
+            "capacity gauge present")
+        (is (str/includes? metrics "name=\"test-initial\"")
+            "name label present")
+        (is (str/includes? metrics "hive_bounded_atom_entries")
+            "entries gauge present")
+        (is (str/includes? metrics "hive_bounded_atom_utilization")
+            "utilization gauge present")))))
+
+(deftest test-instrumented-atom-requires-name
+  (testing "instrumented-bounded-atom asserts :name is required"
+    (is (thrown? AssertionError
+                 (bam/instrumented-bounded-atom {:max-entries 10})))))
+
+(deftest test-bput-updates-metrics-on-eviction
+  (testing "bput! triggers metrics update when evictions occur"
+    (let [store (bam/instrumented-bounded-atom
+                  {:max-entries 3
+                   :eviction-policy :lru
+                   :name "evict-test"})]
+      ;; Fill to capacity
+      (ba/bput! store :k1 "a")
+      (Thread/sleep 2)
+      (ba/bput! store :k2 "b")
+      (Thread/sleep 2)
+      (ba/bput! store :k3 "c")
+      (Thread/sleep 2)
+      ;; This should trigger capacity eviction
+      (ba/bput! store :k4 "d")
+
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "hive_bounded_atom_evictions_total")
+            "evictions counter present after eviction")
+        (is (str/includes? metrics "name=\"evict-test\"")
+            "eviction has correct name label")
+        (is (str/includes? metrics "reason=\"capacity\"")
+            "eviction reason is capacity")))))
+
+(deftest test-bput-no-eviction-no-callback
+  (testing "bput! does not fire callback when no evictions"
+    (let [callback-count (atom 0)
+          store (ba/bounded-atom
+                  {:max-entries 10
+                   :name "no-evict-test"
+                   :on-evict (fn [_] (swap! callback-count inc))})]
+      (ba/bput! store :k1 "a")
+      (ba/bput! store :k2 "b")
+      (is (= 0 @callback-count)
+          "callback should not fire when no evictions"))))
+
+(deftest test-entries-gauge-tracks-count
+  (testing "entries gauge reflects actual entry count after puts"
+    (let [store (bam/instrumented-bounded-atom
+                  {:max-entries 10 :name "count-test"})]
+      (ba/bput! store :k1 "a")
+      (ba/bput! store :k2 "b")
+      (ba/bput! store :k3 "c")
+      ;; Force a metrics snapshot
+      (bam/set-entries! "count-test" (ba/bcount store))
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "hive_bounded_atom_entries")
+            "entries gauge present")))))
+
+;;; =============================================================================
+;;; TTL Eviction Metrics Tests
+;;; =============================================================================
+
+(deftest test-ttl-eviction-updates-metrics
+  (testing "TTL eviction during bput! updates eviction counter with reason=ttl"
+    (let [store (bam/instrumented-bounded-atom
+                  {:max-entries 5
+                   :ttl-ms 50
+                   :name "ttl-evict-test"})]
+      ;; Add entries
+      (ba/bput! store :k1 "old")
+      (ba/bput! store :k2 "old-too")
+      ;; Wait for TTL to expire
+      (Thread/sleep 80)
+      ;; This bput! should trigger TTL eviction
+      (ba/bput! store :k3 "new")
+      (ba/bput! store :k4 "newer")
+      (ba/bput! store :k5 "newest")
+
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "hive_bounded_atom_evictions_total")
+            "evictions counter present after TTL eviction")))))
+
+;;; =============================================================================
+;;; Sweep Metrics Tests
+;;; =============================================================================
+
+(deftest test-sweep-updates-metrics
+  (testing "sweep! updates sweep counter, evicted gauge, and duration histogram"
+    (let [store (bam/instrumented-bounded-atom
+                  {:max-entries 10
+                   :ttl-ms 50
+                   :name "sweep-test"})]
+      ;; Register for sweep
+      (ba/register-sweepable! store :sweep-test)
+      ;; Add entries
+      (ba/bput! store :k1 "old")
+      (ba/bput! store :k2 "old-too")
+      ;; Wait for TTL
+      (Thread/sleep 80)
+      ;; Sweep
+      (let [result (ba/sweep! store :sweep-test)]
+        (is (= 2 (:evicted-count result)) "sweep evicted 2 entries")
+        (is (= 0 (:remaining result)) "no entries remain"))
+
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "hive_lifecycle_sweep_total")
+            "sweep total counter present")
+        (is (str/includes? metrics "hive_lifecycle_sweep_last_evicted")
+            "sweep last evicted gauge present")
+        (is (str/includes? metrics "hive_lifecycle_sweep_duration_seconds")
+            "sweep duration histogram present")))))
+
+(deftest test-sweep-duration-recorded
+  (testing "sweep! records duration in histogram"
+    (let [store (bam/instrumented-bounded-atom
+                  {:max-entries 10
+                   :ttl-ms 50
+                   :name "sweep-duration-test"})]
+      (ba/bput! store :k1 "data")
+      (Thread/sleep 80)
+      (let [result (ba/sweep! store :sweep-duration)]
+        (is (number? (:duration-ms result))
+            "sweep result includes duration-ms")
+        (is (>= (:duration-ms result) 0)
+            "duration-ms is non-negative")))))
+
+;;; =============================================================================
+;;; Instrument! Tests (existing atom)
+;;; =============================================================================
+
+(deftest test-instrument-existing-atom
+  (testing "instrument! adds metrics to an existing bounded atom"
+    (let [store (ba/bounded-atom {:max-entries 5})
+          _ (ba/bput! store :k1 "existing")
+          instrumented (bam/instrument! store "retrofitted")]
+      ;; Should still have the existing entry
+      (is (= "existing" (ba/bget instrumented :k1))
+          "existing data preserved after instrumentation")
+      ;; Metrics should be initialized
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "name=\"retrofitted\"")
+            "retrofitted name label present in metrics"))
+      ;; Adding entries through instrumented should trigger callbacks
+      (ba/bput! instrumented :k2 "new")
+      (ba/bput! instrumented :k3 "new-2")
+      (ba/bput! instrumented :k4 "new-3")
+      (ba/bput! instrumented :k5 "new-4")
+      ;; This should evict via capacity
+      (ba/bput! instrumented :k6 "overflow")
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "hive_bounded_atom_evictions_total")
+            "eviction counter updated through instrumented atom")))))
+
+;;; =============================================================================
+;;; Snapshot Tests
+;;; =============================================================================
+
+(deftest test-snapshot-all-updates-gauges
+  (testing "snapshot-all! polls registry and updates all gauges"
+    (let [store1 (ba/bounded-atom {:max-entries 10})
+          store2 (ba/bounded-atom {:max-entries 20})]
+      ;; Register with names
+      (ba/register-sweepable! (assoc store1 :name "snap-1") :snap-1)
+      (ba/register-sweepable! (assoc store2 :name "snap-2") :snap-2)
+      ;; Add some entries
+      (ba/bput! store1 :k1 "a")
+      (ba/bput! store2 :k1 "b")
+      (ba/bput! store2 :k2 "c")
+      ;; Snapshot
+      (bam/snapshot-all!)
+      (let [metrics (bam/metrics-response)]
+        (is (str/includes? metrics "name=\"snap-1\"")
+            "snap-1 metrics present after snapshot")
+        (is (str/includes? metrics "name=\"snap-2\"")
+            "snap-2 metrics present after snapshot")))))
+
+;;; =============================================================================
+;;; Callback Safety Tests
+;;; =============================================================================
+
+(deftest test-callback-exception-does-not-break-bput
+  (testing "exception in on-evict callback does not prevent bput! from completing"
+    (let [store (ba/bounded-atom
+                  {:max-entries 2
+                   :name "err-test"
+                   :on-evict (fn [_] (throw (RuntimeException. "boom!")))})]
+      (ba/bput! store :k1 "a")
+      (ba/bput! store :k2 "b")
+      ;; This triggers eviction + broken callback — should NOT throw
+      (ba/bput! store :k3 "c")
+      (is (<= (ba/bcount store) 2)
+          "capacity still enforced despite callback error"))))
+
+(deftest test-callback-exception-does-not-break-sweep
+  (testing "exception in on-sweep callback does not prevent sweep! from completing"
+    (let [store (ba/bounded-atom
+                  {:max-entries 10
+                   :ttl-ms 50
+                   :name "sweep-err-test"
+                   :on-sweep (fn [_] (throw (RuntimeException. "sweep boom!")))})]
+      (ba/bput! store :k1 "old")
+      (Thread/sleep 80)
+      ;; sweep! should complete without throwing
+      (let [result (ba/sweep! store :sweep-err)]
+        (is (= 1 (:evicted-count result))
+            "sweep still works despite callback error")))))
+
+;;; =============================================================================
+;;; Export Format Tests
+;;; =============================================================================
+
+(deftest test-metrics-response-format
+  (testing "metrics-response returns valid Prometheus format"
+    (let [_ (bam/instrumented-bounded-atom {:max-entries 5 :name "format-test"})
+          metrics (bam/metrics-response)]
+      (is (string? metrics) "Response is a string")
+      (is (str/includes? metrics "# HELP")
+          "Contains HELP comments")
+      (is (str/includes? metrics "# TYPE")
+          "Contains TYPE comments")
+      (is (str/includes? metrics "hive_bounded_atom")
+          "Contains bounded atom metrics")
+      (is (str/includes? metrics "hive_lifecycle_sweep")
+          "Contains lifecycle sweep metrics"))))
+
+;;; =============================================================================
+;;; Integration Test — Full Flow
+;;; =============================================================================
+
+(deftest test-full-metrics-flow
+  (testing "Complete flow: create, fill, evict, sweep, export"
+    (let [store (bam/instrumented-bounded-atom
+                  {:max-entries 3
+                   :ttl-ms 100
+                   :eviction-policy :fifo
+                   :name "full-flow"})]
+      ;; Register for sweep
+      (ba/register-sweepable! store :full-flow)
+
+      ;; Fill to capacity
+      (ba/bput! store :k1 "first")
+      (Thread/sleep 5)
+      (ba/bput! store :k2 "second")
+      (Thread/sleep 5)
+      (ba/bput! store :k3 "third")
+      (Thread/sleep 5)
+
+      ;; Trigger capacity eviction (FIFO: k1 should be evicted)
+      (ba/bput! store :k4 "fourth")
+
+      ;; Wait for TTL to expire
+      (Thread/sleep 120)
+
+      ;; Sweep should evict remaining expired entries
+      (ba/sweep! store :full-flow)
+
+      ;; Verify all metric types are present
+      (let [metrics (bam/metrics-response)]
+        ;; Per-atom gauges
+        (is (str/includes? metrics "hive_bounded_atom_entries{name=\"full-flow\"")
+            "entries gauge with label")
+        (is (str/includes? metrics "hive_bounded_atom_capacity{name=\"full-flow\"")
+            "capacity gauge with label")
+        (is (str/includes? metrics "hive_bounded_atom_utilization{name=\"full-flow\"")
+            "utilization gauge with label")
+        ;; Eviction counter
+        (is (str/includes? metrics "hive_bounded_atom_evictions_total")
+            "evictions counter present")
+        ;; Sweep metrics
+        (is (str/includes? metrics "hive_lifecycle_sweep_total")
+            "sweep total counter")
+        (is (str/includes? metrics "hive_lifecycle_sweep_last_evicted")
+            "sweep last evicted gauge")
+        (is (str/includes? metrics "hive_lifecycle_sweep_duration_seconds_bucket")
+            "sweep duration histogram bucket")))))
+
+(comment
+  ;; Run tests from REPL
+  (clojure.test/run-tests 'hive-mcp.telemetry.bounded-atom-metrics-test))

--- a/test/hive_mcp/tools/diff_pinning_test.clj
+++ b/test/hive_mcp/tools/diff_pinning_test.clj
@@ -14,7 +14,8 @@
             [clojure.java.io :as io]
             [hive-mcp.tools.diff :as diff]
             [hive-mcp.tools.diff.validation :as diff-validation]
-            [hive-mcp.agent.context :as ctx]))
+            [hive-mcp.agent.context :as ctx]
+            [hive-dsl.bounded-atom :refer [bput! bget bcount bclear!]]))
 
 ;; =============================================================================
 ;; Test Helpers
@@ -49,7 +50,7 @@
 (defn clear-pending-diffs!
   "Clear all pending diffs for test isolation."
   []
-  (reset! diff/pending-diffs {}))
+  (bclear! diff/pending-diffs))
 
 (defn mock-validate-path
   "Mock path validation to always succeed for testing."
@@ -121,8 +122,8 @@
         (is (string? (:id parsed)))
         (is (= "pending" (:status parsed)))
         ;; Verify stored in atom
-        (is (= 1 (count @diff/pending-diffs)))
-        (let [stored (get @diff/pending-diffs (:id parsed))]
+        (is (= 1 (bcount diff/pending-diffs)))
+        (let [stored (bget diff/pending-diffs (:id parsed))]
           (is (= "/src/core.clj" (:file-path stored)))
           (is (= "Add docstring" (:description stored)))
           (is (= "drone-worker-1" (:drone-id stored))))))))
@@ -138,7 +139,7 @@
                        :drone_id "drone-1"})
             parsed (parse-response-text response)]
         (is (nil? (:isError response)))
-        (let [stored (get @diff/pending-diffs (:id parsed))]
+        (let [stored (bget diff/pending-diffs (:id parsed))]
           ;; Hunks are stored for tier-2 retrieval
           (is (vector? (:hunks stored)))
           (is (= 1 (count (:hunks stored))))
@@ -177,7 +178,7 @@
       (diff/handle-propose-diff
        {:file_path "/src/c.clj" :old_content "c" :new_content "c2"
         :description "Fix C" :drone_id "drone-1"})
-      (is (= 3 (count @diff/pending-diffs))))))
+      (is (= 3 (bcount diff/pending-diffs))))))
 
 ;; =============================================================================
 ;; Test: CLARITY-Y Empty Content Validation
@@ -196,7 +197,7 @@
             parsed (parse-response-text response)]
         (is (true? (:isError response)))
         (is (re-find #"(?i)empty|whitespace" (:error parsed)))
-        (is (= 0 (count @diff/pending-diffs)) "No diff should be stored"))))
+        (is (= 0 (bcount diff/pending-diffs)) "No diff should be stored"))))
 
   (testing "propose_diff rejects whitespace-only new_content"
     (with-mock-path-validation
@@ -210,13 +211,13 @@
             parsed (parse-response-text response)]
         (is (true? (:isError response)))
         (is (re-find #"(?i)empty|whitespace" (:error parsed)))
-        (is (= 0 (count @diff/pending-diffs)) "No diff should be stored")))))
+        (is (= 0 (bcount diff/pending-diffs)) "No diff should be stored")))))
 
 (deftest test-apply-diff-blocks-empty-new-content-defense-in-depth
   (testing "apply_diff blocks empty new_content even if diff was stored (defense-in-depth)"
     ;; Manually inject a diff with empty content (simulating a bug bypass)
     (let [diff-id "test-empty-diff-12345"]
-      (swap! diff/pending-diffs assoc diff-id
+      (bput! diff/pending-diffs diff-id
              {:id diff-id
               :file-path "/src/test.clj"
               :old-content ""
@@ -231,11 +232,11 @@
         (is (true? (:isError response)))
         (is (re-find #"(?i)empty|whitespace" (:error parsed)))
         ;; Diff should be removed after blocked apply
-        (is (nil? (get @diff/pending-diffs diff-id))))))
+        (is (nil? (bget diff/pending-diffs diff-id))))))
 
   (testing "apply_diff blocks whitespace-only new_content"
     (let [diff-id "test-whitespace-diff-12345"]
-      (swap! diff/pending-diffs assoc diff-id
+      (bput! diff/pending-diffs diff-id
              {:id diff-id
               :file-path "/src/test.clj"
               :old-content "(defn foo [] 1)"
@@ -364,7 +365,7 @@
             (is (= "applied" (:status parsed)))
             (is (= diff-id (:id parsed)))
             ;; Verify removed from pending
-            (is (= 0 (count @diff/pending-diffs)))
+            (is (= 0 (bcount diff/pending-diffs)))
             ;; Verify file was updated
             (is (= "(defn test [] :ok)" @file-content))))))))
 
@@ -392,7 +393,7 @@
             (is (true? (:isError apply-response)))
             (is (re-find #"(?i)not found|modified" (:error parsed)))
             ;; Diff should still be pending (not removed on error)
-            (is (= 1 (count @diff/pending-diffs)))))))))
+            (is (= 1 (bcount diff/pending-diffs)))))))))
 
 (deftest test-apply-diff-missing-diff-id
   (testing "Returns error when diff_id not provided"
@@ -442,7 +443,7 @@
             (is (true? (:isError apply-response)))
             (is (re-find #"(?i)multiple|ambiguous" (:error parsed)))
             ;; Diff should remain pending
-            (is (= 1 (count @diff/pending-diffs)))))))))
+            (is (= 1 (bcount diff/pending-diffs)))))))))
 
 (deftest test-sandbox-path-translation
   (testing "translate-sandbox-path converts /tmp/fs-N/ paths to project paths"
@@ -479,7 +480,7 @@
             (is (nil? (:isError reject-response)))
             (is (= "rejected" (:status parsed)))
             ;; Verify removed from pending
-            (is (= 0 (count @diff/pending-diffs)))
+            (is (= 0 (bcount diff/pending-diffs)))
             ;; Verify file was NOT changed
             (is (= "old" @file-content))))))))
 

--- a/test/hive_mcp/tools/swarm_test.clj
+++ b/test/hive_mcp/tools/swarm_test.clj
@@ -11,7 +11,8 @@
             [hive-mcp.tools.swarm.core :as swarm-core]
             [hive-mcp.swarm.datascript :as ds]
             [hive-mcp.emacs.client :as ec]
-            [hive-mcp.hivemind.core :as hivemind]))
+            [hive-mcp.hivemind.core :as hivemind]
+            [hive-dsl.bounded-atom :refer [bput! bget bclear!]]))
 
 ;; =============================================================================
 ;; Test Fixtures
@@ -24,11 +25,11 @@
   ;; Reset DataScript (primary - ADR-002)
   (ds/reset-conn!)
   ;; Reset hivemind agent-registry (message history)
-  (reset! hivemind/agent-registry {})
+  (bclear! hivemind/agent-registry)
   (f)
   ;; Cleanup after test
   (ds/reset-conn!)
-  (reset! hivemind/agent-registry {}))
+  (bclear! hivemind/agent-registry))
 
 (use-fixtures :each reset-registry-fixture)
 
@@ -136,8 +137,9 @@
 (deftest swarm-status-merge-with-hivemind-preserves-all-test
   (testing "Merging hivemind status preserves all slaves"
     ;; Setup: Add hivemind status for some agents
-    (swap! hivemind/agent-registry assoc
-           "slave-1" {:status :progress :task "Working on tests"}
+    (bput! hivemind/agent-registry
+           "slave-1" {:status :progress :task "Working on tests"})
+    (bput! hivemind/agent-registry
            "slave-3" {:status :completed :task "Done with review"})
 
     (let [status-json (json/write-str
@@ -215,11 +217,15 @@
 (deftest get-slave-working-status-test
   (testing "Maps hivemind event types to working status"
     ;; Setup various agent states
-    (swap! hivemind/agent-registry assoc
-           "agent-started" {:status :started}
-           "agent-progress" {:status :progress}
-           "agent-completed" {:status :completed}
-           "agent-error" {:status :error}
+    (bput! hivemind/agent-registry
+           "agent-started" {:status :started})
+    (bput! hivemind/agent-registry
+           "agent-progress" {:status :progress})
+    (bput! hivemind/agent-registry
+           "agent-completed" {:status :completed})
+    (bput! hivemind/agent-registry
+           "agent-error" {:status :error})
+    (bput! hivemind/agent-registry
            "agent-blocked" {:status :blocked})
 
     (is (= "working" (swarm/get-slave-working-status "agent-started")))


### PR DESCRIPTION
## Summary
- Enrichment addon (:cu/a) now runs fire-and-forget — catchup response is no longer blocked
- Removes sync wait that caused piggyback self-consumption (blocks drained on same call that enqueued them)
- Scrubs IP-specific block names from FOSS docstrings
- Raw `_caller_id` flows through ctx-id ADTs instead of hardcoded fallback

## Test plan
- [x] Hot-reload via CIDER — compiles clean
- [x] Catchup responds fast (no 17s enrichment wait)
- [x] Manually enqueued piggyback blocks drain correctly on subsequent calls
- [x] `---MEMORY---` continues draining normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)