### PR TITLE
fix(hot): nest :resolve-config under :mount-opts

### DIFF
--- a/src/hive_mcp/tools/consolidated/hot.clj
+++ b/src/hive_mcp/tools/consolidated/hot.clj
@@ -116,11 +116,20 @@
 (defn- reload-opts
   "Options handed to the bridge.
 
-   :resolve-config must match what the original mount used, or a remounted addon
-   silently receives raw manifest config instead of the config.edn-merged config
-   it was first initialized with."
+   :resolve-config MUST sit under :mount-opts \u2014 that is the key the bridge
+   threads into boundary/mount!. Passing it at the top level is silently
+   ignored: mount! then falls back to port/resolve-config-default, which returns
+   the bare manifest :addon/config with NO config.edn merge and NO
+   :runtime/ports. The addon still constructs, still initializes, still reports
+   :success? true \u2014 and comes back DEGRADED, having lost the host adapters it
+   needs to contribute its own MCP commands. Measured: remounting hive.carto
+   that way left it :active with runtime-ports :configured [] and dropped the
+   `code carto \u2026` subdomain entirely.
+
+   manifest/prepare-config is what the original mount used; anything less hands
+   a remounted addon a thinner config than its first mount received."
   []
-  {:resolve-config manifest/prepare-config})
+  {:mount-opts {:resolve-config manifest/prepare-config}})
 
 (defn- prepared
   "Resolve specs + host + plan and make sure hive-hot is initialized correctly.


### PR DESCRIPTION
A top-level `:resolve-config` was silently ignored, so `mount!` fell back to `resolve-config-default` — no config.edn merge, no `:runtime/ports`.

Measured live: remounting `hive.knowledge` cascaded correctly to `hive.agent` + `hive.carto` and reported `ok? true` with all addons `:active` — while `hive.carto` came back `:degraded`, ports `:configured []`, and its `code carto …` subdomain gone.

With the fix: carto returns to `:ok`, ports `ready? true`, subdomain restored.