### PR TITLE
ci(release): gate on the suite before deploying; explain the tag refusal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           cli: '1.12.5.1664'
 
+      # Gate BEFORE the deploy, as every other hive repo does: a published
+      # pom is immutable on Clojars, so a red suite must never be able to
+      # ship a version that cannot be withdrawn.
+      - name: Test
+        run: clojure -M:test-unit
+
       - name: Deploy
         env:
           CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
@@ -42,8 +48,17 @@ jobs:
           VER=$(tr -d '[:space:]' < VERSION)
           git fetch --tags
           if git rev-parse --verify "refs/tags/v$VER" >/dev/null 2>&1; then
-            test "$(git rev-list -n 1 "v$VER")" = "$GITHUB_SHA"
-          else
-            git tag "v$VER" "$GITHUB_SHA"
-            git push origin "refs/tags/v$VER"
+            TAGGED=$(git rev-list -n 1 "v$VER")
+            if [ "$TAGGED" = "$GITHUB_SHA" ]; then
+              echo "v$VER already points at this commit — nothing to do."
+              exit 0
+            fi
+            echo "::error::VERSION is still $VER, but v$VER points at $TAGGED,"
+            echo "::error::not at this commit. Source landed on main without a"
+            echo "::error::version bump, so Deploy was a no-op against an"
+            echo "::error::immutable coordinate and these changes are NOT"
+            echo "::error::published. Bump VERSION in a PR to release them."
+            exit 1
           fi
+          git tag "v$VER" "$GITHUB_SHA"
+          git push origin "refs/tags/v$VER"

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,11 @@ RUN clj -P -M:mcp:${ADDON_PROFILE}:build
 COPY src/ src/
 COPY resources/ resources/
 
-# Build the uberjar via tools.build (see build.clj).
+# BROKEN: there is no `uber` task. It was dropped from the local build.clj
+# in 3b1dc57 and hive-build.api never had one, so this line has been failing
+# since then — no workflow builds this image, which is why it went unseen.
+# hive-store keeps its own build.clj precisely to retain an `uber`; the fix
+# is to add one to hive-build and consume it here.
 # The profile alias is passed so addon deps are included in the classpath
 # during AOT compilation and bundled into the uber jar.
 RUN clj -T:build uber :profile ${ADDON_PROFILE}

--- a/deps.edn
+++ b/deps.edn
@@ -421,12 +421,16 @@
   :test-backends
   {:extra-paths ["test-backends"]}
 
-  ;; Build via hive-build: uberjar (server) + source jar /
-  ;; Clojars deploy. deps-deploy pushes the library jar; version autobumps.
-  ;; Usage: clj -T:build uber            ; runnable server uberjar
-  ;;        clj -T:build uber :profile k8s-headless
-  ;;        clj -T:build print-version   ; computed 0.{minor}.{patch}
-  ;;        clj -T:build deploy          ; jar -> Clojars (needs CLOJARS_* env)
+  ;; Build via hive-build (io.github.hive-agi/hive-build), the same release
+  ;; path every other hive library uses. Version = the repo's VERSION file;
+  ;; coordinates and :publish come from version.edn.
+  ;; Tasks: clean jar jar-aot install bump verify-license kondo deploy
+  ;; Usage: clj -T:build jar              ; source jar
+  ;;        clj -T:build jar-aot          ; AOT jar, metadata elided
+  ;;        clj -T:build bump :level :patch
+  ;;        clj -T:build deploy           ; jar -> Clojars (needs CLOJARS_* env)
+  ;; There is NO `uber` task here and never has been in this repo; the
+  ;; Dockerfile still calls one. See the note in Dockerfile.
   :build
   {:deps {io.github.hive-agi/hive-build {:mvn/version "0.1.0"}}
    :ns-default hive-build.api}


### PR DESCRIPTION
Follow-up to #141, aligning this repo's release automation with the rest of the fleet where it is safe to do so.

## What the fleet does that this repo did not

`hive-dsl` and the other 55 hive-build consumers run their suite **before** minting a version:

> Gate BEFORE the bump: a published pom is immutable, so a red suite must not be able to mint a version, tag it and ship it.

`release.yml` here went straight to `clojure -T:build deploy` with no gate. Now it runs the same `clojure -M:test-unit` that `ci.yml` uses, first.

## What this repo does differently, and keeps doing

The fleet pattern also **self-bumps** — `clojure -T:build bump :level :patch`, then commits and pushes the bump from CI. That is deliberately not adopted: this repo's default branch requires PRs and verified signatures, so release CI must never push an unsigned bump commit of its own. The version stays whatever the merged PR reviewed. That divergence is intentional and unchanged.

Worth noting the fleet's version of that step is `git push --follow-tags`, which is **not atomic** — a rejected branch push still leaves the tag behind and wedges every later run on "tag already exists". That is a live bug in the self-bumping repos (design-forge hit it and now uses `--atomic`); it does not affect this repo, which pushes only a tag.

## The tag step

Behaviour is unchanged; it stopped being unreadable. A bare

```sh
test "$(git rev-list -n 1 "v$VER")" = "$GITHUB_SHA"
```

failed with no output whenever source landed on main without a VERSION bump — a routine event. Deploy no-ops against the immutable coordinate, then the run goes red with nothing to read. It happened on `f26f61a` an hour ago and on `10ac83e` before that. It now explains that the changes are unpublished and that a VERSION bump in a PR is what releases them, and exits 0 when the tag already points at this commit.

If you would rather that case be green than red, say so — the signal "main has unreleased source changes" is real, so I kept it failing rather than decide the policy here.

## Two stale claims corrected

- The `:build` comment in `deps.edn` advertised `clj -T:build uber` and `print-version`. Neither has ever existed in this repo's build namespace. Replaced with the eight tasks `hive-build.api` actually exposes.
- `Dockerfile:64` calls `clj -T:build uber`, dropped from the local `build.clj` in `3b1dc57` and never present in `hive-build`. Marked as the known breakage it is. **Not fixed here** — the real fix is adding an `uber` task to `hive-build` (which `hive-store` also needs, and is why it still keeps a local `build.clj`), and that is a shared-library release, not a drive-by.

`CLOJARS_PASSWORD` is left mapped to the repo-level secret of that name rather than the fleet's `CLOJARS_DEPLOY_TOKEN`; this repo has its own `CLOJARS_USERNAME`/`CLOJARS_PASSWORD` set since 2026-07-16 and the 0.19.0 deploy used them successfully.