### PR TITLE
feat(kanban): content-editing dispatch path for `kanban update`

### DIFF
--- a/src/hive_mcp/tools/consolidated/kanban.clj
+++ b/src/hive_mcp/tools/consolidated/kanban.clj
@@ -120,7 +120,7 @@
 (def tool-def
   {:name "kanban"
    :consolidated true
-   :description "Kanban task management: list (all/filtered tasks), get (single task/entry by id — unified across the kanban store AND the default memory store, since they are separate backends; surfaces full fields + KG edges; on miss returns semantic-search suggestions), create (new task), update (change status/modify task), delete (hard-remove task by id; no archival, no completion — use for duplicates/cancellations), retag (scope-move via project_id + optional ±tags; preserves entry id + KG edges, no re-embed), status (board overview + milestones), sync (backends), plan-to-kanban (convert plan to tasks, supports plan_id or plan_path), plan-schema (the plan-memory EDN contract: JSON-schema + example + how-to, so a type=plan memory can be authored without reading source), batch-update (bulk status changes; per-op :command respected — pass :command \"delete\" inside an op to mix delete in), batch-delete (sweep many task_ids; mirror of batch-update), batch-retag (sweep many scope-moves). Aliases (deprecated): move→update, roadmap→status, my-tasks→list. Use command='help' to list all. HCR: a list shows its own scope + ANCESTORS (parent tasks, always — 'child sees parent'); include_descendants=true (default) also aggregates DESCENDANT (child) project tasks; scope=\"all\" lifts the project filter entirely for a cross-workspace whole-board view. List filters: query (substring), tags (extra required tags), tag_match (any|all), created_after / updated_after (ISO-8601), limit / offset (pagination), fields (projection)."
+   :description "Kanban task management: list (all/filtered tasks), get (single task/entry by id — unified across the kanban store AND the default memory store, since they are separate backends; surfaces full fields + KG edges; on miss returns semantic-search suggestions), create (new task), update (move status via new_status and/or edit title/description/priority in place; both in one call move first, then edit), delete (hard-remove task by id; no archival, no completion — use for duplicates/cancellations), retag (scope-move via project_id + optional ±tags; preserves entry id + KG edges, no re-embed), status (board overview + milestones), sync (backends), plan-to-kanban (convert plan to tasks, supports plan_id or plan_path), plan-schema (the plan-memory EDN contract: JSON-schema + example + how-to, so a type=plan memory can be authored without reading source), batch-update (bulk status changes; per-op :command respected — pass :command \"delete\" inside an op to mix delete in), batch-delete (sweep many task_ids; mirror of batch-update), batch-retag (sweep many scope-moves). Aliases (deprecated): move→update, roadmap→status, my-tasks→list. Use command='help' to list all. HCR: a list shows its own scope + ANCESTORS (parent tasks, always — 'child sees parent'); include_descendants=true (default) also aggregates DESCENDANT (child) project tasks; scope=\"all\" lifts the project filter entirely for a cross-workspace whole-board view. List filters: query (substring), tags (extra required tags), tag_match (any|all), created_after / updated_after (ISO-8601), limit / offset (pagination), fields (projection)."
    :inputSchema {:type "object"
                  :properties {"command" {:type "string"
                                          :enum ["list" "get" "create" "move" "status" "update" "delete" "retag" "roadmap" "my-tasks" "sync" "plan-to-kanban" "plan-schema" "batch-update" "batch-delete" "batch-create" "batch-retag" "help"]
@@ -129,9 +129,9 @@
                                         :enum ["todo" "inprogress" "inreview" "done"]
                                         :description "Filter by task status"}
                               "title" {:type "string"
-                                       :description "Task title for create"}
+                                       :description "[create|update] Task title. On update a non-blank value replaces the current title in place — entry id, KG edges, status and scope are preserved."}
                               "description" {:type "string"
-                                             :description "Task description"}
+                                             :description "[create|update] Task description. On update a non-blank value replaces the current description in place."}
                               "task_id" {:type "string"
                                          :description "Task ID to get/move/update/retag/delete"}
                               "id" {:type "string"
@@ -161,7 +161,9 @@
                                                                  "add_tags"       {:type "array" :items {:type "string"}}
                                                                  "remove_tags"    {:type "array" :items {:type "string"}}
                                                                  "title"          {:type "string"}
-                                                                 "description"    {:type "string"}}}
+                                                                 "description"    {:type "string"}
+                                                                 "priority"       {:type "string"
+                                                                                   :enum ["high" "medium" "low"]}}}
                                             :description "Array of operations for batch-update / batch-delete / batch-create / batch-retag. Each op may specify :command to mix verbs in one batch; otherwise the wrapper's default applies."}
                               "directory" {:type "string"
                                            :description "Working directory for project scope (auto-detected if not provided)"}
@@ -181,7 +183,7 @@
                                            :description "[list] Tag match semantics for `tags` (default 'all')"}
                               "priority" {:type "string"
                                           :enum ["high" "medium" "low"]
-                                          :description "[list] Filter by exact priority"}
+                                          :description "[list] Filter by exact priority. [create|update] Set the task priority — an update rewrites the `priority-*` tag together with the content field, so `list` and `get` cannot disagree."}
                               "created_after" {:type "string"
                                                :description "[list] ISO-8601 timestamp; only entries with content :created >= this"}
                               "updated_after" {:type "string"

--- a/src/hive_mcp/tools/consolidated/project.clj
+++ b/src/hive_mcp/tools/consolidated/project.clj
@@ -146,8 +146,8 @@
                               "project_id" {:type "string"
                                             :description "Project ID to query tree for / [kanban list] exact-match project filter / [kanban retag] alias for new_project_id"}
                               ;; Kanban params
-                              "title" {:type "string" :description "[kanban create] Task title"}
-                              "description" {:type "string" :description "[kanban create] Task description"}
+                              "title" {:type "string" :description "[kanban create|update] Task title. On update a non-blank value replaces the current title in place — entry id, KG edges, status and scope are preserved."}
+                              "description" {:type "string" :description "[kanban create|update] Task description. On update a non-blank value replaces the current description in place."}
                               "task_id" {:type "string" :description "[kanban get|update|delete|retag] Task ID"}
                               "id" {:type "string" :description "[kanban get] Alias for task_id — entry id to fetch from either store"}
                               "new_status" {:type "string"
@@ -179,7 +179,7 @@
                                            :description "[kanban list] Tag match semantics for `tags` (default 'all')"}
                               "priority" {:type "string"
                                           :enum ["high" "medium" "low"]
-                                          :description "[kanban list] Filter by exact priority"}
+                                          :description "[kanban list] Filter by exact priority / [kanban create|update] Set the task priority. An update rewrites the `priority-*` tag together with the content field, so `list` and `get` cannot disagree."}
                               "created_after" {:type "string"
                                                :description "[kanban list] ISO-8601 timestamp; only entries with content :created >= this"}
                               "updated_after" {:type "string"

--- a/src/hive_mcp/tools/kanban/events.clj
+++ b/src/hive_mcp/tools/kanban/events.clj
@@ -83,6 +83,41 @@
                                 :payload {:tags       new-tags
                                           :project-id new-project-id}}})))
 
+(defn edit-fx
+  "Pure handler. Given coeffects (entry) and an event, return the effect map
+   describing a content edit — title, description, priority. Status, scope
+   and KG edges are untouched. Returns nil for missing/non-kanban entries.
+
+   Effect map invariants:
+     * `:kanban/facade-update` is ALWAYS present (the soft commit), and
+       carries `:tags` ONLY when the priority moved — see
+       `kt/edit-transition` for why the tag must travel with the content.
+     * `:kanban/temporal-record` op = `:kanban-edit`, emitted only when a
+       field actually changed, so a no-op edit leaves no audit noise.
+     * No completion hooks, no movement tracking, no delete effect"
+  [{:keys [:kanban/entry]} [_ {:keys [task-id title description priority]}]]
+  (when (and entry (pred/kanban-entry? entry))
+    (let [{:keys [changed new-content new-tags
+                  old-title new-title old-priority new-priority]}
+          (kt/edit-transition entry {:title       title
+                                     :description description
+                                     :priority    priority})
+          project-id (kt/extract-project-id-from-tags entry)]
+      (cond-> {:kanban/facade-update
+               {:task-id task-id
+                :payload (cond-> {:content new-content}
+                           new-tags (assoc :tags new-tags))}}
+        (seq changed)
+        (assoc :kanban/temporal-record
+               {:entry-id   task-id
+                :op         :kanban-edit
+                :data       {:changed      (vec (sort (map name changed)))
+                             :old-title    old-title
+                             :new-title    new-title
+                             :old-priority old-priority
+                             :new-priority new-priority}
+                :project-id project-id})))))
+
 (defn- result-from-fx
   "Lift a possibly-nil effect map into a Result."
   [fx-map task-id]
@@ -105,7 +140,11 @@
   (router/reg-event-fx
    :kanban/retag
    [(cofx/inject-cofx :kanban/entry)]
-   retag-fx))
+   retag-fx)
+  (router/reg-event-fx
+   :kanban/edit
+   [(cofx/inject-cofx :kanban/entry)]
+   edit-fx))
 
 (defonce ^:private initialized? (atom false))
 
@@ -172,3 +211,48 @@
     :else
     (let [ctx (router/dispatch-sync [:kanban/retag event-payload])]
       (result-from-fx (:effects ctx) task-id))))
+
+(defn dispatch-edit!
+  "Public boundary entry point. Synchronously dispatch a `:kanban/edit` event
+   and return a Result wrapping the effect map. Effects run before this returns.
+
+   `event-payload` shape:
+     {:task-id ..     — required
+      :title ..       — optional, non-blank string to replace the title
+      :description .. — optional, non-blank string to replace the description
+      :priority ..    — optional, one of high|medium|low
+      :directory ..}  — optional, threaded for cofx context
+
+   A field that is absent, nil, or blank leaves the current value standing;
+   at least one of the three must be present.
+
+   Returns:
+     (r/ok effect-map)                      on success
+     (r/err :kanban/invalid-task-id ...)    when task-id missing/blank
+     (r/err :kanban/nothing-to-edit ...)    when no editable field was given
+     (r/err :kanban/invalid-priority ...)   when priority is outside the enum
+     (r/err :kanban/invalid-task ...)       when entry missing or non-kanban"
+  [{:keys [task-id title description priority] :as event-payload}]
+  (init!)
+  (let [given?     (fn [v] (and (string? v) (not (clojure.string/blank? v))))
+        priorities #{"high" "medium" "low"}]
+    (cond
+      (or (nil? task-id)
+          (and (string? task-id) (clojure.string/blank? task-id)))
+      (r/err :kanban/invalid-task-id
+             {:message "Edit requires :task-id"
+              :given   task-id})
+
+      (not (some given? [title description priority]))
+      (r/err :kanban/nothing-to-edit
+             {:message "Edit requires at least one of :title, :description, :priority"
+              :task-id task-id})
+
+      (and (given? priority) (not (priorities priority)))
+      (r/err :kanban/invalid-priority
+             {:message "Priority must be one of high, medium, low"
+              :given   priority})
+
+      :else
+      (let [ctx (router/dispatch-sync [:kanban/edit event-payload])]
+        (result-from-fx (:effects ctx) task-id)))))

--- a/src/hive_mcp/tools/kanban/transitions.clj
+++ b/src/hive_mcp/tools/kanban/transitions.clj
@@ -125,6 +125,65 @@
      :priority       priority
      :title          title}))
 
+(defn reprioritize-tags
+  "Pure: swap the `priority-*` tag for `priority`, leaving every other tag
+   untouched. Distinct, priority tag first."
+  [existing-tags priority]
+  (->> (or existing-tags [])
+       (filter string?)
+       (remove #(str/starts-with? % "priority-"))
+       (cons (str "priority-" priority))
+       distinct
+       vec))
+
+(defn- put-field
+  "Assoc `k` and drop its JSON-roundtripped string twin, so `content-val`
+   cannot read a stale value through the string key."
+  [content k v]
+  (-> content (dissoc (name k)) (assoc k v)))
+
+(defn edit-transition
+  "Pure: derive the content edit for a task. A field is edited only when
+   `edits` carries a non-blank string for it; anything else leaves the
+   current value standing. Status, scope and every other tag are preserved.
+
+   `:new-tags` is nil unless the priority changed. Priority lives in BOTH
+   the content map and a `priority-*` tag — `kanban get` reads content while
+   `kanban list :priority` filters on the tag — so an edit that moves one
+   without the other makes a task answer differently depending on which
+   command found it.
+
+   Returns {:old-title .. :new-title .. :old-priority .. :new-priority ..
+            :changed #{:title :description :priority} :new-content ..
+            :new-tags ..}."
+  [entry edits]
+  (let [content   (or (:content entry) {})
+        pick      (fn [k current]
+                    (let [v (get edits k)]
+                      (if (and (string? v) (not (str/blank? v))) v current)))
+        old-title (current-title entry)
+        old-desc  (content-val content :description nil)
+        old-prio  (current-priority entry)
+        new-title (pick :title old-title)
+        new-desc  (pick :description old-desc)
+        new-prio  (pick :priority old-prio)
+        changed   (cond-> #{}
+                    (not= new-title old-title) (conj :title)
+                    (not= new-desc old-desc)   (conj :description)
+                    (not= new-prio old-prio)   (conj :priority))
+        new-content (cond-> content
+                      (changed :title)       (put-field :title new-title)
+                      (changed :description) (put-field :description new-desc)
+                      (changed :priority)    (put-field :priority new-prio))]
+    {:old-title    old-title
+     :new-title    new-title
+     :old-priority old-prio
+     :new-priority new-prio
+     :changed      changed
+     :new-content  new-content
+     :new-tags     (when (changed :priority)
+                     (reprioritize-tags (:tags entry) new-prio))}))
+
 (defn transition
   "Pure: derive {:old-status :new-status :new-content :new-tags :title :project-id}.
    Caller supplies project-id (typically from coeffect). Tags MERGE onto the

--- a/src/hive_mcp/tools/memory_kanban.clj
+++ b/src/hive_mcp/tools/memory_kanban.clj
@@ -217,6 +217,39 @@
       (mcp-error (or (:message result)
                      (str "Move failed: " (:error result)))))))
 
+(defn- edit*
+  "Edit a kanban task's title/description/priority via the event bus.
+   Like `move*`, the slim view is derived from the committed effect payload
+   rather than a read-back, because some vector backends are eventual here."
+  [{:keys [task_id id title description priority directory]}]
+  (let [task-id (or task_id id)
+        result  (kanban-events/dispatch-edit!
+                 {:task-id     task-id
+                  :title       title
+                  :description description
+                  :priority    priority
+                  :directory   directory})]
+    (if (r/ok? result)
+      (let [{:keys [content tags]} (get-in result [:ok :kanban/facade-update :payload])]
+        (mcp-json (kt/task->slim {:id task-id :content content :tags tags})))
+      (mcp-error (or (:message result)
+                     (str "Edit failed: " (:error result)))))))
+
+(defn- update*
+  "Route a `kanban update` call to a status move, a content edit, or both.
+
+   `new_status`/`status` moves; `title`/`description`/`priority` edit. When
+   both are given the move commits first, so the edit's coeffect reads the
+   already-moved entry and the returned slim view carries both changes."
+  [{:keys [new_status status title description priority] :as params}]
+  (let [given? (fn [v] (and (string? v) (not (str/blank? v))))
+        move?  (some given? [new_status status])
+        edit?  (some given? [title description priority])]
+    (cond
+      (and move? edit?) (do (move* params) (edit* params))
+      edit?             (edit* params)
+      :else             (move* params))))
+
 (defn- retag*
   "Retag a kanban entry: scope-move (project_id) + optional ±tags.
    Tags-only mutation — preserves entry id, content, KG edges, qdrant point.
@@ -373,11 +406,15 @@
   (safe-call :kanban/list-failed #(with-store (list-slim* params))))
 
 (defn handle-mem-kanban-move
-  "Move task to new status via the kanban event bus.
+  "Update a task via the kanban event bus: status move, content edit, or both.
    Moving to `done` is a SOFT transition: status retagged, entry preserved,
-   KG edges intact. Use `handle-mem-kanban-delete` for hard removal."
+   KG edges intact. Use `handle-mem-kanban-delete` for hard removal.
+
+   `title`/`description`/`priority` edit the entry's content in place. A
+   priority edit rewrites the `priority-*` tag too, so `list :priority` and
+   `get` cannot disagree."
   [params]
-  (safe-call :kanban/move-failed #(with-store (move* params))))
+  (safe-call :kanban/move-failed #(with-store (update* params))))
 
 (defn handle-mem-kanban-retag
   "Retag a kanban entry: scope-move (project_id) + optional ±tags.

--- a/test/golden/kanban/edit-transition.edn
+++ b/test/golden/kanban/edit-transition.edn
@@ -1,0 +1,109 @@
+{:all-three
+ {:old-title "original title",
+  :new-title "t",
+  :old-priority "medium",
+  :new-priority "low",
+  :changed #{:description :title :priority},
+  :new-content
+  {:task-type "kanban",
+   :title "t",
+   :description "d",
+   :status "todo",
+   :priority "low"},
+  :new-tags
+  ["priority-low"
+   "kanban"
+   "todo"
+   "scope:project:hive"
+   "epic:adapter"]},
+ :blank-is-ignored
+ {:old-title "original title",
+  :new-title "original title",
+  :old-priority "medium",
+  :new-priority "medium",
+  :changed #{},
+  :new-content
+  {:task-type "kanban",
+   :title "original title",
+   :description "original description",
+   :status "todo",
+   :priority "medium"},
+  :new-tags nil},
+ :description-only
+ {:old-title "original title",
+  :new-title "original title",
+  :old-priority "medium",
+  :new-priority "medium",
+  :changed #{:description},
+  :new-content
+  {:task-type "kanban",
+   :title "original title",
+   :description "new description",
+   :status "todo",
+   :priority "medium"},
+  :new-tags nil},
+ :nil-is-ignored
+ {:old-title "original title",
+  :new-title "original title",
+  :old-priority "medium",
+  :new-priority "medium",
+  :changed #{},
+  :new-content
+  {:task-type "kanban",
+   :title "original title",
+   :description "original description",
+   :status "todo",
+   :priority "medium"},
+  :new-tags nil},
+ :no-op-same-values
+ {:old-title "original title",
+  :new-title "original title",
+  :old-priority "medium",
+  :new-priority "medium",
+  :changed #{},
+  :new-content
+  {:task-type "kanban",
+   :title "original title",
+   :description "original description",
+   :status "todo",
+   :priority "medium"},
+  :new-tags nil},
+ :priority-only
+ {:old-title "original title",
+  :new-title "original title",
+  :old-priority "medium",
+  :new-priority "high",
+  :changed #{:priority},
+  :new-content
+  {:task-type "kanban",
+   :title "original title",
+   :description "original description",
+   :status "todo",
+   :priority "high"},
+  :new-tags
+  ["priority-high"
+   "kanban"
+   "todo"
+   "scope:project:hive"
+   "epic:adapter"]},
+ :string-keyed-content
+ {:old-title "from json",
+  :new-title "replaced",
+  :old-priority "low",
+  :new-priority "low",
+  :changed #{:title},
+  :new-content {"priority" "low", :title "replaced"},
+  :new-tags nil},
+ :title-only
+ {:old-title "original title",
+  :new-title "new title",
+  :old-priority "medium",
+  :new-priority "medium",
+  :changed #{:title},
+  :new-content
+  {:task-type "kanban",
+   :title "new title",
+   :description "original description",
+   :status "todo",
+   :priority "medium"},
+  :new-tags nil}}

--- a/test/hive_mcp/memory_kanban_test.clj
+++ b/test/hive_mcp/memory_kanban_test.clj
@@ -278,7 +278,12 @@
       (is (not (str/includes? result "\"todo\""))))))
 
 ;; =============================================================================
-;; 5. Update Tests
+;; 5. Update Tests — ELISP BRIDGE ONLY
+;;
+;; These assert on the string `kanban-update-elisp` builds for the Emacs API.
+;; They do NOT exercise the MCP `kanban update` path, so their green says
+;; nothing about whether a title/description/priority edit reaches the store.
+;; That contract lives in hive-mcp.tools.kanban.edit-trifecta-test.
 ;; =============================================================================
 
 (deftest test-update-generates-valid-elisp

--- a/test/hive_mcp/tools/kanban/edit_trifecta_test.clj
+++ b/test/hive_mcp/tools/kanban/edit_trifecta_test.clj
@@ -1,0 +1,217 @@
+(ns hive-mcp.tools.kanban.edit-trifecta-test
+  "Trifecta + invariant tests for kanban content edit.
+
+   Covers:
+   - `kt/edit-transition` — pure, golden + property + mutation
+   - `events/edit-fx`     — effect-map invariants (content payload, tags only
+                            when the priority moved, no completion hooks)
+
+   The edit contract: content-only mutation of title/description/priority.
+   Status, scope and entry id are preserved; the `priority-*` tag travels
+   with a priority change so `list :priority` and `get` cannot disagree."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [hive-test.trifecta :refer [deftrifecta]]
+            [hive-mcp.tools.kanban.events :as events]
+            [hive-mcp.tools.kanban.transitions :as kt]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Fixture
+;; =============================================================================
+
+(def ^:private fixture-entry
+  {:id      "20260101000000-deadbeef"
+   :tags    ["kanban" "todo" "priority-medium" "scope:project:hive" "epic:adapter"]
+   :content {:task-type   "kanban"
+             :title       "original title"
+             :description "original description"
+             :status      "todo"
+             :priority    "medium"}})
+
+;; =============================================================================
+;; 1. edit-transition — pure trifecta
+;; =============================================================================
+
+(defn run-edit-transition [{:keys [entry edits]}]
+  (kt/edit-transition (or entry fixture-entry) (or edits {})))
+
+(deftrifecta edit-transition-contract
+  hive-mcp.tools.kanban.edit-trifecta-test/run-edit-transition
+  {:golden-path "test/golden/kanban/edit-transition.edn"
+   :cases       {:title-only
+                 {:entry fixture-entry :edits {:title "new title"}}
+
+                 :description-only
+                 {:entry fixture-entry :edits {:description "new description"}}
+
+                 :priority-only
+                 {:entry fixture-entry :edits {:priority "high"}}
+
+                 :all-three
+                 {:entry fixture-entry
+                  :edits {:title "t" :description "d" :priority "low"}}
+
+                 :blank-is-ignored
+                 {:entry fixture-entry :edits {:title "   " :description ""}}
+
+                 :nil-is-ignored
+                 {:entry fixture-entry :edits {:title nil :priority nil}}
+
+                 :no-op-same-values
+                 {:entry fixture-entry
+                  :edits {:title "original title" :priority "medium"}}
+
+                 :string-keyed-content
+                 {:entry {:id   "x"
+                          :tags ["kanban" "todo" "priority-low"]
+                          :content {"title" "from json" "priority" "low"}}
+                  :edits {:title "replaced"}}}
+   :gen         (gen/let [title (gen/one-of [(gen/return nil) gen/string-alphanumeric])
+                          desc  (gen/one-of [(gen/return nil) gen/string-alphanumeric])
+                          prio  (gen/elements [nil "high" "medium" "low"])]
+                  {:entry fixture-entry
+                   :edits {:title title :description desc :priority prio}})
+   :pred        (fn [r]
+                  (and (map? r)
+                       (set? (:changed r))
+                       (map? (:new-content r))
+                       ;; tags move if and only if the priority moved
+                       (= (contains? (:changed r) :priority)
+                          (some? (:new-tags r)))
+                       ;; a tag rewrite always leaves exactly one priority tag
+                       (or (nil? (:new-tags r))
+                           (= 1 (count (filter #(str/starts-with? (str %) "priority-")
+                                               (:new-tags r)))))
+                       ;; status is never touched by an edit
+                       (= "todo" (get (:new-content r) :status))))
+   :num-tests   100
+   :mutations   [["always-changed"
+                  (fn [_] {:changed #{:title :description :priority}
+                           :new-content {} :new-tags []})]
+                 ["never-changed"
+                  (fn [_] {:changed #{} :new-content {} :new-tags nil})]
+                 ["tags-without-priority"
+                  (fn [_] {:changed #{:title}
+                           :new-content {:status "todo"}
+                           :new-tags ["priority-medium"]})]
+                 ["drops-status"
+                  (fn [{:keys [edits]}]
+                    {:changed #{:title}
+                     :new-content (dissoc (:content fixture-entry) :status)
+                     :new-tags nil
+                     :new-title (:title edits)})]]})
+
+;; =============================================================================
+;; 2. edit-fx — effect-map invariants
+;; =============================================================================
+
+(defn- fx-for [edits]
+  (events/edit-fx
+   {:kanban/entry fixture-entry}
+   [:kanban/edit (merge {:task-id (:id fixture-entry)} edits)]))
+
+(deftest edit-emits-content-update
+  (let [fx (fx-for {:title "new title"})]
+    (is (some? fx) "fx map present for a valid edit")
+    (is (contains? fx :kanban/facade-update) "facade-update is the soft commit")
+    (is (= "new title" (get-in fx [:kanban/facade-update :payload :content :title])))
+    (is (= "original description"
+           (get-in fx [:kanban/facade-update :payload :content :description]))
+        "untouched fields survive the edit")
+    (is (= "todo" (get-in fx [:kanban/facade-update :payload :content :status]))
+        "status is not a content edit")))
+
+(deftest edit-carries-tags-only-when-priority-moves
+  (testing "a title edit leaves tags alone"
+    (let [fx (fx-for {:title "new title"})]
+      (is (not (contains? (get-in fx [:kanban/facade-update :payload]) :tags))
+          "no tag rewrite when the priority did not move")))
+  (testing "a priority edit rewrites the priority tag"
+    (let [fx   (fx-for {:priority "high"})
+          tags (get-in fx [:kanban/facade-update :payload :tags])]
+      (is (some? tags) "tags travel with a priority change")
+      (is (= ["priority-high"] (filter #(str/starts-with? % "priority-") tags))
+          "exactly one priority tag, and it is the new one")
+      (is (= "high" (get-in fx [:kanban/facade-update :payload :content :priority]))
+          "content and tag agree")
+      (is (every? (set tags) ["kanban" "todo" "scope:project:hive" "epic:adapter"])
+          "every non-priority tag survives"))))
+
+(deftest edit-never-emits-completion-hooks-or-delete
+  (let [fx (fx-for {:title "new title" :priority "high"})]
+    (is (not (contains? fx :kanban/notify-done)))
+    (is (not (contains? fx :kanban/archive-external)))
+    (is (not (contains? fx :kanban/track-movement))
+        "an edit is not a movement")
+    (is (not (contains? fx :facade/delete-entry)))
+    (is (not (contains? fx :kanban/facade-delete)))))
+
+(deftest edit-records-temporal-only-when-something-changed
+  (testing "a real change is audited"
+    (let [fx (fx-for {:title "new title"})]
+      (is (= :kanban-edit (get-in fx [:kanban/temporal-record :op])))
+      (is (= ["title"] (get-in fx [:kanban/temporal-record :data :changed])))
+      (is (= "original title" (get-in fx [:kanban/temporal-record :data :old-title])))
+      (is (= "new title" (get-in fx [:kanban/temporal-record :data :new-title])))
+      (is (= "hive" (get-in fx [:kanban/temporal-record :project-id])))))
+  (testing "a no-op edit still commits but leaves no audit noise"
+    (let [fx (fx-for {:title "original title"})]
+      (is (contains? fx :kanban/facade-update))
+      (is (not (contains? fx :kanban/temporal-record))))))
+
+(deftest edit-invalid-entry-yields-nil-fx
+  (is (nil? (events/edit-fx
+             {:kanban/entry nil}
+             [:kanban/edit {:task-id "missing" :title "x"}])))
+  (is (nil? (events/edit-fx
+             {:kanban/entry {:content {:task-type "memo"}}}
+             [:kanban/edit {:task-id "x" :title "y"}]))))
+
+;; =============================================================================
+;; 3. Properties
+;; =============================================================================
+
+(def gen-priority (gen/elements ["high" "medium" "low"]))
+
+(defspec edit-preserves-status-and-scope 200
+  (prop/for-all [title gen/string-alphanumeric
+                 prio  gen-priority]
+    (let [fx      (fx-for {:title title :priority prio})
+          content (get-in fx [:kanban/facade-update :payload :content])
+          tags    (or (get-in fx [:kanban/facade-update :payload :tags])
+                      (:tags fixture-entry))]
+      (and (= "todo" (:status content))
+           (contains? (set tags) "scope:project:hive")
+           (contains? (set tags) "todo")))))
+
+(defspec edit-priority-tag-matches-content 200
+  (prop/for-all [prio gen-priority]
+    (let [fx      (fx-for {:priority prio})
+          content (get-in fx [:kanban/facade-update :payload :content])
+          tags    (or (get-in fx [:kanban/facade-update :payload :tags])
+                      (:tags fixture-entry))]
+      (= (str "priority-" (:priority content))
+         (first (filter #(str/starts-with? % "priority-") tags))))))
+
+(defspec edit-blank-never-overwrites 200
+  (prop/for-all [pad (gen/vector (gen/elements [\space \tab]) 0 5)]
+    (let [fx      (fx-for {:title (apply str pad)})
+          content (get-in fx [:kanban/facade-update :payload :content])]
+      (= "original title" (:title content)))))
+
+(defspec edit-is-idempotent 100
+  (prop/for-all [title gen/string-alphanumeric
+                 prio  gen-priority]
+    (let [once  (kt/edit-transition fixture-entry {:title title :priority prio})
+          twice (kt/edit-transition (assoc fixture-entry
+                                           :content (:new-content once)
+                                           :tags    (or (:new-tags once)
+                                                        (:tags fixture-entry)))
+                                    {:title title :priority prio})]
+      (and (empty? (:changed twice))
+           (= (:new-content once) (:new-content twice))))))


### PR DESCRIPTION
`kanban update` could only move status. `move*` never read title, description or priority, and the event bus had no dispatcher other than `dispatch-move!` / `dispatch-retag!` — a missing feature, not a dropped parameter. Renaming a task meant recreating it and superseding the old id.

Built on the retag shape (narrow pure transition + one `:kanban/facade-update` + a `:kanban/temporal-record`):

- `kt/edit-transition` — pure derivation of `{:changed :new-content :new-tags}`
- `events/edit-fx` on `:kanban/edit`, cofx `:kanban/entry`
- `events/dispatch-edit!` — Result-wrapped boundary
- `memory-kanban/edit*` + `update*`, routing status → move, content → edit, both → move first then edit

## The invariant worth reviewing

Priority is stored **twice**: in the content map and as a `priority-*` tag. `kanban list :priority` filters the tag; `kanban get` reads content. An edit that moves one without the other makes a task answer differently depending on which command found it. So `edit-transition` returns `:new-tags` iff the priority changed, and `edit-fx` puts `:tags` in the payload only then.

Same shape as the existing retag lesson (`:project-id` must travel with the scope tag).

## Two smaller decisions

- A blank or nil field leaves the current value standing — a partial update can never blank a task by omission. Property-tested.
- `facade-update` is emitted even for a no-op edit (house invariant: it is ALWAYS present), but `temporal-record` is not, so a no-op leaves no audit noise.

## Coverage

`hive-mcp.tools.kanban.edit-trifecta-test` — golden + property + mutation on the pure transition, plus fx-invariant deftests. **91 tests / 232 assertions green** against this base, run in a dedicated JVM (not the live coordinator). clj-kondo: 0 errors.

The pre-existing `test-update-*` cases in `memory_kanban_test` only assert on an elisp string builder; they are labelled as such, since their green is what made this gap look covered.