### PR TITLE
chore(deps): hive-addon 0.3.5 -> 0.3.6

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -143,7 +143,7 @@
         ;; hive-mcp.addons.protocol re-exports it via def-aliases so the ~30
         ;; monorepo addon implementors can depend on hive-addon instead of
         ;; compile-depending on hive-mcp.
-        io.github.hive-agi/hive-addon {:mvn/version "0.3.5"}
+        io.github.hive-agi/hive-addon {:mvn/version "0.3.6"}
 
         ;; hive-di — declarative typed config resolution (defconfig/env/literal)
         ;; Used by hive-mcp.embeddings.env-config and downstream addons.


### PR DESCRIPTION
0.3.6 folds stray mount options into `:mount-opts` instead of dropping them — defence in depth against the class of bug that left `hive.carto` green-but-degraded.