### PR TITLE
chore(deps): hive-addon 0.3.4 -> 0.3.5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -143,7 +143,7 @@
         ;; hive-mcp.addons.protocol re-exports it via def-aliases so the ~30
         ;; monorepo addon implementors can depend on hive-addon instead of
         ;; compile-depending on hive-mcp.
-        io.github.hive-agi/hive-addon {:mvn/version "0.3.4"}
+        io.github.hive-agi/hive-addon {:mvn/version "0.3.5"}
 
         ;; hive-di — declarative typed config resolution (defconfig/env/literal)
         ;; Used by hive-mcp.embeddings.env-config and downstream addons.


### PR DESCRIPTION
Picks up `hive-addon.hot`, the IAddon hot-reload bridge that the `hot` tool drives. On 0.3.4 the tool soft-resolved to :unavailable.

Verified consumable, not merely published — resolved 0.3.5 from Clojars in a throwaway classpath and loaded `hive-addon.hot` with its strategy chain intact.