### PR TITLE
CI hardening: untrap .clj-kondo, pin the CLI, fix release dep resolution, settle test futures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@13.2
         with:
-          cli: 'latest'
+          cli: '1.12.5.1664'
           clj-kondo: '2026.07.24'
 
       - name: Lint with clj-kondo
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@13.2
         with:
-          cli: 'latest'
+          cli: '1.12.5.1664'
 
       - name: Cache Maven deps
         uses: actions/cache@v4
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@13.2
         with:
-          cli: 'latest'
+          cli: '1.12.5.1664'
 
       - name: Cache Maven deps
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: DeLaGuardo/setup-clojure@13.0
+      - uses: DeLaGuardo/setup-clojure@13.2
         with:
-          cli: latest
+          cli: '1.12.5.1664'
 
       - name: Deploy
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,6 @@ claude-code-ide.el/
 hive-mcp.wiki/
 hive-hot
 local.deps.edn
-.clj-kondo/
 .worktrees/
 
 # Retrieval experiment inputs are private by default. Only deliberately

--- a/deps.edn
+++ b/deps.edn
@@ -157,6 +157,12 @@
         ;; hive-emacs — Emacs vessel addon (IEditor, daemon, CIDER/Magit/Projectile)
         io.github.hive-agi/hive-emacs {:git/tag "v0.4.6" :git/sha "bb042ee"}
 
+        ;; hive-schemas — pinned at the TOP level, not only in :test/:test-unit.
+        ;; hive-emacs pulls 0.1.6 transitively, and 0.1.6 exists on Gitea only
+        ;; (404 on Clojars and Central), so the default tree cannot resolve from
+        ;; a public runner. :use-top makes this pin win everywhere.
+        io.github.hive-agi/hive-schemas {:mvn/version "0.1.10"}
+
         ;; hive-proximum — temporal/bitemporal memory backend (IMemoryStore via IAddon).
         ;; Auto-discovered via its hive-addons manifest. Stub store until the
         ;; backend impl lands.

--- a/test/hive_mcp/bug_regression_test.clj
+++ b/test/hive_mcp/bug_regression_test.clj
@@ -49,18 +49,18 @@
 
 (deftest ^:integration test-kanban-status-performance
   (testing "BUG #5: kanban-status should complete within reasonable time"
-    (let [start (System/currentTimeMillis)
-          ;; Use a timeout wrapper
-          result (deref
-                  (future (kanban/handle-kanban {:command "status"}))
-                  5000 ; 5 second timeout
-                  {:timeout true})]
-      (is (not (:timeout result))
-          "kanban-status should complete within 5 seconds")
-      (when-not (:timeout result)
-        (let [elapsed (- (System/currentTimeMillis) start)]
-          (is (< elapsed 5000)
-              (format "Should complete in <5s, took %dms" elapsed)))))))
+    (let [start  (System/currentTimeMillis)
+          f      (future (kanban/handle-kanban {:command "status"}))
+          result (deref f 5000 {:timeout true})]
+      (try
+        (is (not (:timeout result))
+            "kanban-status should complete within 5 seconds")
+        (when-not (:timeout result)
+          (let [elapsed (- (System/currentTimeMillis) start)]
+            (is (< elapsed 5000)
+                (format "Should complete in <5s, took %dms" elapsed))))
+        (finally
+          (future-cancel f))))))
 
 ;; =============================================================================
 ;; BUG #6: Swarm returns double-encoded JSON (LOW)
@@ -123,18 +123,17 @@
 
 (deftest ^:integration test-cider-eval-does-not-hang
   (testing "BUG #8: cider_eval_silent should not hang indefinitely"
-    ;; Use a timeout wrapper to detect hanging
-    (let [result (deref
-                  (future
-                    (try
-                      (cider/handle-cider-eval-silent {:code "(+ 1 1)"})
-                      (catch Exception e
-                        {:error (.getMessage e)})))
-                  10000 ; 10 second timeout - should be plenty
-                  {:timeout true :error "Evaluation hung for 10+ seconds"})]
-      ;; Should either succeed or fail fast, never hang
-      (is (not (:timeout result))
-          "cider_eval_silent should complete within 10 seconds, not hang"))))
+    (let [f      (future
+                   (try
+                     (cider/handle-cider-eval-silent {:code "(+ 1 1)"})
+                     (catch Exception e
+                       {:error (.getMessage e)})))
+          result (deref f 10000 {:timeout true :error "Evaluation hung for 10+ seconds"})]
+      (try
+        (is (not (:timeout result))
+            "cider_eval_silent should complete within 10 seconds, not hang")
+        (finally
+          (future-cancel f))))))
 
 ;; =============================================================================
 ;; BUG #9: claude-context search hangs (HIGH) - OPEN

--- a/test/hive_mcp/chroma/gate_property_test.clj
+++ b/test/hive_mcp/chroma/gate_property_test.clj
@@ -117,7 +117,9 @@
                                   (Thread/sleep 10)
                                   (swap! active dec))))
                             (catch Exception _ nil)))))]
-        (doseq [f futures] (deref f 10000 nil))
+        (doseq [f futures]
+          (when (= ::pending (deref f 10000 ::pending))
+            (future-cancel f)))
         ;; Peak concurrent should never exceed permits
         (<= @peak permits)))))
 
@@ -193,6 +195,8 @@
                               (Thread/sleep 50)
                               (swap! active dec)))
                           (catch Exception _ nil)))))]
-      (doseq [f futures] (deref f 10000 nil))
+      (doseq [f futures]
+        (when (= ::pending (deref f 10000 ::pending))
+          (future-cancel f)))
       ;; embed-gate has 2 permits
       (is (<= @peak 2) "Embedding concurrency must be bounded to 2"))))

--- a/test/hive_mcp/swarm/event_bridge_test.clj
+++ b/test/hive_mcp/swarm/event_bridge_test.clj
@@ -40,7 +40,8 @@
 
 (defn- capture-local!
   "Subscribe to an event-type and drain everything published while the
-   thunk runs. Returns [result events-seen]."
+   thunk runs. Returns [result events-seen]. The drain pump is settled
+   before returning."
   [event-type thunk]
   (let [ch (channel/subscribe! event-type)
         acc (atom [])
@@ -60,6 +61,8 @@
         [r @acc])
       (finally
         (reset! stop? true)
+        (when (= ::pending (deref pump 500 ::pending))
+          (future-cancel pump))
         (try (clojure.core.async/close! ch) (catch Exception _ nil))))))
 
 ;; =============================================================================

--- a/test/hive_mcp/tools/catchup_test.clj
+++ b/test/hive_mcp/tools/catchup_test.clj
@@ -9,11 +9,15 @@
       (is (= :ok (:status result)))
       (is (= {:entries [1]} (outcome/value-or result {})))))
   (testing "timeout"
-    (let [gate (promise)
-          result (#'catchup/safe-deref (future @gate) 10 "slow")]
-      (is (= :timeout (:status result)))
-      (is (false? (outcome/available? result)))
-      (is (= :fallback (outcome/value-or result :fallback)))))
+    (let [gate    (promise)
+          blocked (future @gate)]
+      (try
+        (let [result (#'catchup/safe-deref blocked 10 "slow")]
+          (is (= :timeout (:status result)))
+          (is (false? (outcome/available? result)))
+          (is (= :fallback (outcome/value-or result :fallback))))
+        (finally
+          (deliver gate ::released)))))
   (testing "error"
     (let [result (#'catchup/safe-deref
                   (future (throw (ex-info "boom" {})))

--- a/test/hive_mcp/tools/consolidated/workflow_test.clj
+++ b/test/hive_mcp/tools/consolidated/workflow_test.clj
@@ -37,6 +37,14 @@
 ;; Keep the retry window tiny so timeout tests stay fast; production default is 2s.
 (def ^:const test-retry-wait-ms 20)
 
+(defn- settle!
+  "Blocks up to timeout-ms for future f, cancelling it if still pending.
+   Guarantees f is settled — done or cancelled — by the time this returns."
+  [f timeout-ms]
+  (when (= ::pending (deref f timeout-ms ::pending))
+    (future-cancel f))
+  nil)
+
 ;; =============================================================================
 ;; Test Fixtures
 ;; =============================================================================
@@ -83,15 +91,17 @@
                   readiness/ling-ready-poll-ms 10
                   readiness/ling-cli-ready? (constantly true)]
       ;; Schedule slave registration after ~30ms
-      (future
-        (Thread/sleep 30)
-        (ds-lings/add-slave! "delayed-ling" {:status :idle :depth 1 :cwd "/tmp"}))
-
-      (let [result (wait-for-ling-ready "delayed-ling" :claude)]
-        (is (:ready? result) "Should eventually find the slave")
-        (is (> (:attempts result) 1) "Should take more than one attempt")
-        (is (some? (:slave result)) "Should include slave data")
-        (is (= :cli-ready (:phase result)) "Should reach cli-ready phase")))))
+      (let [registrar (future
+                        (Thread/sleep 30)
+                        (ds-lings/add-slave! "delayed-ling" {:status :idle :depth 1 :cwd "/tmp"}))]
+        (try
+          (let [result (wait-for-ling-ready "delayed-ling" :claude)]
+            (is (:ready? result) "Should eventually find the slave")
+            (is (> (:attempts result) 1) "Should take more than one attempt")
+            (is (some? (:slave result)) "Should include slave data")
+            (is (= :cli-ready (:phase result)) "Should reach cli-ready phase"))
+          (finally
+            (settle! registrar 1000)))))))
 
 ;; =============================================================================
 ;; Phase 2: CLI Readiness Tests
@@ -154,16 +164,18 @@
                   readiness/ling-cli-ready? (constantly true)]
       ;; Registers at ~250ms: too late for the initial 150ms window,
       ;; but well inside the retry window that starts at ~450ms.
-      (future
-        (Thread/sleep 250)
-        (ds-lings/add-slave! "late-ling" {:status :idle :depth 1 :cwd "/tmp"}))
-
-      (let [result (wait-for-ling-ready "late-ling" :claude)]
-        (is (:ready? result) "Should become ready on the retry pass")
-        (is (= :cli-ready (:phase result)) "Should reach cli-ready phase")
-        (is (some? (:slave result)) "Should include slave data")
-        (is (>= (:elapsed-ms result) 400)
-            "Elapsed should include the timed-out window + retry wait")))))
+      (let [registrar (future
+                        (Thread/sleep 250)
+                        (ds-lings/add-slave! "late-ling" {:status :idle :depth 1 :cwd "/tmp"}))]
+        (try
+          (let [result (wait-for-ling-ready "late-ling" :claude)]
+            (is (:ready? result) "Should become ready on the retry pass")
+            (is (= :cli-ready (:phase result)) "Should reach cli-ready phase")
+            (is (some? (:slave result)) "Should include slave data")
+            (is (>= (:elapsed-ms result) 400)
+                "Elapsed should include the timed-out window + retry wait"))
+          (finally
+            (settle! registrar 1000)))))))
 
 ;; =============================================================================
 ;; Spawn-Mode Timeout Selection (added in 508a7e8)


### PR DESCRIPTION
Four follow-ups filed while getting the unit gate green, each from something observed rather than suspected.

### `.gitignore` — new kondo hooks were silently untracked
A stray `.clj-kondo/` in the sibling-projects block shadowed the narrow rules above it. Already-tracked files kept working, so nothing looked wrong; any **new** hook file would have been invisible to git. Generated subdirs stay ignored.

### CI — pin the Clojure CLI
`cli: latest` in all three `ci.yml` jobs and in `release.yml`. Pinned to `1.12.5.1664`, the version `latest` resolved to in the last green run. `release.yml` also moves to `setup-clojure@13.2` to match `ci.yml`. An upstream release should not be able to change what the gate runs.

### `deps.edn` — release could not resolve hive-schemas
`hive-emacs v0.4.6` pulls `hive-schemas 0.1.6` transitively, and **0.1.6 was never published publicly** — 404 on both Clojars and Central (Clojars goes 0.1.5 → 0.1.9). The `:test`/`:test-unit` aliases pinned 0.1.10 and won by `:use-top`, so CI went green while `clojure -T:build deploy` resolved the default tree and died on the Gitea-only 0.1.6.

Pinning 0.1.10 at the top level makes `:use-top` select it everywhere. The resolved tree changes only those three lines — no other dependency moves.

### tests — futures outliving their own deftest
Six sites left a future running past the test that started it. Two of them mattered: `workflow_test` scheduled `add-slave!` into the **shared** lings db on a sleep and never awaited it, and that pending mutation is what drove the readiness counter inside a concurrently-running test. The rest: a future parked forever on an undelivered promise, two hang-detectors that never cancelled the hang they detect, an unawaited drain pump, and a timeout-deref with no cancel.

All now bound and settled in a `finally`.

### Verification
- clj-kondo 2026.07.24 (the pinned CI version), cache cleared: **errors: 0**
- touched namespaces, cold: 32 tests / 92 assertions, 0 failures
- full cold gate: **6356 tests / 21316 assertions, 0 failures**
- an ambient-service audit ran the full gate while sampling sockets filtered to the test JVM's process tree: **zero** connections to ollama/qdrant/nats/postgres/chroma or the live nREPL across 461 samples

### Not merging yet
`release.yml` triggers on `deps.edn`. With the resolution fixed, merging will publish **hive-mcp 0.18.3 to Clojars and tag v0.18.3** — Clojars currently has 0.18.0/0.18.1, and its releases are immutable. That should be a deliberate call, so this is left for review rather than merged.