### PR TITLE
staging/v1.1.0

### DIFF
--- a/docker/lsp-sidecar/Dockerfile
+++ b/docker/lsp-sidecar/Dockerfile
@@ -76,6 +76,14 @@ RUN curl -fsSL "https://raw.githubusercontent.com/technomancy/leiningen/${LEIN_V
 # Trust common git hosts so SSH-backed clojure :git/url deps don't fail on host-key prompt
 RUN mkdir -p /etc/ssh && ssh-keyscan -H github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts 2>/dev/null
 
+# Non-interactive git for every child process (clojure -Spath / lein classpath /
+# clojure-lsp dep resolve). An uncached/private :git/url dep must fail fast, not
+# block on a credential, host-key, or passphrase prompt. GIT_TERMINAL_PROMPT=0
+# disables HTTPS credential prompts; BatchMode=yes + accept-new keep SSH silent;
+# ConnectTimeout bounds an unreachable-host handshake.
+ENV GIT_TERMINAL_PROMPT=0
+ENV GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"
+
 # Install clojure-lsp standalone JAR
 ARG CLOJURE_LSP_VERSION=2025.11.28-12.47.43
 RUN curl -L "https://github.com/clojure-lsp/clojure-lsp/releases/download/${CLOJURE_LSP_VERSION}/clojure-lsp-standalone.jar" \

--- a/docker/lsp-sidecar/analyze.sh
+++ b/docker/lsp-sidecar/analyze.sh
@@ -17,6 +17,14 @@ HEARTBEAT_INTERVAL=${LSP_HEARTBEAT_INTERVAL_SECONDS:-5}
 [[ "$PROJECT_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || PROJECT_TIMEOUT=300
 [[ "$HEARTBEAT_INTERVAL" =~ ^[1-9][0-9]*$ ]] || HEARTBEAT_INTERVAL=5
 
+# Non-interactive git so an uncached/private :git/url dep resolved during
+# `clojure -Spath` fails fast instead of blocking on a credential, host-key, or
+# passphrase prompt. GIT_TERMINAL_PROMPT=0 kills HTTPS credential prompts;
+# BatchMode=yes disables SSH password/passphrase prompts; accept-new trusts an
+# unseen host key without asking; ConnectTimeout bounds an unreachable handshake.
+export GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-0}
+export GIT_SSH_COMMAND=${GIT_SSH_COMMAND:-"ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"}
+
 enabled() {
     case "${1,,}" in
         1|true|yes|on) return 0 ;;


### PR DESCRIPTION
Release branch staging/v1.1.0 into main: 95 commits since main.

Highlights, newest first (feat/fix only):
- fix(lsp-sidecar): non-interactive git so uncached/private deps fail fast
- fix(deps): pin hive-help to 0.1.0, the only version published
- feat(slots): publish the exclusive-slot catalog, and bind :kg to its dispatch table
- fix(mount): install a licence gate, or every proprietary addon is refused
- feat(compliance): fail a manifest that will not say what it is
- fix(batch): a $ref the host cannot parse is a broken ref, not a value passed through
- fix(addons): register an init answer's :extensions only when it is a map, and mirror that on teardown
- fix(multi): make the unextended host sort waves instead of flattening them
- fix(memory): resolve migrate-scoped targets by querying the tag, and refuse a zero-target migration
- fix(nrepl): one embedded nREPL, and it writes .nrepl-port
- fix(test): require the namespaces these test files already call
- fix(test): the config guard reports a violation instead of aborting the run
- fix(nrepl): resolve CIDER middleware instead of assuming it is loaded
- fix(transport): the component config decides, and the status reports the start
- fix(test,lint): hive-test 0.3.19 unblocks the unit gate; drop dead lint
- fix(deps): hive-events 0.5.10, the release that publishes the router API
- fix(ns): require the namespaces these files already call
- fix(addons): both bridge records implement the whole IAddon contract
- feat(starter): both vessels join the pack; every coordinate is a published jar
- fix(deps): raise the hive-spi floor to the release that carries headless-caps
- feat(foss): IVessel re-export, hive-addon 0.3.12, and a starter pack of released addons
- feat(dev): probe the mount contract at runtime, and detect host coupling
- feat(dev): measure every public hive-agi repo against the FOSS compliance checks
- fix(kg): pass the projection map get-entries-projected actually reads
- feat(starter): ship starter.deps.edn and merge it from the FOSS launcher
- feat(hot): inject addons after boot, and advertise late contributions without a restart
- feat(catchup): cache the bundle across sessions, pull invalidation from write events
- feat(testing): ship the shared test fixtures so consumers can load them
- feat(addons): hydrate declared addon config at start-time
- fix(kg): a cluster is defined by live MEMBER COUNT, not by a live ratio

Verification: CI (lint, test, deps, boot) on this PR; the release workflow runs on main after merge.