### PR TITLE
feat(tools): add `hot` root tool for IAddon hot-reload

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -59,8 +59,8 @@
         ;; logback-classic is the SLF4J implementation
         ;; logstash-encoder provides JSON output for Loki/ELK ingestion
         org.clojure/tools.logging {:mvn/version "1.3.1"}
-        ch.qos.logback/logback-classic {:mvn/version "1.5.18"}
-        net.logstash.logback/logstash-logback-encoder {:mvn/version "8.1"}
+        ch.qos.logback/logback-classic {:mvn/version "1.6.3"}
+        net.logstash.logback/logstash-logback-encoder {:mvn/version "9.0"}
         ;; Keep Timbre for gradual migration (existing code uses it)
         ;; It will log to its own backend, not SLF4J
         com.taoensso/timbre {:mvn/version "6.8.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps {org.clojure/clojure {:mvn/version "1.12.5"}
         org.clojure/data.json {:mvn/version "2.5.2"}
-        org.clojure/core.async {:mvn/version "1.7.701"}
+        org.clojure/core.async {:mvn/version "1.9.865"}
 
         ;; MCP SDK - BuddhiLW fork with async handler fix
         ;; Includes: graceful stdin EOF fix, dep upgrades, lsp4clj lint fix

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
-        org.clojure/data.json {:mvn/version "2.5.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.5"}
+        org.clojure/data.json {:mvn/version "2.5.2"}
         org.clojure/core.async {:mvn/version "1.7.701"}
 
         ;; MCP SDK - BuddhiLW fork with async handler fix
@@ -58,7 +58,7 @@
         ;; clojure.tools.logging provides the Clojure facade
         ;; logback-classic is the SLF4J implementation
         ;; logstash-encoder provides JSON output for Loki/ELK ingestion
-        org.clojure/tools.logging {:mvn/version "1.3.0"}
+        org.clojure/tools.logging {:mvn/version "1.3.1"}
         ch.qos.logback/logback-classic {:mvn/version "1.5.18"}
         net.logstash.logback/logstash-logback-encoder {:mvn/version "8.1"}
         ;; Keep Timbre for gradual migration (existing code uses it)
@@ -104,11 +104,11 @@
         io.prometheus/simpleclient_hotspot {:mvn/version "0.16.0"}
 
         ;; NATS client for push-based drone notifications
-        io.nats/jnats {:mvn/version "2.21.1"}
+        io.nats/jnats {:mvn/version "2.26.2"}
 
         ;; java-diff-utils for proper unified diff computation (hunks, context)
         ;; Used by drone diff protocol for token-efficient diff storage
-        io.github.java-diff-utils/java-diff-utils {:mvn/version "4.15"}
+        io.github.java-diff-utils/java-diff-utils {:mvn/version "4.17"}
 
         ;; Process execution - babashka.process for CLI wrappers
         ;; Used by overarch, scc, and other CLI tool integrations
@@ -356,7 +356,7 @@
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                 ;; Generative testing for spec validation
-                org.clojure/test.check {:mvn/version "1.1.1"}
+                org.clojure/test.check {:mvn/version "1.1.3"}
                 ;; Trifecta macro: golden + property + mutation facets
                 io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
                 ;; hive-schemas.test — a malli schema drives hive-test property +
@@ -385,7 +385,7 @@
   {:extra-paths ["test" "test/resources"]
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                org.clojure/test.check {:mvn/version "1.1.1"}
+                org.clojure/test.check {:mvn/version "1.1.3"}
                 io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
                 ;; Must match :test. The runner LOADS every test namespace before
                 ;; it filters by selector, so a test ns requiring hive-schemas.test
@@ -403,7 +403,7 @@
   {:extra-paths ["test" "test/resources"]
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                org.clojure/test.check {:mvn/version "1.1.1"}
+                org.clojure/test.check {:mvn/version "1.1.3"}
                 io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
                 ;; Same reason as :test-unit — this alias also puts test/ on the
                 ;; path, so it loads every test ns before selecting :integration.

--- a/deps.edn
+++ b/deps.edn
@@ -92,11 +92,11 @@
         ;; hive-events - re-frame inspired event system for JVM
         ;; v0.4.0 adds sub-FSM composition + multi-dispatch
         io.github.hive-agi/hive-events
-        {:mvn/version "0.5.6"}
+        {:mvn/version "0.5.7"}
 
         ;; hive-hot - unified hot-reload with events integration
         io.github.hive-agi/hive-hot
-        {:git/tag "v0.1.5" :git/sha "d82976b"}
+        {:git/tag "v0.1.6" :git/sha "3bd5f82"}
 
         ;; Prometheus metrics - iapetos wrapper; hotspot collector adds
         ;; JVM metrics (memory, GC, threads).
@@ -116,7 +116,7 @@
 
         ;; hive-dsl — Result monad, rescue/guard DSL, error taxonomy
         io.github.hive-agi/hive-dsl
-        {:mvn/version "0.5.15"}
+        {:mvn/version "0.5.16"}
 
         ;; hive-spi — pure SPI contract leaf (protocols + schemas + ADTs).
         ;; Required at compile time by core namespaces. Pinned to the published
@@ -137,7 +137,7 @@
         ;; hive-help — required directly by hive-mcp.embeddings.routing. It used
         ;; to arrive transitively through hive-milvus; once the backend left
         ;; :deps that route vanished, so the real dependency is declared here.
-        io.github.hive-agi/hive-help {:mvn/version "0.1.0"}
+        io.github.hive-agi/hive-help {:mvn/version "0.1.1"}
 
         ;; hive-addon — standalone IAddon contract (leaf lib) + plug/mount/compose.
         ;; hive-mcp.addons.protocol re-exports it via def-aliases so the ~30
@@ -147,27 +147,27 @@
 
         ;; hive-di — declarative typed config resolution (defconfig/env/literal)
         ;; Used by hive-mcp.embeddings.env-config and downstream addons.
-        io.github.hive-agi/hive-di {:mvn/version "0.4.3"}
+        io.github.hive-agi/hive-di {:mvn/version "0.4.4"}
 
         ;; hive-weave — Parallel utilities (bounded-pmap) used by project/tree.clj;
         ;; hive-weave.retry/with-recovery used by knowledge-graph/store/datahike.clj
         ;; (first released in 0.2.6 — 0.2.5 does not contain the retry ns).
-        io.github.hive-agi/hive-weave {:mvn/version "0.3.1"}
+        io.github.hive-agi/hive-weave {:mvn/version "0.3.2"}
 
         ;; hive-schemas — pinned at the TOP level, not only in :test/:test-unit.
         ;; Transitive callers can pull 0.1.6, which exists on Gitea only (404 on
         ;; Clojars and Central), so the default tree cannot resolve from a public
         ;; runner. :use-top makes this pin win everywhere.
-        io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}
+        io.github.hive-agi/hive-schemas {:mvn/version "0.1.15"}
 
         ;; hive-proximum — temporal/bitemporal memory backend (IMemoryStore via IAddon).
         ;; Auto-discovered via its hive-addons manifest. Stub store until the
         ;; backend impl lands.
-        io.github.hive-agi/hive-proximum {:mvn/version "0.1.12"}
+        io.github.hive-agi/hive-proximum {:mvn/version "0.1.13"}
 
         ;; hive-ttracking — telemetry/timing (timed-query, track*, bench*).
         ;; Consumed by catchup.clj and siblings (bundle/hydration/hierarchy).
-        io.github.hive-agi/hive-ttracking {:mvn/version "0.1.8"}
+        io.github.hive-agi/hive-ttracking {:mvn/version "0.1.9"}
 
         ;; hive-system — system-level abstractions (IProcess, INetwork,
         ;; process liveness, secrets, shell, redaction).
@@ -358,13 +358,13 @@
                 ;; Generative testing for spec validation
                 org.clojure/test.check {:mvn/version "1.1.3"}
                 ;; Trifecta macro: golden + property + mutation facets
-                io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
+                io.github.hive-agi/hive-test {:mvn/version "0.3.14"}
                 ;; hive-schemas.test — a malli schema drives hive-test property +
                 ;; mutation facets with no hand-written generator, oracle, or
                 ;; mutant. Must come from the JAR, not :local/root — the macros
                 ;; live in src/synth, which ships but is not on the project's
                 ;; :paths.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.15"}}
                 ;; hive-spi now lives in :deps (core nses require it) — no
                 ;; :test-alias override needed.
    ;; Backend drivers are NOT here — the default cold-CI test path is
@@ -386,13 +386,13 @@
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                 org.clojure/test.check {:mvn/version "1.1.3"}
-                io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
+                io.github.hive-agi/hive-test {:mvn/version "0.3.14"}
                 ;; Must match :test. The runner LOADS every test namespace before
                 ;; it filters by selector, so a test ns requiring hive-schemas.test
                 ;; aborts this whole alias — all 405 namespaces — if the dep is
                 ;; only declared on :test. This is the CI alias; it is the one that
                 ;; must not be able to fail at load.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.15"}}
    :jvm-opts ["-Dhive.kg.backend=datascript"]
    :main-opts ["-m" "cognitect.test-runner" "-e" ":integration"]
    :exec-fn cognitect.test-runner.api/test
@@ -404,10 +404,10 @@
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                 org.clojure/test.check {:mvn/version "1.1.3"}
-                io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
+                io.github.hive-agi/hive-test {:mvn/version "0.3.14"}
                 ;; Same reason as :test-unit — this alias also puts test/ on the
                 ;; path, so it loads every test ns before selecting :integration.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.15"}}
    :jvm-opts ["-Dhive.kg.backend=datascript"]
    :main-opts ["-m" "cognitect.test-runner" "-i" ":integration"]
    :exec-fn cognitect.test-runner.api/test
@@ -428,7 +428,7 @@
   ;;        clj -T:build print-version   ; computed 0.{minor}.{patch}
   ;;        clj -T:build deploy          ; jar -> Clojars (needs CLOJARS_* env)
   :build
-  {:deps {io.github.hive-agi/hive-build {:mvn/version "0.1.9"}}
+  {:deps {io.github.hive-agi/hive-build {:mvn/version "0.1.10"}}
    :ns-default hive-build.api}
 
   ;; Sibling :local/root overrides go in a gitignored local.deps.edn, merged

--- a/deps.edn
+++ b/deps.edn
@@ -116,7 +116,7 @@
 
         ;; hive-dsl — Result monad, rescue/guard DSL, error taxonomy
         io.github.hive-agi/hive-dsl
-        {:mvn/version "0.5.14"}
+        {:mvn/version "0.5.15"}
 
         ;; hive-spi — pure SPI contract leaf (protocols + schemas + ADTs).
         ;; Required at compile time by core namespaces. Pinned to the published
@@ -147,7 +147,7 @@
 
         ;; hive-di — declarative typed config resolution (defconfig/env/literal)
         ;; Used by hive-mcp.embeddings.env-config and downstream addons.
-        io.github.hive-agi/hive-di {:mvn/version "0.4.2"}
+        io.github.hive-agi/hive-di {:mvn/version "0.4.3"}
 
         ;; hive-weave — Parallel utilities (bounded-pmap) used by project/tree.clj;
         ;; hive-weave.retry/with-recovery used by knowledge-graph/store/datahike.clj
@@ -158,12 +158,12 @@
         ;; Transitive callers can pull 0.1.6, which exists on Gitea only (404 on
         ;; Clojars and Central), so the default tree cannot resolve from a public
         ;; runner. :use-top makes this pin win everywhere.
-        io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}
+        io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}
 
         ;; hive-proximum — temporal/bitemporal memory backend (IMemoryStore via IAddon).
         ;; Auto-discovered via its hive-addons manifest. Stub store until the
         ;; backend impl lands.
-        io.github.hive-agi/hive-proximum {:mvn/version "0.1.11"}
+        io.github.hive-agi/hive-proximum {:mvn/version "0.1.12"}
 
         ;; hive-ttracking — telemetry/timing (timed-query, track*, bench*).
         ;; Consumed by catchup.clj and siblings (bundle/hydration/hierarchy).
@@ -171,7 +171,7 @@
 
         ;; hive-system — system-level abstractions (IProcess, INetwork,
         ;; process liveness, secrets, shell, redaction).
-        io.github.hive-agi/hive-system {:mvn/version "0.3.4"}
+        io.github.hive-agi/hive-system {:mvn/version "0.3.5"}
 
         ;; Integrant — lifecycle framework for component-based systems
         ;; Replaces monolithic start! with declarative system map + profile merging
@@ -364,7 +364,7 @@
                 ;; mutant. Must come from the JAR, not :local/root — the macros
                 ;; live in src/synth, which ships but is not on the project's
                 ;; :paths.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}}
                 ;; hive-spi now lives in :deps (core nses require it) — no
                 ;; :test-alias override needed.
    ;; Backend drivers are NOT here — the default cold-CI test path is
@@ -392,7 +392,7 @@
                 ;; aborts this whole alias — all 405 namespaces — if the dep is
                 ;; only declared on :test. This is the CI alias; it is the one that
                 ;; must not be able to fail at load.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}}
    :jvm-opts ["-Dhive.kg.backend=datascript"]
    :main-opts ["-m" "cognitect.test-runner" "-e" ":integration"]
    :exec-fn cognitect.test-runner.api/test
@@ -407,7 +407,7 @@
                 io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
                 ;; Same reason as :test-unit — this alias also puts test/ on the
                 ;; path, so it loads every test ns before selecting :integration.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.14"}}
    :jvm-opts ["-Dhive.kg.backend=datascript"]
    :main-opts ["-m" "cognitect.test-runner" "-i" ":integration"]
    :exec-fn cognitect.test-runner.api/test
@@ -428,7 +428,7 @@
   ;;        clj -T:build print-version   ; computed 0.{minor}.{patch}
   ;;        clj -T:build deploy          ; jar -> Clojars (needs CLOJARS_* env)
   :build
-  {:deps {io.github.hive-agi/hive-build {:mvn/version "0.1.8"}}
+  {:deps {io.github.hive-agi/hive-build {:mvn/version "0.1.9"}}
    :ns-default hive-build.api}
 
   ;; Sibling :local/root overrides go in a gitignored local.deps.edn, merged

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
         nrepl/nrepl {:mvn/version "1.7.0"}
 
         ;; Aleph for robust async TCP/networking (replaces custom sockets)
-        aleph/aleph {:mvn/version "0.9.7"}
+        aleph/aleph {:mvn/version "0.9.10"}
         manifold/manifold {:mvn/version "0.5.0"}
 
         ;; Logic programming for swarm hivemind coordination
@@ -31,7 +31,7 @@
         clj-time/clj-time {:mvn/version "0.15.2"}
 
         ;; Datascript for in-memory graph storage (GraphStore backend)
-        datascript/datascript {:mvn/version "1.7.8"}
+        datascript/datascript {:mvn/version "1.8.1"}
         ;; me.tonsky namespace for datascript/datahike: provided by local 0.3.118 jar.
         ;; org.replikativ namespace for Datahike: provided by addon (0.4.119).
         ;; Different group IDs → both on classpath, non-overlapping namespaces.
@@ -46,13 +46,13 @@
 
         ;; sci pinned to latest ecosystem-wide. Requires overarch consumed as
         ;; source (hive-overarch), not its AOT uberjar which bundles older sci.
-        org.babashka/sci {:mvn/version "0.13.53"}
+        org.babashka/sci {:mvn/version "0.15.58"}
 
         ;; Proximum — pure-JVM HNSW vector index backing the vector-store slots.
         ;; SIMD via Java Vector API (needs --add-modules jdk.incubator.vector).
         ;; Late-bound via requiring-resolve so a missing jar surfaces as
         ;; :slot/factory-failed, not a JVM crash.
-        org.replikativ/proximum {:mvn/version "0.1.24"}
+        org.replikativ/proximum {:mvn/version "0.1.35"}
 
         ;; Logging - SLF4J with Logback backend
         ;; clojure.tools.logging provides the Clojure facade
@@ -86,7 +86,7 @@
 
         ;; clj-kondo for code analysis (call graphs, linting)
         ;; Exclude log4j-slf4j2-impl to avoid conflict with slf4j-timbre
-        clj-kondo/clj-kondo {:mvn/version "2026.01.19"
+        clj-kondo/clj-kondo {:mvn/version "2026.08.04"
                              :exclusions [org.apache.logging.log4j/log4j-slf4j2-impl]}
 
         ;; hive-events - re-frame inspired event system for JVM
@@ -100,7 +100,7 @@
 
         ;; Prometheus metrics - iapetos wrapper; hotspot collector adds
         ;; JVM metrics (memory, GC, threads).
-        clj-commons/iapetos {:mvn/version "0.1.14"}
+        clj-commons/iapetos {:mvn/version "0.1.15"}
         io.prometheus/simpleclient_hotspot {:mvn/version "0.16.0"}
 
         ;; NATS client for push-based drone notifications
@@ -116,14 +116,14 @@
 
         ;; hive-dsl — Result monad, rescue/guard DSL, error taxonomy
         io.github.hive-agi/hive-dsl
-        {:mvn/version "0.5.9"}
+        {:mvn/version "0.5.14"}
 
         ;; hive-spi — pure SPI contract leaf (protocols + schemas + ADTs).
         ;; Required at compile time by core namespaces. Pinned to the published
         ;; git tag (== master head) so CI and the Clojars jar build resolve it
         ;; without a sibling checkout; sibling co-dev goes through a gitignored
         ;; local.deps.edn :local/root override.
-        io.github.hive-agi/hive-spi {:mvn/version "0.1.17"}
+        io.github.hive-agi/hive-spi {:mvn/version "0.1.20"}
 
         ;; NO CONCRETE BACKEND BELONGS HERE. hive-milvus / hive-qdrant /
         ;; clj-qdrant depend on hive-mcp for their addon surface, so declaring
@@ -147,7 +147,7 @@
 
         ;; hive-di — declarative typed config resolution (defconfig/env/literal)
         ;; Used by hive-mcp.embeddings.env-config and downstream addons.
-        io.github.hive-agi/hive-di {:mvn/version "0.3.2"}
+        io.github.hive-agi/hive-di {:mvn/version "0.4.2"}
 
         ;; hive-weave — Parallel utilities (bounded-pmap) used by project/tree.clj;
         ;; hive-weave.retry/with-recovery used by knowledge-graph/store/datahike.clj
@@ -158,12 +158,12 @@
         ;; Transitive callers can pull 0.1.6, which exists on Gitea only (404 on
         ;; Clojars and Central), so the default tree cannot resolve from a public
         ;; runner. :use-top makes this pin win everywhere.
-        io.github.hive-agi/hive-schemas {:mvn/version "0.1.11"}
+        io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}
 
         ;; hive-proximum — temporal/bitemporal memory backend (IMemoryStore via IAddon).
         ;; Auto-discovered via its hive-addons manifest. Stub store until the
         ;; backend impl lands.
-        io.github.hive-agi/hive-proximum {:mvn/version "0.1.8"}
+        io.github.hive-agi/hive-proximum {:mvn/version "0.1.11"}
 
         ;; hive-ttracking — telemetry/timing (timed-query, track*, bench*).
         ;; Consumed by catchup.clj and siblings (bundle/hydration/hierarchy).
@@ -171,7 +171,7 @@
 
         ;; hive-system — system-level abstractions (IProcess, INetwork,
         ;; process liveness, secrets, shell, redaction).
-        io.github.hive-agi/hive-system {:mvn/version "0.2.11"}
+        io.github.hive-agi/hive-system {:mvn/version "0.3.4"}
 
         ;; Integrant — lifecycle framework for component-based systems
         ;; Replaces monolithic start! with declarative system map + profile merging
@@ -185,7 +185,7 @@
   {:exec-fn hive-mcp.server.core/start!
    :exec-args {}
    :extra-deps {nrepl/nrepl {:mvn/version "1.7.0"}
-                cider/cider-nrepl {:mvn/version "0.58.0"}}
+                cider/cider-nrepl {:mvn/version "0.62.2"}}
    ;; Heap cap, G1GC tuning, string dedup for prompt/response data,
    ;; bounded core.async pool, Netty access, aggressive GC return-to-OS
    :jvm-opts ["-Xmx8g"
@@ -224,14 +224,14 @@
   :dev
   {:extra-paths ["dev" "test"]
    :extra-deps {nrepl/nrepl {:mvn/version "1.7.0"}
-                cider/cider-nrepl {:mvn/version "0.58.0"}
-                refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}
+                cider/cider-nrepl {:mvn/version "0.62.2"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.14.0"}
                 ;; --- Heap/RAM diagnostics (clojure-goes-fast). Toggleable via
                 ;; hive-mcp.diag.heap; needs -Djdk.attach.allowAttachSelf=true
                 ;; (clj-memory-meter self-attach) + DebugNonSafepoints (profiler).
-                com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.4.0"}
+                com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.5.0"}
                 com.clojure-goes-fast/jvm-alloc-rate-meter {:mvn/version "0.1.4"}
-                com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.6.2"}}
+                com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.8.0"}}
    ;; Heap cap + G1GC tuning, string dedup, bounded core.async pool, Netty
    ;; access, Proximum HNSW SIMD. -Xmx6g hard cap; SoftMaxHeapSize=4g soft-caps
    ;; the peak; ratio flags + periodic GC return idle RSS to the OS.
@@ -285,14 +285,14 @@
   :nrepl
   {:extra-paths ["dev" "test"]
    :extra-deps {nrepl/nrepl {:mvn/version "1.7.0"}
-                cider/cider-nrepl {:mvn/version "0.58.0"}
-                refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}
+                cider/cider-nrepl {:mvn/version "0.62.2"}
+                refactor-nrepl/refactor-nrepl {:mvn/version "3.14.0"}
                 ;; --- Heap/RAM diagnostics (clojure-goes-fast). Toggleable via
                 ;; hive-mcp.diag.heap; needs -Djdk.attach.allowAttachSelf=true
                 ;; (clj-memory-meter self-attach) + DebugNonSafepoints (profiler).
-                com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.4.0"}
+                com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.5.0"}
                 com.clojure-goes-fast/jvm-alloc-rate-meter {:mvn/version "0.1.4"}
-                com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.6.2"}}
+                com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.8.0"}}
    ;; Heap cap + G1GC tuning, string dedup, bounded core.async pool, Netty
    ;; access, Proximum HNSW SIMD. -Xmx6g hard cap; SoftMaxHeapSize=4g soft-caps
    ;; the peak; ratio flags + periodic GC return idle RSS to the OS.
@@ -358,13 +358,13 @@
                 ;; Generative testing for spec validation
                 org.clojure/test.check {:mvn/version "1.1.1"}
                 ;; Trifecta macro: golden + property + mutation facets
-                io.github.hive-agi/hive-test {:mvn/version "0.3.11"}
+                io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
                 ;; hive-schemas.test — a malli schema drives hive-test property +
                 ;; mutation facets with no hand-written generator, oracle, or
                 ;; mutant. Must come from the JAR, not :local/root — the macros
                 ;; live in src/synth, which ships but is not on the project's
                 ;; :paths.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.11"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}}
                 ;; hive-spi now lives in :deps (core nses require it) — no
                 ;; :test-alias override needed.
    ;; Backend drivers are NOT here — the default cold-CI test path is
@@ -386,13 +386,13 @@
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                 org.clojure/test.check {:mvn/version "1.1.1"}
-                io.github.hive-agi/hive-test {:mvn/version "0.3.11"}
+                io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
                 ;; Must match :test. The runner LOADS every test namespace before
                 ;; it filters by selector, so a test ns requiring hive-schemas.test
                 ;; aborts this whole alias — all 405 namespaces — if the dep is
                 ;; only declared on :test. This is the CI alias; it is the one that
                 ;; must not be able to fail at load.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.11"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}}
    :jvm-opts ["-Dhive.kg.backend=datascript"]
    :main-opts ["-m" "cognitect.test-runner" "-e" ":integration"]
    :exec-fn cognitect.test-runner.api/test
@@ -404,10 +404,10 @@
    :extra-deps {io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                 org.clojure/test.check {:mvn/version "1.1.1"}
-                io.github.hive-agi/hive-test {:mvn/version "0.3.11"}
+                io.github.hive-agi/hive-test {:mvn/version "0.3.12"}
                 ;; Same reason as :test-unit — this alias also puts test/ on the
                 ;; path, so it loads every test ns before selecting :integration.
-                io.github.hive-agi/hive-schemas {:mvn/version "0.1.11"}}
+                io.github.hive-agi/hive-schemas {:mvn/version "0.1.13"}}
    :jvm-opts ["-Dhive.kg.backend=datascript"]
    :main-opts ["-m" "cognitect.test-runner" "-i" ":integration"]
    :exec-fn cognitect.test-runner.api/test
@@ -428,7 +428,7 @@
   ;;        clj -T:build print-version   ; computed 0.{minor}.{patch}
   ;;        clj -T:build deploy          ; jar -> Clojars (needs CLOJARS_* env)
   :build
-  {:deps {io.github.hive-agi/hive-build {:mvn/version "0.1.0"}}
+  {:deps {io.github.hive-agi/hive-build {:mvn/version "0.1.8"}}
    :ns-default hive-build.api}
 
   ;; Sibling :local/root overrides go in a gitignored local.deps.edn, merged

--- a/src/hive_mcp/extensions/mount_host.clj
+++ b/src/hive_mcp/extensions/mount_host.clj
@@ -10,22 +10,41 @@
    Seams are injectable (DIP) so the adapter is testable against a fake
    registry with no global state."
   (:require [hive-addon.mount.port :as port]
-            [hive-mcp.addons.core :as addon-core]))
+            [hive-mcp.addons.core :as addon-core]
+            [hive-addon.protocol :as proto]))
 
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 
 (defn addon-registry-host
   "Construct an IMountHost backed by the hive-mcp addon registry. opts may
    override the default addons.core seams (:reg-fn :init-fn :shutdown-fn
-   :registered-fn) for isolated tests."
+   :unreg-fn :registered-fn) for isolated tests.
+
+   register! has REPLACE semantics, which a remount depends on — see its body."
   ([] (addon-registry-host {}))
-  ([{:keys [reg-fn init-fn shutdown-fn registered-fn]
+  ([{:keys [reg-fn init-fn shutdown-fn unreg-fn registered-fn]
      :or {reg-fn        addon-core/register-addon!
           init-fn       addon-core/init-addon!
           shutdown-fn   addon-core/shutdown-addon!
+          unreg-fn      addon-core/unregister-addon!
           registered-fn (fn [id] (:addon (addon-core/get-addon-entry id)))}}]
    (reify port/IMountHost
-     (register! [this addon] (reg-fn addon) this)
+     (register! [this addon]
+       ;; addons.core/register-addon! REFUSES a duplicate id: it warns and returns
+       ;; {:success? false}, leaving the incumbent instance in place. This port
+       ;; returns the host either way, so that refusal is invisible to the caller
+       ;; — and a remount would then keep the STALE object and merely re-initialize
+       ;; it, while reporting success. Dropping the old entry first is what makes
+       ;; re-registration actually take.
+       ;;
+       ;; Safe during a remount: teardown! has already run shutdown-addon!, which
+       ;; moves the entry to :registered, so unregister-addon! sees a non-:active
+       ;; entry and will not shut the addon down a second time.
+       (let [id (proto/addon-id addon)]
+         (when (some? (registered-fn id))
+           (unreg-fn id))
+         (reg-fn addon))
+       this)
      (init! [_ addon-id config] (init-fn addon-id config))
      (shutdown! [_ addon-id] (shutdown-fn addon-id) nil)
      (registered [_ addon-id] (registered-fn addon-id)))))

--- a/src/hive_mcp/recall/canary.clj
+++ b/src/hive_mcp/recall/canary.clj
@@ -1,0 +1,239 @@
+(ns hive-mcp.recall.canary
+  "The golden recall canary: fault taxonomy + the fixture corpus it owns.
+
+   Pure. Every fn takes OBSERVATIONS and returns a fault map or nil; nothing
+   here reads a store, a config or a clock. `hive-mcp.recall.canary.live`
+   supplies the observations and runs the probes.
+
+   Fault contract. A fault fn NEVER throws and NEVER returns a bare boolean —
+   nil means healthy, a map names what broke and prints as the diagnosis.
+
+   Fixture contract. The canary owns its own anchor. Every fixture below is
+   discovered by tag, not by id, and is created on first run if absent, so no
+   probe can be silently disarmed by an entry someone deleted.
+
+   Verdict contract. A probe that could not run is `:skipped` with a reason and
+   is reported as such — never folded into the pass count."
+  (:require [clojure.set :as set]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; The fixtures the canary owns
+;; =============================================================================
+
+(def canary-tag
+  "Tag carried by every entry the canary owns. Discovery key, not an id."
+  "recall-canary")
+
+(def anchor-tag "recall-canary-anchor")
+(def superseded-tag "recall-canary-superseded")
+(def current-tag "recall-canary-current")
+
+(def anchor-query
+  "Rare literal tokens that co-occur in the anchor fixture and nowhere else."
+  "quokka vestibule 7731 recall canary anchor")
+
+(def supersession-query
+  "A query both supersession fixtures answer; only the current one may return."
+  "canary pelican index rebuild cadence")
+
+(def fixtures
+  "The corpus the canary writes once and re-reads forever.
+
+   :role is the handle the probes use; :tags is how the row is found again;
+   :supersedes names the role this row retracts (KG edge, written on create)."
+  [{:role     :anchor
+    :type     "note"
+    :tags     [canary-tag anchor-tag]
+    :content  (str "# Recall canary anchor (do not delete)\n\n"
+                   "quokka vestibule 7731 — three rare literal tokens that occur "
+                   "together in this entry and nowhere else in the corpus. The "
+                   "recall canary searches for them on every scheduler tick; if "
+                   "this row stops coming back, the lexical channel is dead and "
+                   "every semantic answer above it is unverified.")}
+   {:role     :superseded
+    :type     "note"
+    :tags     [canary-tag superseded-tag]
+    :content  (str "# Recall canary — the RETRACTED claim (do not delete)\n\n"
+                   "canary pelican index rebuild cadence: nightly. This row is "
+                   "superseded on purpose. A retrieval path that returns it has "
+                   "lost supersede-suppression, which means agents are being "
+                   "served a claim the corpus has already retracted.")}
+   {:role       :current
+    :type       "note"
+    :tags       [canary-tag current-tag]
+    :supersedes :superseded
+    :content    (str "# Recall canary — the CURRENT claim (do not delete)\n\n"
+                     "canary pelican index rebuild cadence: hourly. This row "
+                     "supersedes the retracted one; retrieval must return THIS "
+                     "and suppress that.")}])
+
+(defn fixture
+  "The fixture spec for `role`, or nil."
+  [role]
+  (first (filter #(= role (:role %)) fixtures)))
+
+(defn fixture-tags
+  "Discovery tags for `role`: [canary-tag role-tag]."
+  [role]
+  (:tags (fixture role)))
+
+;; =============================================================================
+;; The fault taxonomy
+;; =============================================================================
+
+(defn recall-fault
+  "Nil when recall is healthy; otherwise a fault map.
+
+   Takes {:label :populated? :results :must-contain}. `:populated? false`
+   yields nil — an empty store returning nothing is honest.
+
+   :recall/empty-from-populated-store — zero rows from a store known to hold
+   entries. :recall/anchor-missing — rows came back, but not the one that must
+   be there."
+  [{:keys [label populated? results must-contain]}]
+  (let [results (vec results)
+        got     (set (keep :id results))
+        want    (set must-contain)
+        missing (set/difference want got)]
+    (cond
+      (not populated?)
+      nil
+
+      (empty? results)
+      {:fault        :recall/empty-from-populated-store
+       :label        label
+       :diagnosis    (str "a populated store returned zero rows. This is a SYSTEM "
+                          "FAULT, not a query outcome — the query encoder, the "
+                          "index, or the ranking unit disagree.")
+       :expected-ids (vec want)}
+
+      (seq missing)
+      {:fault        :recall/anchor-missing
+       :label        label
+       :diagnosis    (str "the store returned " (count results) " confident rows "
+                          "but not the anchor. Indistinguishable from success at "
+                          "the call site — this is why the outage was silent.")
+       :missing-ids  (vec missing)
+       :returned-ids (mapv :id results)}
+
+      :else nil)))
+
+(defn rank-fault
+  "Nil when `results` are ordered nearest-first; otherwise a fault map.
+
+   Takes {:label :results}. The pipeline's contract is DISTANCE — lower is
+   nearer — end to end. Rows with no :distance are ignored: tag/KG enrichment
+   hits legitimately have none."
+  [{:keys [label results]}]
+  (let [ds (keep :distance results)]
+    (when (and (seq ds) (not (apply <= ds)))
+      {:fault     :recall/rank-inverted
+       :label     label
+       :diagnosis (str "results are not ordered nearest-first. Either the sort "
+                       "reversed, or a similarity (higher = better) is being "
+                       "carried in the :distance field (lower = better).")
+       :distances (vec ds)})))
+
+(defn dimension-fault
+  "Nil when every reading's emitted width equals its collection's width.
+
+   Takes {:label :readings}, readings a seq of {:collection :expected :actual}.
+   Readings with no :expected (width not derivable from the name) are ignored;
+   a nil :actual against a known :expected IS a mismatch — an unreadable width
+   is not a passing width."
+  [{:keys [label readings]}]
+  (let [known      (filter :expected readings)
+        mismatched (remove #(= (:expected %) (:actual %)) known)]
+    (cond
+      (empty? known)
+      {:fault     :recall/no-collections-configured
+       :label     label
+       :diagnosis (str "no collection reports a derivable width, so the invariant "
+                       "is vacuous. The embedding service did not come up.")}
+
+      (seq mismatched)
+      {:fault      :recall/dimension-mismatch
+       :label      label
+       :diagnosis  (str "a query embedded at one width and searched against an "
+                        "index of another returns confident neighbours from a "
+                        "space the query was never in.")
+       :mismatched (vec mismatched)}
+
+      :else nil)))
+
+(defn supersession-fault
+  "Nil when the retracted row stays out of `results`; otherwise a fault map.
+
+   Takes {:label :results :superseded-id :current-id}. Returning the superseded
+   row is the fault. A missing :current-id is reported separately so a dead
+   retrieval lane is not mistaken for working suppression."
+  [{:keys [label results superseded-id current-id]}]
+  (let [ids (set (keep :id results))]
+    (cond
+      (contains? ids superseded-id)
+      {:fault         :recall/superseded-returned
+       :label         label
+       :diagnosis     (str "a retrieval path returned an entry that a newer entry "
+                           "supersedes. Wrongness is not a ranking preference — "
+                           "suppression must happen at the exit of every path.")
+       :superseded-id superseded-id
+       :returned-ids  (vec ids)}
+
+      (and current-id (not (contains? ids current-id)))
+      {:fault       :recall/current-missing
+       :label       label
+       :diagnosis   (str "the superseding entry did not come back either, so the "
+                         "clean result proves nothing about suppression — the "
+                         "lane itself returned nothing relevant.")
+       :current-id  current-id
+       :returned-ids (vec ids)}
+
+      :else nil)))
+
+(defn presence-fault
+  "Nil when `count` is positive; otherwise a fault map.
+
+   Takes {:label :count :probe :diagnosis}. The shape for a probe whose only
+   contract is 'this index answers at all'."
+  [{:keys [label count probe diagnosis]}]
+  (when-not (and (number? count) (pos? count))
+    {:fault     :recall/probe-empty
+     :label     label
+     :probe     probe
+     :count     count
+     :diagnosis (or diagnosis
+                    (str "the probe returned nothing. An index that answers "
+                         "zero to its own smoke query is down, not empty."))}))
+
+;; =============================================================================
+;; The verdict
+;; =============================================================================
+
+(defn outcome
+  "One probe's outcome. `fault` nil = pass; `skip` reason = not run."
+  ([label fault] (outcome label fault nil))
+  ([label fault skip]
+   (cond
+     skip  {:label label :status :skipped :reason skip}
+     fault {:label label :status :fault :fault fault}
+     :else {:label label :status :ok})))
+
+(defn verdict
+  "Fold probe outcomes into a report.
+
+   {:ok? :ran :passed :faults :skipped}. `:ok?` is false the moment ANY probe
+   faults; skipped probes never make it true and never make it false — they are
+   counted so a canary that quietly stopped running is visible."
+  [outcomes]
+  (let [os      (vec outcomes)
+        faults  (filterv #(= :fault (:status %)) os)
+        skipped (filterv #(= :skipped (:status %)) os)
+        passed  (filterv #(= :ok (:status %)) os)]
+    {:ok?     (empty? faults)
+     :ran     (count os)
+     :passed  (count passed)
+     :faults  (mapv :fault faults)
+     :skipped (mapv #(select-keys % [:label :reason]) skipped)}))

--- a/src/hive_mcp/recall/canary/live.clj
+++ b/src/hive_mcp/recall/canary/live.clj
@@ -1,0 +1,266 @@
+(ns hive-mcp.recall.canary.live
+  "The runtime arm of the golden recall canary: fixtures, probes, one `run!`.
+
+   Boundary. Every observation is read through the SAME seam an agent uses —
+   `tools.memory.search/handle-search-semantic` for retrieval, the embedding
+   service for widths, the carto handlers for the code index — so a canary pass
+   means the caller-visible path works, not that some inner fn does.
+
+   Contract:
+   - `run!` never throws. It returns `hive-mcp.recall.canary/verdict`.
+   - A probe whose provider is absent is SKIPPED with a reason and is reported;
+     it never counts as a pass.
+   - A fault is logged at ERROR and dispatched as :recall/canary-failed when a
+     handler is registered (same opt-in shape as the grounding pass).
+   - Fixtures are created once, discovered by tag thereafter, and marked
+     permanent — the canary owns its anchor so no deletion can disarm it."
+  (:refer-clojure :exclude [run!])
+  (:require [clojure.data.json :as json]
+            [hive-mcp.dns.result :as result]
+            [hive-mcp.protocols.memory :as mem-proto]
+            [hive-mcp.recall.canary :as canary]
+            [taoensso.timbre :as log]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(def ^:private fixture-project "hive")
+
+;; =============================================================================
+;; Seams
+;; =============================================================================
+
+(defn- store
+  "The registered :default IMemoryStore, or nil."
+  []
+  (result/rescue nil (when (mem-proto/store-set?) (mem-proto/get-store))))
+
+(defn- resolve-fn
+  "`requiring-resolve` that answers nil for an ABSENT namespace.
+
+   Bare requiring-resolve throws FileNotFoundException when the namespace does
+   not exist at all, which is the normal state for an addon nobody loaded. A
+   throw there would be caught by `run!`'s outer rescue and reported as a
+   crashed canary — turning 'hive-carto is not installed' into 'retrieval is
+   broken'. A missing provider is a SKIP; only a present one can fault."
+  [sym]
+  (result/rescue nil (requiring-resolve sym)))
+
+(defn- populated?
+  "True when the store demonstrably holds entries. The premise every recall
+   assertion rests on — asserted, never assumed."
+  [st]
+  (result/rescue false (boolean (seq (mem-proto/query-entries st {:type "note" :limit 1})))))
+
+(defn- search
+  "Run `query` through the agent-visible semantic search seam.
+   Returns {:results [...]} or {:error msg}."
+  [query limit]
+  (if-let [f (resolve-fn 'hive-mcp.tools.memory.search/handle-search-semantic)]
+    (result/rescue
+     {:error "search threw"}
+     (let [resp (f {:query query :limit limit :scope "global"})]
+       (if (:isError resp)
+         {:error (str (:text resp))}
+         (json/read-str (:text resp) :key-fn keyword))))
+    {:error "hive-mcp.tools.memory.search/handle-search-semantic not available"}))
+
+(defn- carto-call
+  "Invoke a carto handler by symbol with `args`; nil when carto is not loaded."
+  [sym args]
+  (when-let [f (resolve-fn sym)]
+    (result/rescue nil
+                   (let [resp (f args)]
+                     (when-not (:isError resp)
+                       (json/read-str (:text resp) :key-fn keyword))))))
+
+(defn- emit-event!
+  "Dispatch `event` when a handler is registered. A missing event bus must never
+   break the pass, hence the rescue."
+  [event payload]
+  (result/rescue
+   nil
+   (let [registered? (resolve-fn 'hive-mcp.events.core/handler-registered?)
+         dispatch!   (resolve-fn 'hive-mcp.events.core/dispatch)]
+     (when (and registered? dispatch! (registered? event))
+       (dispatch! [event payload])))))
+
+;; =============================================================================
+;; Fixtures — created once, found by tag forever after
+;; =============================================================================
+
+(defn- find-fixture
+  [st role]
+  (result/rescue nil
+                 (first (mem-proto/query-entries st {:tags (canary/fixture-tags role)
+                                                     :limit 1}))))
+
+(defn- create-fixture!
+  [st role]
+  (let [{:keys [type content tags]} (canary/fixture role)]
+    (result/rescue nil
+                   (mem-proto/add-entry! st {:type type
+                                             :content content
+                                             :tags tags
+                                             :duration "permanent"
+                                             :abstraction-level 2
+                                             :project-id fixture-project}))))
+
+(defn- link-supersession!
+  "Write the :supersedes edge current -> superseded. Returns true on success."
+  [current-id superseded-id]
+  (boolean
+   (when-let [f (resolve-fn 'hive-mcp.knowledge-graph.edges.write/add-edge!)]
+     (result/rescue false
+                    (do (f {:from current-id :to superseded-id :relation :supersedes
+                            :created-by "recall-canary" :source-type :manual
+                            :scope fixture-project})
+                        true)))))
+
+(defn ensure-fixtures!
+  "Ids of the canary's own entries, creating any that are missing.
+
+   Returns {:anchor id :superseded id :current id :created [roles] :linked? bool}.
+   Ids may be nil when the store refused the write — probes read that as a skip,
+   never as a pass."
+  [st]
+  (let [existing (into {} (for [{:keys [role]} canary/fixtures]
+                            [role (:id (find-fixture st role))]))
+        created  (into {} (for [[role id] existing
+                                :when (nil? id)]
+                            [role (create-fixture! st role)]))
+        ids      (merge existing created)
+        linked?  (if (and (contains? created :current) (:current ids) (:superseded ids))
+                   (link-supersession! (:current ids) (:superseded ids))
+                   true)]
+    (assoc ids :created (vec (keys created)) :linked? linked?)))
+
+;; =============================================================================
+;; Probes
+;; =============================================================================
+
+(defn probe-dimension
+  "CASE 5 — the width the embedder emits must equal the width the index holds."
+  []
+  (let [dim-of (resolve-fn 'hive-mcp.embeddings.service/dimension-for-collection)
+        listed (resolve-fn 'hive-mcp.embeddings.service/list-configured-collections)
+        actual (resolve-fn 'hive-mcp.embeddings.service/get-dimension-for)]
+    (if (and dim-of listed actual)
+      (let [readings (result/rescue
+                      []
+                      (vec (for [c (keys (listed))]
+                             {:collection c
+                              :expected   (dim-of c)
+                              :actual     (result/rescue nil (actual c))})))]
+        (canary/outcome :dimension-invariant
+                        (canary/dimension-fault {:label :dimension-invariant
+                                                 :readings readings})))
+      (canary/outcome :dimension-invariant nil "embedding service not available"))))
+
+(defn probe-anchor
+  "CASE 1 — the anchor's rare tokens must retrieve the anchor, nearest first."
+  [st ids]
+  (cond
+    (nil? (:anchor ids))
+    (canary/outcome :lexical-anchor nil "anchor fixture absent and could not be written")
+
+    :else
+    (let [{:keys [results error]} (search canary/anchor-query 10)]
+      (if error
+        (canary/outcome :lexical-anchor {:fault :recall/search-errored
+                                         :label :lexical-anchor
+                                         :diagnosis error})
+        (canary/outcome :lexical-anchor
+                        (or (canary/recall-fault {:label        :lexical-anchor
+                                                  :populated?   (populated? st)
+                                                  :results      results
+                                                  :must-contain [(:anchor ids)]})
+                            (canary/rank-fault {:label   :lexical-anchor-ordering
+                                                :results results})))))))
+
+(defn probe-supersession
+  "CASE 2 — a retracted entry must not come back from any retrieval path."
+  [ids]
+  (cond
+    (not (and (:superseded ids) (:current ids)))
+    (canary/outcome :supersession nil "supersession fixtures absent")
+
+    (not (:linked? ids))
+    (canary/outcome :supersession nil "supersedes edge could not be written")
+
+    :else
+    (let [{:keys [results error]} (search canary/supersession-query 10)]
+      (if error
+        (canary/outcome :supersession {:fault :recall/search-errored
+                                       :label :supersession
+                                       :diagnosis error})
+        (canary/outcome :supersession
+                        (canary/supersession-fault {:label         :supersession
+                                                    :results       results
+                                                    :superseded-id (:superseded ids)
+                                                    :current-id    (:current ids)}))))))
+
+(defn probe-carto-tag
+  "CASE 3 — the code index answers its own match-all tag query."
+  [scope]
+  (if-let [body (carto-call 'hive-carto.cartography.handlers.kg-queries/handle-carto-search
+                            {:name-pattern "*" :limit 5 :scope scope})]
+    (canary/outcome :carto-tag
+                    (canary/presence-fault
+                     {:label :carto-tag
+                      :probe (str "carto_search name-pattern=* scope=" scope)
+                      :count (or (:count body) (count (:results body)))
+                      :diagnosis (str "the carto index returned zero forms for a "
+                                      "match-all pattern on a scanned scope — the "
+                                      "index is down or empty, and every carto "
+                                      "answer above it is vacuous.")}))
+    (canary/outcome :carto-tag nil "hive-carto not loaded")))
+
+(defn probe-carto-semantic
+  "CASE 4 — the carto vector lane answers a natural-language query."
+  [scope]
+  (if-let [body (carto-call 'hive-carto.cartography.handlers.semantic-grep/handle-semantic-grep
+                            {:query "run a decay cycle over memory and edges"
+                             :limit 5 :scope scope})]
+    (canary/outcome :carto-semantic
+                    (canary/presence-fault
+                     {:label :carto-semantic
+                      :probe (str "semantic-grep scope=" scope)
+                      :count (or (:count body) (count (:results body)))
+                      :diagnosis (str "the carto semantic lane returned nothing for "
+                                      "a query drawn from the corpus's own "
+                                      "docstrings — the vector side is dead.")}))
+    (canary/outcome :carto-semantic nil "hive-carto not loaded")))
+
+;; =============================================================================
+;; The pass
+;; =============================================================================
+
+(defn run!
+  "Run every canary probe once and return the verdict.
+
+   Opts: :scope (carto scope, default \"hive-mcp\"), :carto? (default true).
+   Never throws. Logs ERROR and dispatches :recall/canary-failed on any fault."
+  ([] (run! {}))
+  ([{:keys [scope carto?] :or {scope "hive-mcp" carto? true}}]
+   (result/rescue
+    {:ok? false :ran 0 :passed 0
+     :faults [{:fault :recall/canary-crashed
+               :diagnosis "the canary itself threw — treat as a fault, not a pass"}]
+     :skipped []}
+    (let [st  (store)
+          ids (when st (ensure-fixtures! st))
+          outs (cond-> [(probe-dimension)]
+                 st        (conj (probe-anchor st ids) (probe-supersession ids))
+                 (nil? st) (conj (canary/outcome :lexical-anchor nil "no :default IMemoryStore registered")
+                                 (canary/outcome :supersession nil "no :default IMemoryStore registered"))
+                 carto?    (conj (probe-carto-tag scope) (probe-carto-semantic scope)))
+          v (canary/verdict outs)
+          v (cond-> v (seq (:created ids)) (assoc :fixtures-created (:created ids)))]
+      (if (:ok? v)
+        (log/info "Recall canary OK:" (select-keys v [:ran :passed :skipped]))
+        (do (log/error "RECALL CANARY FAULT — retrieval is not trustworthy:" (:faults v))
+            (emit-event! :recall/canary-failed v)))
+      (when (seq (:skipped v))
+        (log/warn "Recall canary skipped probes:" (:skipped v)))
+      v))))

--- a/src/hive_mcp/scheduler/decay.clj
+++ b/src/hive_mcp/scheduler/decay.clj
@@ -84,13 +84,29 @@
     (emit-grounding-event! stats)
     stats))
 
+(defn- run-canary-pass!
+  "Read back what retrieval returns and report faults.
+
+   Read-only, and the only pass on the tick that can declare the system
+   UNTRUSTWORTHY rather than merely aged: it queries through the agent-visible
+   search seam and asserts the anchor comes back, ordered, unsuperseded.
+   A missing canary ns degrades to {:skipped true}, never to a silent pass."
+  [opts]
+  (resolve-and-call
+   'hive-mcp.recall.canary.live/run!
+   #(% opts)
+   {:ok? false
+    :faults [{:fault :recall/canary-crashed
+              :diagnosis "the canary pass threw; treat as untrusted retrieval"}]
+    :skipped []}))
+
 (defn run-decay-cycle!
-  "Run a complete decay cycle: memory + edges + discs + grounding."
+  "Run a complete decay cycle: memory + edges + discs + grounding + recall canary."
   ([] (run-decay-cycle! {}))
   ([{:keys [directory project-id memory-limit edge-limit disc-enabled
-            grounding-enabled grounding-limit]
+            grounding-enabled grounding-limit canary-enabled canary-scope]
      :or {memory-limit 50 edge-limit 100 disc-enabled true
-          grounding-enabled true grounding-limit 50}}]
+          grounding-enabled true grounding-limit 50 canary-enabled true}}]
    (let [start-ms (System/currentTimeMillis)
          cycle-num (-> (swap! scheduler-state update :cycle-count inc)
                        :cycle-count)
@@ -123,11 +139,17 @@
                                                  :limit grounding-limit})
                            {:skipped true :reason "grounding-disabled"})
 
+         ;; 5. Recall canary — the tick's only READ-BACK check
+         canary-stats (if canary-enabled
+                        (run-canary-pass! {:scope (or canary-scope resolved-project-id)})
+                        {:skipped true :reason "canary-disabled"})
+
          elapsed-ms (- (System/currentTimeMillis) start-ms)
          result {:memory-stats memory-stats
                  :edge-stats edge-stats
                  :disc-stats disc-stats
                  :grounding-stats grounding-stats
+                 :canary-stats canary-stats
                  :cycle-number cycle-num
                  :duration-ms elapsed-ms
                  :timestamp (java.time.Instant/now)}]
@@ -145,7 +167,9 @@
                 :edges-pruned (or (:pruned edge-stats) 0)
                 :discs-updated (or (:updated disc-stats) 0)
                 :grounding-processed (or (:processed grounding-stats) 0)
-                :grounding-persistence-lost (or (:persistence-lost grounding-stats) 0)})
+                :grounding-persistence-lost (or (:persistence-lost grounding-stats) 0)
+                :canary-ok? (:ok? canary-stats)
+                :canary-faults (count (:faults canary-stats))})
      result)))
 
 ;; =============================================================================

--- a/src/hive_mcp/server/init.clj
+++ b/src/hive_mcp/server/init.clj
@@ -488,6 +488,41 @@
                          (log/info "Decay scheduler started:" result)
                          (log/info "Decay scheduler not started:" (:reason result))))))))
 
+(defn run-recall-canary!
+  "Run the golden recall canary once, at boot, before agents ask anything.
+
+   Returns the verdict map (or nil when the canary ns is absent). Non-fatal by
+   construction: a faulting canary must not stop the server from starting, or
+   an operator loses the very tool that would tell them what is wrong. The
+   fault is on the boot log at ERROR and on the scheduler tick thereafter.
+
+   Configure via config.edn :services :recall-canary {:enabled true}."
+  []
+  (result/rescue
+   nil
+   (let [enabled? (not (false? (global-config/get-config-value [:services :recall-canary :enabled])))]
+     (if-not enabled?
+       (log/info "Recall canary disabled by config")
+       (when-let [run! (requiring-resolve 'hive-mcp.recall.canary.live/run!)]
+         (let [verdict (run!)]
+           (if (:ok? verdict)
+             (log/info "Recall canary OK at boot:" (select-keys verdict [:ran :passed :skipped]))
+             (log/error "RECALL CANARY FAULT AT BOOT — retrieval answers cannot be"
+                        "trusted until this clears:" (:faults verdict)))
+           verdict))))))
+
+(defn run-recall-canary-async!
+  "Run the boot canary on a daemon thread.
+
+   Off-thread because the canary talks to the embedder and the store, and a
+   slow provider must not lengthen boot; daemon because a canary must never
+   hold the JVM open. Loudness is unaffected — the verdict lands on the log
+   either way. Returns the Thread."
+  []
+  (doto (Thread. ^Runnable (fn [] (run-recall-canary!)) "recall-canary-boot")
+    (.setDaemon true)
+    (.start)))
+
 (defn stop-decay-scheduler!
   "Stop the periodic decay scheduler. Called during shutdown."
   []

--- a/src/hive_mcp/system/layer5.clj
+++ b/src/hive_mcp/system/layer5.clj
@@ -61,6 +61,11 @@
   (log/info ":hive/decay-scheduler init — starting decay scheduler" config)
   (result/rescue nil
     (init/start-decay-scheduler!))
+  ;; The recall canary's boot arm rides here because this key initializes after
+  ;; the memory addon has registered its store — the canary needs a store to
+  ;; read back from. Off-thread; a fault lands on the log at ERROR.
+  (result/rescue nil
+    (init/run-recall-canary-async!))
   {:status :running})
 
 (defmethod ig/halt-key! :hive/decay-scheduler

--- a/src/hive_mcp/tools/consolidated/hot.clj
+++ b/src/hive_mcp/tools/consolidated/hot.clj
@@ -1,0 +1,328 @@
+(ns hive-mcp.tools.consolidated.hot
+  "Consolidated `hot` tool — hot-reload of mounted IAddon instances.
+
+   `hive hot reload <addon-id>` rebuilds one addon from its mount manifest and
+   cascades to every addon that was handed its instance at mount time. The work
+   itself lives in hive-addon.hot; this namespace is only the MCP edge:
+   resolve which addons are actually mounted, drive the bridge, render a report.
+
+   hive-addon.hot is resolved SOFTLY. hive-mcp pins hive-addon by version, and
+   the bridge lands in a later release than the pin — a hard `:require` would
+   make this namespace fail to compile against the pinned jar. Until the pin is
+   bumped every command answers with an actionable :unavailable message instead
+   of breaking the tool surface.
+
+   Only addons that are CURRENTLY REGISTERED in the host are reloadable. The
+   classpath manifests are the superset; the composer's plug layers may have
+   deliberately dropped some of them, and remounting a dropped addon from its raw
+   manifest would resurrect something the system chose not to run.
+
+   hive-hot is the namespace-level engine. It MUST be initialized with the addon
+   source dirs this system actually derived (`:hot/dirs`) and with the protocol
+   interlock (`:no-reload`) — see `ensure-hot-init!` for why letting it
+   self-initialize is a bug, not a convenience."
+  (:require [hive-mcp.addons.core :as addon-core]
+            [hive-mcp.addons.manifest :as manifest]
+            [hive-mcp.tools.composite :as composite]
+            [hive-mcp.tools.core :refer [mcp-json mcp-error]]
+            [taoensso.timbre :as log]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Soft resolution of the bridge
+;; =============================================================================
+
+(defn- soft
+  "Resolve a var, or nil. Re-resolved per call so a pin bump takes effect without
+   restarting this namespace."
+  [sym]
+  (try (requiring-resolve sym) (catch Throwable _ nil)))
+
+(defn- bridge-available? []
+  (some? (soft 'hive-addon.hot/reload-addon!)))
+
+(def ^:private unavailable-msg
+  (str "hive-addon.hot is not on the classpath. The hot-reload bridge ships in "
+       "hive-addon >= 0.3.5; bump io.github.hive-agi/hive-addon in deps.edn "
+       "(or point local.deps.edn at ../hive-addon) and restart the server."))
+
+;; =============================================================================
+;; What is actually mounted
+;; =============================================================================
+
+(defn- mounted-ids
+  "Ids of addons currently in the host registry."
+  []
+  (into #{} (map :name) (addon-core/list-addons)))
+
+(defn effective-specs
+  "MountSpecs for the addons that are actually mounted right now.
+
+   Classpath discovery is the superset; intersecting it with the live registry is
+   what keeps a reload from resurrecting an addon the composer dropped."
+  []
+  (if-let [discover (soft 'hive-addon.mount/discover-specs)]
+    (let [live (mounted-ids)]
+      (into [] (filter #(contains? live (:addon/id %))) (:specs (discover))))
+    []))
+
+(defn- host []
+  (when-let [ctor (soft 'hive-mcp.extensions.mount-host/addon-registry-host)]
+    (ctor)))
+
+;; =============================================================================
+;; hive-hot initialization — the dirs matter
+;; =============================================================================
+
+(defn ensure-hot-init!
+  "Initialize hive-hot with THIS system's addon source dirs, once.
+
+   Without this, the first reload calls `hive-hot.core/reload!` on an
+   uninitialized clj-reload, which self-initializes with its default
+   `{:dirs [\"src\"]}` — resolved against the SERVER's working directory, not the
+   addon repos. clj-reload then watches the wrong tree: it can neither see the
+   addon sources that actually changed nor protect the protocol namespaces, and
+   every subsequent reload reports success while reloading nothing relevant.
+
+   The dirs come from `hive-addon.hot/plan`, which derives them from where each
+   addon's constructor namespace physically resolves — so only `:local/root`
+   addons contribute, which is exactly the set whose bytes can change.
+   `:no-reload` carries the protocol interlock.
+
+   Returns {:initialized? bool :dirs [...] :already? bool}. Never throws."
+  [plan]
+  (let [status (soft 'hive-hot.core/status)
+        init!  (soft 'hive-hot.core/init!)]
+    (cond
+      (nil? init!) {:initialized? false :dirs [] :reason :hive-hot-absent}
+
+      (:initialized? (status)) {:initialized? true :already? true
+                                :dirs (vec (:hot/dirs plan))}
+
+      :else
+      (try
+        (init! {:dirs (vec (:hot/dirs plan))
+                :no-reload (:hot/no-reload plan)})
+        (log/info "hive-hot initialized for addon hot-reload"
+                  {:dirs (count (:hot/dirs plan))})
+        {:initialized? true :already? false :dirs (vec (:hot/dirs plan))}
+        (catch Throwable t
+          (log/warn "hive-hot init failed" {:error (ex-message t)})
+          {:initialized? false :dirs [] :reason (ex-message t)})))))
+
+(defn- reload-opts
+  "Options handed to the bridge.
+
+   :resolve-config must match what the original mount used, or a remounted addon
+   silently receives raw manifest config instead of the config.edn-merged config
+   it was first initialized with."
+  []
+  {:resolve-config manifest/prepare-config})
+
+(defn- prepared
+  "Resolve specs + host + plan and make sure hive-hot is initialized correctly.
+   Returns {:specs :host :plan :hot-init} or {:error <mcp-error>}."
+  []
+  (let [specs (effective-specs)
+        h     (host)]
+    (cond
+      (empty? specs)
+      {:error (mcp-error "no mounted addons discovered — is the mount-compose loader enabled?")}
+
+      (nil? h)
+      {:error (mcp-error "mount-host adapter unavailable")}
+
+      :else
+      (let [plan ((soft 'hive-addon.hot/plan) h specs)]
+        {:specs specs :host h :plan plan :hot-init (ensure-hot-init! plan)}))))
+
+(defn- override-strategy
+  "Apply an explicit :addon/reload-strategy to the targeted spec."
+  [specs addon-id strategy]
+  (if-not strategy
+    specs
+    (mapv (fn [s]
+            (cond-> s
+              (= addon-id (:addon/id s))
+              (assoc :addon/reload-strategy (keyword strategy))))
+          specs)))
+
+(defn- summarize
+  "Trim a RemountReport to what is worth reading in a terminal."
+  [report]
+  (cond-> (select-keys report [:hot/strategy :hot/seeds :hot/affected
+                               :hot/torn-down :hot/cycles :hot/ns-reloaded :ok? :errors
+                               :teardown/data-preserved?])
+    (seq (:mounted report))
+    (assoc :mounted (mapv #(select-keys % [:addon/id :success? :phase :errors])
+                          (:mounted report)))))
+
+;; =============================================================================
+;; Handlers
+;; =============================================================================
+
+(defn handle-reload
+  "Reload one addon (or every addon built from one namespace) plus dependents."
+  [{:keys [addon namespace strategy]}]
+  (cond
+    (not (bridge-available?)) (mcp-error unavailable-msg)
+    (and (nil? addon) (nil? namespace))
+    (mcp-error "addon (or namespace) is required — e.g. {:command \"reload\" :addon \"hive.carto\"}")
+
+    :else
+    (let [{:keys [specs host hot-init error]} (prepared)]
+      (if error
+        error
+        (let [specs  (override-strategy specs addon strategy)
+              report (if namespace
+                       ((soft 'hive-addon.hot/reload-namespace!) host specs namespace (reload-opts))
+                       ((soft 'hive-addon.hot/reload-addon!) host specs addon (reload-opts)))]
+          (log/info "hot reload" {:addon addon :namespace namespace
+                                  :ok? (:ok? report)
+                                  :affected (:hot/affected report)})
+          (mcp-json (assoc (summarize report) :hive-hot hot-init)))))))
+
+(defn handle-reload-all
+  "Reload every mounted addon, in dependency order."
+  [_params]
+  (if-not (bridge-available?)
+    (mcp-error unavailable-msg)
+    (let [{:keys [specs host hot-init error]} (prepared)]
+      (if error
+        error
+        (mcp-json (assoc (summarize ((soft 'hive-addon.hot/reload-all!) host specs (reload-opts)))
+                         :hive-hot hot-init))))))
+
+(defn handle-list
+  "Per-addon hot-reload readiness: strategy, where its source lives, and whether
+   it can be reloaded at all. Effect-free apart from hive-hot init."
+  [_params]
+  (if-not (bridge-available?)
+    (mcp-error unavailable-msg)
+    (let [{:keys [plan error]} (prepared)]
+      (if error
+        error
+        (mcp-json
+         {:reloadable (mapv #(select-keys % [:addon/id :hot/strategy-id
+                                             :addon/init-ns :hot/source-kind])
+                            (:hot/registered plan))
+          :not-reloadable (mapv #(select-keys % [:addon/id :addon/init-ns
+                                                 :hot/source-kind])
+                                (:hot/skipped plan))
+          :watch-dirs (vec (:hot/dirs plan))
+          :never-reload (mapv str (:hot/no-reload plan))
+          :hive-hot-available? (:hot/available? plan)})))))
+
+(defn handle-watch
+  "Register every reloadable addon with hive-hot and START the file watcher, so
+   editing an addon's source remounts it automatically.
+
+   This is the standing-subscription form of `reload`: hive-hot's watcher and
+   debouncer detect the change, clj-reload brings the new namespaces in, and the
+   registered component callback remounts the affected addons."
+  [_params]
+  (if-not (bridge-available?)
+    (mcp-error unavailable-msg)
+    (let [{:keys [specs host plan error]} (prepared)]
+      (if error
+        error
+        (let [report ((soft 'hive-addon.hot/hot!) host specs (reload-opts))
+              watch! (soft 'hive-hot.core/init-with-watcher!)]
+          (if-not watch!
+            (mcp-error "hive-hot is not on the classpath — cannot start the watcher.")
+            (let [res (try
+                        (watch! {:dirs (vec (:hot/dirs plan))
+                                 :no-reload (:hot/no-reload plan)})
+                        (catch Throwable t {:error (ex-message t)}))]
+              (log/info "hot watch started" {:dirs (count (:hot/dirs plan))
+                                             :components (count (:hot/registered report))})
+              (mcp-json {:watching (if (map? res) res (str res))
+                         :dirs (vec (:hot/dirs plan))
+                         :registered (mapv :addon/id (:hot/registered report))
+                         :skipped (mapv :addon/id (:hot/skipped report))
+                         :never-reload (mapv str (:hot/no-reload plan))
+                         :ok? (:ok? report)
+                         :errors (:errors report)}))))))))
+
+(defn handle-unwatch
+  "Stop the hive-hot file watcher and deregister every addon component."
+  [_params]
+  (if-not (bridge-available?)
+    (mcp-error unavailable-msg)
+    (let [specs (effective-specs)
+          stop! (soft 'hive-hot.core/stop-watcher!)
+          un    ((soft 'hive-addon.hot/unhot!) specs)]
+      (mcp-json {:watcher (if stop! (str (stop!)) "hive-hot absent")
+                 :unregistered (:hot/unregistered un)}))))
+
+(defn handle-status
+  "hive-hot availability + watcher state, the installed strategy chain, and the
+   protocol interlock."
+  [_params]
+  (if-not (bridge-available?)
+    (mcp-error unavailable-msg)
+    (let [s ((soft 'hive-addon.hot/status))
+          watcher (soft 'hive-hot.core/watcher-status)]
+      (mcp-json (-> s
+                    (update :hot/no-reload #(mapv str %))
+                    (assoc :mounted-addon-count (count (effective-specs))
+                           :watcher (when watcher (watcher))))))))
+
+(defn handle-strategies
+  "The installed reload-strategy chain, in selection order."
+  [_params]
+  (if-not (bridge-available?)
+    (mcp-error unavailable-msg)
+    (let [chain ((soft 'hive-addon.hot/installed-strategies))
+          sid   (soft 'hive-addon.hot.strategy/-strategy-id)]
+      (mcp-json {:ids (mapv sid chain)
+                 :note (str "Selection order. A spec may name one explicitly via "
+                            ":addon/reload-strategy; modules add their own with "
+                            "hive-addon.hot/register-strategy!.")}))))
+
+;; =============================================================================
+;; Tool definition
+;; =============================================================================
+
+(def canonical-handlers
+  {:reload     handle-reload
+   :reload-all handle-reload-all
+   :watch      handle-watch
+   :unwatch    handle-unwatch
+   :list       handle-list
+   :status     handle-status
+   :strategies handle-strategies})
+
+(def handlers canonical-handlers)
+
+(def tool-def
+  {:name "hot"
+   :consolidated true
+   :description
+   (str "Hot-reload mounted IAddon instances via hive-hot. reload (rebuild one "
+        "addon from its mount manifest and cascade to every addon holding its "
+        "instance), reload-all (every mounted addon in dependency order), watch/"
+        "unwatch (file-watcher: edit an addon's source and it remounts itself), "
+        "list (per-addon strategy + source-kind + whether it is reloadable at "
+        "all), status, strategies. Only addons wired as :local/root deps have "
+        "reloadable source; jar-backed addons report :restart-required. "
+        "Use command='help' to list all.")
+   :inputSchema
+   {:type "object"
+    :properties
+    {"command" {:type "string"
+                :enum ["reload" "reload-all" "watch" "unwatch" "list" "status" "strategies" "help"]
+                :description "Hot-reload operation to perform"}
+     "addon" {:type "string"
+              :description "[reload] Addon id to reload, e.g. \"hive.carto\". Dependents cascade automatically."}
+     "namespace" {:type "string"
+                  :description "[reload] Constructor namespace to reload instead of an addon id — seeds every addon built from it."}
+     "strategy" {:type "string"
+                 :description "[reload] Override the reload strategy for this addon (e.g. \"remount\", \"in-place\", \"inert\"). Omit to let the chain select."}}
+    :required ["command"]}
+   :handler (composite/build-merged-handler "hot" canonical-handlers)})
+
+(def tools [tool-def])

--- a/src/hive_mcp/tools/registry.clj
+++ b/src/hive_mcp/tools/registry.clj
@@ -38,7 +38,8 @@
             [hive-mcp.extensions.registry :as ext]
             [clojure.string :as str]
             [taoensso.timbre :as log]
-            [hive-mcp.tools.consolidated.migrate-kanban :as c-migrate-kanban]))
+            [hive-mcp.tools.consolidated.migrate-kanban :as c-migrate-kanban]
+            [hive-mcp.tools.consolidated.hot :as c-hot]))
 
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
@@ -126,6 +127,7 @@
                                   c-web/tools
                                   c-events/tools
                                   c-multi/tools
+                                  c-hot/tools
                                   c-migrate-kanban/tools))
         domain-names   (into #{} (map :name) domain-roots)
         cfg-absorbed   (config-absorbed-names)

--- a/test/hive_mcp/recall/canary_live_test.clj
+++ b/test/hive_mcp/recall/canary_live_test.clj
@@ -1,0 +1,194 @@
+(ns hive-mcp.recall.canary-live-test
+  "The canary's RUNTIME arm, driven end to end against a writable store double.
+
+   Proves the three things the pure tests cannot: the fixtures are created once
+   and then re-found by tag, the probes read through the production search
+   handler, and an absent provider degrades to a visible skip instead of a
+   silent pass."
+  (:require [clojure.test :refer [deftest is testing]]
+            [hive-mcp.agent.context :as ctx]
+            [hive-mcp.chroma.search :as chroma-search]
+            [hive-mcp.knowledge-graph.edges :as kg-edges]
+            [hive-mcp.knowledge-graph.scope :as kg-scope]
+            [hive-mcp.protocols.memory :as mem-proto]
+            [hive-mcp.recall.canary.live :as cl]
+            [hive-mcp.recall.golden :as g]
+            [hive-mcp.tools.memory.scope :as scope]
+            [hive-mcp.tools.memory.search :as search]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; A store double that can actually be written to and tag-queried
+;; =============================================================================
+
+(defn- matches-tags?
+  [entry tags]
+  (let [have (set (:tags entry))]
+    (every? have tags)))
+
+(defrecord WritableStore [rows]
+  mem-proto/IMemoryStore
+  (connect!                  [_ _])
+  (disconnect!               [_])
+  (connected?                [_] true)
+  (health-check              [_] {:healthy? true})
+  (add-entry!                [_ entry]
+    (let [id (or (:id entry) (str "canary-" (count @rows)))]
+      (swap! rows conj (assoc entry :id id))
+      id))
+  (get-entry                 [_ id] (first (filter #(= id (:id %)) @rows)))
+  (update-entry!             [_ _ _])
+  (delete-entry!             [_ _])
+  (query-entries             [_ opts]
+    (let [{:keys [tags limit]} opts]
+      (->> @rows
+           (filter #(or (empty? tags) (matches-tags? % tags)))
+           (take (or limit 100))
+           vec)))
+  (search-similar            [_ q opts]
+    (let [qt (g/tokens q)]
+      (->> @rows
+           (map #(assoc % :similarity (g/cosine qt (g/tokens (:content %)))))
+           (filter #(pos? (:similarity %)))
+           (map #(assoc % :distance (max 0.0 (- 1.0 (:similarity %)))))
+           (sort-by :distance <)
+           (take (or (:limit opts) 10))
+           vec)))
+  (supports-semantic-search? [_] true)
+  (cleanup-expired!          [_])
+  (entries-expiring-soon     [_ _ _])
+  (find-duplicate            [_ _ _ _])
+  (store-status              [_] {:ok true :count (count @rows)})
+  (reset-store!              [_] (reset! rows [])))
+
+(defn- ->writable-store [] (->WritableStore (atom [])))
+
+(defn- run-with-stubs [f]
+  (with-redefs [kg-edges/record-co-access!           (constantly nil)
+                kg-scope/visible-scopes              (constantly ["hive"])
+                kg-scope/descendant-scopes           (constantly [])
+                scope/get-current-project-id         (constantly "hive")
+                ctx/current-directory                (constantly "/tmp/recall")
+                chroma-search/resolve-ingest-search  (constantly nil)]
+    (f)))
+
+(defmacro ^:private with-stubs [& body] `(run-with-stubs (fn [] ~@body)))
+
+;; =============================================================================
+;; Fixture lifecycle — the canary owns its anchor
+;; =============================================================================
+
+(deftest fixtures-are-created-once-and-then-found-by-tag
+  (testing "first pass writes the corpus it needs; the second finds it again and
+            writes nothing — otherwise every tick would litter the store"
+    (let [store (->writable-store)]
+      (with-stubs
+        (g/with-store store
+          (let [first-pass  (cl/ensure-fixtures! store)
+                second-pass (cl/ensure-fixtures! store)]
+            (is (= #{:anchor :superseded :current} (set (:created first-pass))))
+            (is (empty? (:created second-pass))
+                "the second pass re-created fixtures — discovery by tag is broken")
+            (is (= (select-keys first-pass [:anchor :superseded :current])
+                   (select-keys second-pass [:anchor :superseded :current]))
+                "the ids moved between passes")
+            (is (every? some? (vals (select-keys first-pass [:anchor :superseded :current])))))))))) 
+
+(deftest a-deleted-fixture-is-rewritten-not-mourned
+  (testing "the failure that disarmed the old canary: someone deletes the
+            anchor. The canary must re-create it, not fail forever."
+    (let [store (->writable-store)]
+      (with-stubs
+        (g/with-store store
+          (cl/ensure-fixtures! store)
+          (reset! (:rows store) [])
+          (let [again (cl/ensure-fixtures! store)]
+            (is (= #{:anchor :superseded :current} (set (:created again))))))))))
+
+;; =============================================================================
+;; The pass, end to end
+;; =============================================================================
+
+(deftest the-anchor-round-trips-through-the-production-handler
+  (testing "fixtures written, anchor retrieved through the real search handler,
+            ordering intact"
+    (let [store (->writable-store)]
+      (with-stubs
+        (g/with-store store
+          (let [v (cl/run! {:carto? false})
+                faults (set (map :fault (:faults v)))]
+            (is (not (contains? faults :recall/anchor-missing))
+                (str "the anchor did not come back: " (:faults v)))
+            (is (not (contains? faults :recall/empty-from-populated-store))
+                (str "a populated store returned nothing: " (:faults v)))
+            (is (not (contains? faults :recall/rank-inverted)))))))))
+
+(deftest suppression-is-NOT-a-property-of-the-store
+  (testing "a bare IMemoryStore has no supersede-suppression — that lives ABOVE
+            it, at the exit of the retrieval path. Driving the canary against a
+            raw store double must therefore FIRE :recall/superseded-returned.
+
+            This is the probe's own wiring proof: it reads the real retrieval
+            path, so whatever that path does or fails to do shows up here."
+    (let [store (->writable-store)]
+      (with-stubs
+        (g/with-store store
+          (let [v (cl/run! {:carto? false})
+                faults (set (map :fault (:faults v)))]
+            (is (contains? faults :recall/superseded-returned)
+                (str "the retracted fixture was suppressed by a store that has "
+                     "no suppression — the probe is not reading the real path: "
+                     (:faults v)))))))))
+
+(deftest an-absent-store-skips-loudly-and-never-passes
+  (testing "no store registered: the retrieval probes must report as SKIPPED
+            with a reason, and must not be counted as passing"
+    (with-redefs [mem-proto/store-set? (constantly false)]
+      (let [v (cl/run! {:carto? false})
+            labels (set (map :label (:skipped v)))]
+        (is (contains? labels :lexical-anchor))
+        (is (contains? labels :supersession))
+        (is (every? #(seq (:reason %)) (:skipped v))
+            "a skip without a reason is indistinguishable from a pass")))))
+
+(deftest carto-probes-skip-when-carto-is-absent
+  (testing "hive-carto is an addon; its probes must degrade to a named skip"
+    (let [out (cl/probe-carto-tag "hive-mcp")]
+      (is (contains? #{:ok :skipped :fault} (:status out)))
+      (when (= :skipped (:status out))
+        (is (= "hive-carto not loaded" (:reason out)))))))
+
+;; =============================================================================
+;; The deliberate break — a canary that cannot fail proves nothing
+;; =============================================================================
+
+(deftest the-canary-fires-when-retrieval-goes-blind
+  (testing "a store that answers every query with nothing must produce a fault,
+            not a green tick"
+    (let [store (->writable-store)]
+      (with-stubs
+        (g/with-store store
+          (cl/ensure-fixtures! store)
+          (with-redefs [search/handle-search-semantic
+                        (constantly {:type "text" :text "{\"results\":[]}"})]
+            (let [v (cl/run! {:carto? false})
+                  faults (set (map :fault (:faults v)))]
+              (is (false? (:ok? v)) "blind retrieval reported OK")
+              (is (contains? faults :recall/empty-from-populated-store)
+                  (str "expected the outage's own fault shape, got " faults)))))))))
+
+(deftest the-canary-fires-when-a-retracted-row-comes-back
+  (testing "suppression regression: the superseded fixture is served again"
+    (let [store (->writable-store)]
+      (with-stubs
+        (g/with-store store
+          (let [ids (cl/ensure-fixtures! store)
+                payload (str "{\"results\":[{\"id\":\"" (:current ids) "\"},"
+                             "{\"id\":\"" (:superseded ids) "\"}]}")]
+            (with-redefs [search/handle-search-semantic
+                          (constantly {:type "text" :text payload})]
+              (let [out (cl/probe-supersession (assoc ids :linked? true))]
+                (is (= :fault (:status out)))
+                (is (= :recall/superseded-returned (get-in out [:fault :fault])))))))))))

--- a/test/hive_mcp/recall/canary_test.clj
+++ b/test/hive_mcp/recall/canary_test.clj
@@ -1,0 +1,184 @@
+(ns hive-mcp.recall.canary-test
+  "The canary's own tests. Every fault predicate is proven BOTH ways: it must
+   stay silent on a healthy observation and it must fire on the broken one.
+   A canary that cannot be made to fail proves nothing."
+  (:require [clojure.test :refer [deftest is testing]]
+            [hive-mcp.recall.canary :as canary]))
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; =============================================================================
+;; Fixtures — the canary owns its anchor, and must keep owning it
+;; =============================================================================
+
+(deftest every-fixture-is-discoverable-by-tag
+  (testing "each fixture carries the shared canary tag plus a role tag, so it is
+            re-found by TAG and never by an id someone else can delete"
+    (doseq [{:keys [role tags]} canary/fixtures]
+      (is (some #{canary/canary-tag} tags)
+          (str role " is missing the shared canary tag"))
+      (is (= 2 (count tags))
+          (str role " must carry exactly [canary-tag role-tag]"))
+      (is (= tags (canary/fixture-tags role))))))
+
+(deftest fixture-roles-are-unique-and-complete
+  (testing "the three roles the probes address all exist, exactly once"
+    (let [roles (mapv :role canary/fixtures)]
+      (is (= (count roles) (count (set roles))))
+      (is (= #{:anchor :superseded :current} (set roles))))))
+
+(deftest the-anchor-query-tokens-live-in-the-anchor
+  (testing "the query the canary fires must actually be answerable by the entry
+            it writes — otherwise the probe fails forever for the wrong reason"
+    (let [content (:content (canary/fixture :anchor))]
+      (doseq [tok ["quokka" "vestibule" "7731"]]
+        (is (re-find (re-pattern tok) content)
+            (str "anchor content does not contain the rare token " tok))))))
+
+(deftest the-supersession-pair-answers-one-query
+  (testing "both supersession fixtures must be plausible answers to the same
+            query, or suppression is never exercised"
+    (doseq [role [:superseded :current]]
+      (is (re-find #"pelican index rebuild" (:content (canary/fixture role)))
+          (str role " does not answer the supersession query")))))
+
+;; =============================================================================
+;; recall-fault
+;; =============================================================================
+
+(deftest recall-fault-is-silent-when-the-anchor-comes-back
+  (is (nil? (canary/recall-fault {:label :t :populated? true
+                                  :results [{:id "a"} {:id "b"}]
+                                  :must-contain ["a"]}))))
+
+(deftest an-empty-store-returning-nothing-is-honest
+  (testing "a canary that cries wolf on an empty store gets ignored"
+    (is (nil? (canary/recall-fault {:label :t :populated? false
+                                    :results [] :must-contain ["a"]})))))
+
+(deftest zero-rows-from-a-populated-store-is-a-system-fault
+  (let [f (canary/recall-fault {:label :t :populated? true
+                                :results [] :must-contain ["a"]})]
+    (is (= :recall/empty-from-populated-store (:fault f)))
+    (is (= ["a"] (:expected-ids f)))))
+
+(deftest confident-rows-without-the-anchor-are-the-dangerous-shape
+  (let [f (canary/recall-fault {:label :t :populated? true
+                                :results [{:id "x"} {:id "y"}]
+                                :must-contain ["a"]})]
+    (is (= :recall/anchor-missing (:fault f)))
+    (is (= ["a"] (:missing-ids f)))
+    (is (= ["x" "y"] (:returned-ids f)))))
+
+;; =============================================================================
+;; rank-fault
+;; =============================================================================
+
+(deftest ascending-distances-pass
+  (is (nil? (canary/rank-fault {:label :t :results [{:distance 0.1} {:distance 0.2}]}))))
+
+(deftest descending-distances-are-an-inverted-rank
+  (let [f (canary/rank-fault {:label :t :results [{:distance 0.9} {:distance 0.2}]})]
+    (is (= :recall/rank-inverted (:fault f)))
+    (is (= [0.9 0.2] (:distances f)))))
+
+(deftest rows-without-a-distance-are-ignored
+  (testing "tag and KG enrichment hits legitimately carry no distance"
+    (is (nil? (canary/rank-fault {:label :t :results [{:id "a"} {:id "b"}]})))))
+
+;; =============================================================================
+;; dimension-fault
+;; =============================================================================
+
+(deftest matching-widths-pass
+  (is (nil? (canary/dimension-fault
+             {:label :t :readings [{:collection "c" :expected 2560 :actual 2560}]}))))
+
+(deftest a-width-mismatch-fires
+  (let [f (canary/dimension-fault
+           {:label :t :readings [{:collection "c" :expected 2560 :actual 768}]})]
+    (is (= :recall/dimension-mismatch (:fault f)))
+    (is (= 1 (count (:mismatched f))))))
+
+(deftest an-unreadable-width-is-not-a-passing-width
+  (testing "nil actual against a known expected must FAIL, not skip — this is
+            exactly the shape that made the 2026-07-12 drift invisible"
+    (is (= :recall/dimension-mismatch
+           (:fault (canary/dimension-fault
+                    {:label :t :readings [{:collection "c" :expected 2560 :actual nil}]}))))))
+
+(deftest no-derivable-collection-is-vacuous-not-green
+  (let [f (canary/dimension-fault {:label :t :readings [{:collection "c"}]})]
+    (is (= :recall/no-collections-configured (:fault f)))))
+
+;; =============================================================================
+;; supersession-fault
+;; =============================================================================
+
+(deftest the-current-row-alone-passes
+  (is (nil? (canary/supersession-fault {:label :t
+                                        :results [{:id "new"}]
+                                        :superseded-id "old"
+                                        :current-id "new"}))))
+
+(deftest returning-the-retracted-row-fires
+  (let [f (canary/supersession-fault {:label :t
+                                      :results [{:id "new"} {:id "old"}]
+                                      :superseded-id "old"
+                                      :current-id "new"})]
+    (is (= :recall/superseded-returned (:fault f)))
+    (is (= "old" (:superseded-id f)))))
+
+(deftest a-dead-lane-is-not-working-suppression
+  (testing "neither row came back: clean, but it proves nothing about
+            suppression, so it must be reported as its own fault"
+    (let [f (canary/supersession-fault {:label :t
+                                        :results [{:id "unrelated"}]
+                                        :superseded-id "old"
+                                        :current-id "new"})]
+      (is (= :recall/current-missing (:fault f))))))
+
+;; =============================================================================
+;; presence-fault
+;; =============================================================================
+
+(deftest a-positive-count-passes
+  (is (nil? (canary/presence-fault {:label :t :count 5 :probe "p"}))))
+
+(deftest zero-and-nil-counts-fire
+  (is (= :recall/probe-empty (:fault (canary/presence-fault {:label :t :count 0 :probe "p"}))))
+  (is (= :recall/probe-empty (:fault (canary/presence-fault {:label :t :count nil :probe "p"})))))
+
+;; =============================================================================
+;; verdict — the part that decides whether the tick is green
+;; =============================================================================
+
+(deftest all-passing-is-ok
+  (let [v (canary/verdict [(canary/outcome :a nil) (canary/outcome :b nil)])]
+    (is (:ok? v))
+    (is (= 2 (:passed v)))
+    (is (empty? (:faults v)))))
+
+(deftest one-fault-fails-the-whole-verdict
+  (let [v (canary/verdict [(canary/outcome :a nil)
+                           (canary/outcome :b {:fault :recall/anchor-missing})])]
+    (is (false? (:ok? v)))
+    (is (= 1 (count (:faults v))))))
+
+(deftest a-skipped-probe-never-counts-as-a-pass
+  (testing "the whole point: a probe that did not run must be visible, not
+            folded into the green count"
+    (let [v (canary/verdict [(canary/outcome :a nil)
+                             (canary/outcome :b nil "hive-carto not loaded")])]
+      (is (:ok? v))
+      (is (= 1 (:passed v)) "the skipped probe was counted as passing")
+      (is (= [{:label :b :reason "hive-carto not loaded"}] (:skipped v))))))
+
+(deftest an-all-skipped-run-reports-zero-passes
+  (testing "a canary that silently stopped running looks identical to a healthy
+            one unless the skips are surfaced"
+    (let [v (canary/verdict [(canary/outcome :a nil "no store")
+                             (canary/outcome :b nil "no store")])]
+      (is (zero? (:passed v)))
+      (is (= 2 (count (:skipped v)))))))

--- a/test/hive_mcp/recall/golden.clj
+++ b/test/hive_mcp/recall/golden.clj
@@ -45,7 +45,8 @@
    nothing. `:similarity` MUST make the suite go red."
   (:require [clojure.set :as set]
             [clojure.string :as str]
-            [hive-mcp.protocols.memory :as mem-proto]))
+            [hive-mcp.protocols.memory :as mem-proto]
+            [hive-mcp.recall.canary :as canary]))
 
 ;; =============================================================================
 ;; The corpus
@@ -128,75 +129,17 @@
 ;; The fault taxonomy — the thing that was missing
 ;; =============================================================================
 
-(defn recall-fault
-  "Nil when recall is healthy; otherwise a FAULT MAP naming what broke.
+(def recall-fault
+  "Alias of `hive-mcp.recall.canary/recall-fault`.
 
-   Never throws, and never returns a bare boolean — a failing `is` must print
-   the diagnosis, not `false`.
+   The taxonomy moved to src so the RUNTIME canary and this suite cannot drift
+   into two definitions of the same fault. Historical
+   `hive-mcp.recall.golden/recall-fault` call sites keep resolving here."
+  canary/recall-fault)
 
-   Arguments (map):
-     :label        — human name of the case, echoed into the fault
-     :populated?   — was the store known to hold entries at query time?
-     :results      — what the pipeline returned (seq of maps with :id)
-     :must-contain — ids that MUST be present (the anchors)
-
-   Faults:
-     :recall/empty-from-populated-store
-         Zero rows out of a store we KNOW is populated. This is the shape the
-         2026-07-12 outage wore. It is never a legitimate answer to a query
-         whose anchor is in the corpus.
-
-     :recall/anchor-missing
-         Rows came back, but not the one that must be there. This is the
-         'confident and wrong' shape — the dangerous one, because a caller
-         cannot tell it from success.
-
-   `:populated? false` yields nil: an empty store returning nothing is honest."
-  [{:keys [label populated? results must-contain]}]
-  (let [results (vec results)
-        got     (set (keep :id results))
-        want    (set must-contain)
-        missing (set/difference want got)]
-    (cond
-      (not populated?)
-      nil
-
-      (empty? results)
-      {:fault        :recall/empty-from-populated-store
-       :label        label
-       :diagnosis    (str "a populated store returned zero rows. This is a SYSTEM "
-                          "FAULT, not a query outcome — the query encoder, the "
-                          "index, or the ranking unit disagree.")
-       :expected-ids (vec want)}
-
-      (seq missing)
-      {:fault        :recall/anchor-missing
-       :label        label
-       :diagnosis    (str "the store returned " (count results) " confident rows "
-                          "but not the anchor. Indistinguishable from success at "
-                          "the call site — this is why the outage was silent.")
-       :missing-ids  (vec missing)
-       :returned-ids (mapv :id results)}
-
-      :else nil)))
-
-(defn rank-fault
-  "Nil when `results` are ordered nearest-first; otherwise a fault map.
-
-   The pipeline's contract is DISTANCE — lower is nearer — end to end. A run
-   whose distances ascend is either sorted backwards or is carrying a
-   similarity in a field the whole pipeline reads as a distance
-   (MEM-P0-EMBED-LANE). Rows with no :distance are ignored: tag/KG enrichment
-   hits legitimately have none."
-  [{:keys [label results]}]
-  (let [ds (keep :distance results)]
-    (when (and (seq ds) (not (apply <= ds)))
-      {:fault     :recall/rank-inverted
-       :label     label
-       :diagnosis (str "results are not ordered nearest-first. Either the sort "
-                       "reversed, or a similarity (higher = better) is being "
-                       "carried in the :distance field (lower = better).")
-       :distances (vec ds)})))
+(def rank-fault
+  "Alias of `hive-mcp.recall.canary/rank-fault`. See `recall-fault`."
+  canary/rank-fault)
 
 ;; =============================================================================
 ;; The golden store — with a bug switch

--- a/test/hive_mcp/recall/live_recall_test.clj
+++ b/test/hive_mcp/recall/live_recall_test.clj
@@ -32,7 +32,9 @@
             [hive-mcp.protocols.memory :as mem-proto]
             [hive-mcp.recall.golden :as g]
             [hive-mcp.server.init :as init]
-            [hive-mcp.tools.memory.search :as search]))
+            [hive-mcp.tools.memory.search :as search]
+            [hive-mcp.recall.canary :as canary]
+            [hive-mcp.recall.canary.live :as canary-live]))
 
 ;; =============================================================================
 ;; Bootstrap — the real config, the real providers. Read-only.
@@ -92,21 +94,29 @@
 ;; =============================================================================
 
 (deftest ^:integration live-lexical-anchor
-  (testing "'SIGSEGV crash JDK 25 bug use Java 21' must retrieve
-            20260511194834-344a3bc0 from the LIVE store. This is the exact query
-            that failed on 2026-07-12 and the exact entry it failed to find."
+  (testing "the canary's OWN anchor must come back from the live store.
+
+            This tier used to assert a hand-picked production id. That id was
+            deleted out from under it and the assertion became unfalsifiable —
+            a canary whose anchor someone else owns is not a canary. It now
+            reads the fixture the canary itself writes and re-finds by tag."
     (live-embeddings!)
-    (if-let [_store (live-store)]
-      (let [resp (search/handle-search-semantic
-                  {:query g/anchor-query :limit 10 :scope "global"})
-            body (when-not (:isError resp)
-                   (json/read-str (:text resp) :key-fn keyword))]
-        (is (not (:isError resp))
-            (str "live memory search errored: " (:text resp)))
-        (is (nil? (g/recall-fault {:label        "case-1/LIVE"
-                                   :populated?   true
-                                   :results      (:results body)
-                                   :must-contain [g/anchor-id]}))))
+    (if-let [store (live-store)]
+      (let [ids (canary-live/ensure-fixtures! store)]
+        (is (:anchor ids)
+            "the canary could not find OR create its anchor fixture — the store
+             refused a write, so recall cannot be measured against it")
+        (when (:anchor ids)
+          (let [resp (search/handle-search-semantic
+                      {:query canary/anchor-query :limit 10 :scope "global"})
+                body (when-not (:isError resp)
+                       (json/read-str (:text resp) :key-fn keyword))]
+            (is (not (:isError resp))
+                (str "live memory search errored: " (:text resp)))
+            (is (nil? (canary/recall-fault {:label        "case-1/LIVE"
+                                            :populated?   true
+                                            :results      (:results body)
+                                            :must-contain [(:anchor ids)]}))))))
       (is (nil? (backend-absent-fault))))))
 
 (deftest ^:integration live-results-are-ordered-nearest-first

--- a/test/hive_mcp/scheduler/decay_test.clj
+++ b/test/hive_mcp/scheduler/decay_test.clj
@@ -77,6 +77,25 @@
       (is (true? (get-in result [:grounding-stats :skipped]))
           "grounding-stats should show skipped"))))
 
+(deftest test-run-decay-cycle-includes-recall-canary
+  (testing "the tick reads retrieval BACK, not just ages it"
+    (let [result (decay/run-decay-cycle! {:memory-limit 1
+                                          :edge-limit 1
+                                          :disc-enabled false
+                                          :grounding-enabled false
+                                          :canary-enabled true})]
+      (is (contains? result :canary-stats) "cycle must report a canary pass")
+      (is (map? (:canary-stats result))))))
+
+(deftest test-run-decay-cycle-canary-disabled
+  (testing "canary pass skipped when :canary-enabled false"
+    (let [result (decay/run-decay-cycle! {:memory-limit 1
+                                          :edge-limit 1
+                                          :disc-enabled false
+                                          :grounding-enabled false
+                                          :canary-enabled false})]
+      (is (true? (get-in result [:canary-stats :skipped]))))))
+
 (deftest test-scheduler-config-exposes-grounding-knobs
   (testing "status :config carries the grounding knobs with code-side defaults"
     (let [cfg (:config (decay/status))]


### PR DESCRIPTION
`hive hot reload <addon-id>` rebuilds one mounted addon from its manifest and cascades to every addon holding its instance. Commands: reload, reload-all, watch, unwatch, list, status, strategies.

- `hive-addon.hot` is resolved SOFTLY — hive-mcp pins hive-addon 0.3.4 and the bridge ships in 0.3.5, so a hard require would not compile against the pin. Until the pin is bumped every command answers with an actionable :unavailable message.
- Only addons CURRENTLY REGISTERED are reloadable; the composer's plug layers may have dropped some deliberately.
- `ensure-hot-init!` seeds hive-hot with the derived addon source dirs + the protocol interlock. Left alone, hive-hot self-initializes clj-reload with `:dirs ["src"]` against the SERVER's cwd — watching the wrong tree while reporting success.
- `mount-host`: `register!` now has REPLACE semantics. `addons.core/register-addon!` refuses a duplicate id and keeps the incumbent; the adapter discarded that, so a remount silently kept the stale instance.

Verified live against the running server: real addon remount with instance replacement, all 17 addons still active.