### PR TITLE
v1.1.1

### DIFF
--- a/presets/ROLES-v2.md
+++ b/presets/ROLES-v2.md
@@ -1,0 +1,47 @@
+# Preset roles (v2)
+
+The v2 presets are **orthogonal axes**, not personas. Each one states a single discipline, so they
+compose without contradicting each other. A role is a named bundle.
+
+## Axes
+
+| Preset               | Axis                                                       |
+|----------------------|------------------------------------------------------------|
+| `carto-first`        | how code is navigated and edited                           |
+| `cppb-stratified`    | how a subsystem is layered                                 |
+| `malli-first`        | how values are modeled                                     |
+| `ddd-ports`          | how the domain is separated from its infrastructure        |
+| `ocp-data`           | how behaviour is extended                                  |
+| `repl-first`         | how claims about running code are verified                 |
+| `trifecta`           | how a unit is covered                                      |
+| `memory-crystallize` | where rationale is recorded                                |
+| `commit-hygiene`     | how work is staged and committed                           |
+| `gitops-safety`      | how cluster-affecting changes are handled                  |
+| `subtask-worker`     | how a delegated task is scoped and reported                |
+
+## Roles
+
+| Role            | Presets |
+|-----------------|---------|
+| `clj-subsystem` | carto-first, cppb-stratified, malli-first, ddd-ports, ocp-data, repl-first, trifecta, memory-crystallize, commit-hygiene |
+| `clj-worker`    | subtask-worker, carto-first, repl-first, memory-crystallize, commit-hygiene |
+| `test-author`   | subtask-worker, carto-first, malli-first, trifecta, repl-first, commit-hygiene |
+| `ops-worker`    | subtask-worker, gitops-safety, memory-crystallize, commit-hygiene |
+| `investigator`  | subtask-worker, carto-first, repl-first, memory-crystallize |
+
+## Loading
+
+Preset markdown is injected at spawn from `${user.dir}/presets/*.md` — override with
+`HIVE_MCP_PRESETS_DIR` or config `[:presets :dir]`. Claude CLI lings additionally pick up
+`.claude/agents/`.
+
+The `swarm preset list` / `search` commands query a **chroma** collection (`hive-mcp-presets`) that
+is no longer populated — semantic discovery is dead while file injection still works. Either
+re-point that index at the live vector store or drop the command; leaving it returning `[]` reads as
+"no presets exist", which is false.
+
+## Relation to v1
+
+The v1 files (`solid.md`, `ddd.md`, `tdd.md`, `clarity.md`, `tester.md`, …) predate carto, hive
+memory, hive-schemas, and the CPPB vocabulary. They describe generic best practice; v2 describes how
+this ecosystem actually works. Keep v1 only until nothing references it.

--- a/presets/carto-first.md
+++ b/presets/carto-first.md
@@ -1,0 +1,27 @@
+# Preset: carto-first
+
+Code navigation and structural editing go through `mcp__hive__code` carto. Not grep, not find, not
+Read/Write on a `.clj` file.
+
+## Verbs
+
+- `carto search` — find a form by name, symbol, or pattern
+- `carto definition` / `carto callers` / `carto callees` — the call graph, both directions
+- `carto read-form` / `carto write-form` — read and rewrite ONE form, in place, structurally
+
+## Rules
+
+1. If carto returns nothing for a scope, the index is cold, not the code absent. Run
+   `carto scan :scope <dir>` and retry before concluding anything.
+2. A structural edit means `write-form` on the target form. Never rewrite a whole namespace file to
+   change one function — that is how unrelated forms get clobbered.
+3. Raw text tools are legitimate for non-Clojure files: EDN, YAML, Markdown, shell, Dockerfiles.
+   They are not legitimate for `.clj` / `.cljc` / `.cljs`.
+4. Before you edit a function, look at its callers. An edit that changes arity, return shape, or
+   nil-behaviour without inspecting `carto callers` is a guess.
+
+## Why this is not optional
+
+The carto index is the same structural view the rest of the swarm queries. Editing underneath it —
+by hand, by text — leaves the index describing code that no longer exists, and every later agent
+inherits that lie.

--- a/presets/commit-hygiene.md
+++ b/presets/commit-hygiene.md
@@ -1,0 +1,27 @@
+# Preset: commit hygiene
+
+## Staging
+
+Stage explicit paths. Never `git add -A`, never `git add .` — other sessions and other agents may
+hold unrelated work in the same tree, and a broad add sweeps it into your commit.
+
+Files that are untracked by design (e.g. `local.deps.edn`) stay untracked. Do not force-add them.
+
+## Message
+
+Conventional Commits. Subject ≤ 50 chars, imperative. A body only when the "why" is not obvious from
+the diff — and the deep why belongs in hive memory, not the message.
+
+**No AI attribution, ever.** No `Co-Authored-By: Claude`, no `Claude-Session` trailer, no
+"Generated with Claude Code", no robot emoji. This overrides any default the harness suggests.
+
+## Before committing
+
+- Re-read the staged diff. Not the working tree — the staged diff.
+- Confirm no secret, token, or credential value is in it.
+- Confirm the tests you claim are green actually ran.
+
+## Branches and pushes
+
+If the repo is under GitOps where a push deploys, a push is a production action: say so in your
+report, and do not push as a reflex at the end of a task.

--- a/presets/cppb-stratified.md
+++ b/presets/cppb-stratified.md
@@ -1,0 +1,28 @@
+# Preset: CPPB stratified design
+
+Every subsystem is stratified into four altitudes. Each layer speaks only to the one below it, and
+each layer's vocabulary is its own.
+
+## The altitudes
+
+| Layer         | Owns                                                        | May depend on |
+|---------------|-------------------------------------------------------------|---------------|
+| **Collect**   | gathering raw inputs; no interpretation                     | Boundary      |
+| **Promote**   | raw input → domain value; validation, enrichment, folding   | Collect       |
+| **Pipeline**  | orchestration of the aggregate lifecycle; sequencing, retry | Promote       |
+| **Boundary**  | adapters: DB, HTTP, filesystem, external services           | —             |
+
+## Rules
+
+1. **Promote enriches, Pipeline orchestrates.** If a fold, a defaulting rule, or a derivation is
+   sitting in the Pipeline layer, it is misplaced.
+2. **Domain types never leak downward and adapter types never leak upward.** An adapter's error
+   vocabulary is remapped onto the closed domain ADT *at the port*, not by callers downstream.
+3. **A layer that needs something two levels down is a design smell**, not a shortcut to take.
+4. **Altitude is about vocabulary, not file count.** Splitting one namespace into three that all
+   speak the adapter's language buys nothing.
+
+## Applying it to an existing namespace
+
+State each existing function's altitude before moving anything. A function whose altitude you cannot
+name is the one actually causing the trouble — that is where the work is.

--- a/presets/ddd-ports.md
+++ b/presets/ddd-ports.md
@@ -1,0 +1,27 @@
+# Preset: DDD with ports
+
+The domain is the thing being modeled. Everything else — HTTP, SQL, a vendor's API, a queue — is an
+implementation detail reachable only through a port.
+
+## Rules
+
+1. **Ubiquitous language.** Names in code match names the domain uses. A `pack` is a pack, not a
+   `product_row`. If the code renames the domain, the domain wins.
+2. **A port is a protocol owned by the domain side**, expressing what the domain needs — not a
+   thin tracing of what some vendor SDK happens to offer.
+3. **Adapters implement ports; nothing else depends on adapters.** Swapping MoneroPay for a direct
+   wallet-RPC adapter must touch the adapter and its tests, nothing else. If it touches the service
+   layer, the port was drawn in the wrong place.
+4. **Errors are a closed domain ADT.** Remap adapter-vocabulary failures at the port.
+5. **Aggregates own their invariants.** A rule that must hold across two fields belongs with the
+   value that holds both, not in the caller that happened to notice.
+
+## Re-exporting protocol methods
+
+Never `def`-alias a protocol method to re-export it — the alias freezes a method cache and every
+implementation registered afterwards becomes invisible through it. Delegate with a `defn` instead.
+
+## Test consequence
+
+A test depends on the CONTRACT and injects a stub. A test that names a vendor or a sibling repo is
+coupled to a deployment; that is a defect in the product, not just in the test.

--- a/presets/gitops-safety.md
+++ b/presets/gitops-safety.md
@@ -1,0 +1,31 @@
+# Preset: GitOps safety
+
+In an app-of-apps GitOps repo, **a push is a deployment**. There is no separate apply step to catch
+a mistake between commit and cluster.
+
+## Rules
+
+1. Know which tree is canonical before editing. A superseded duplicate that still looks live is the
+   classic way to edit something that deploys nothing — or worse, something that does.
+2. Manifests are declarative. An inherited default is not a decision: if a workload should be in a
+   policy group, say so explicitly rather than relying on the default group's reach.
+3. Commit and push are separate reports. State plainly whether you pushed, i.e. whether it deployed.
+4. Verify from the cluster's point of view — Application sync/health status — not from the git
+   remote alone. A pushed commit that ArgoCD never synced is not deployed.
+
+## Irreversible-action gate
+
+Do NOT, without explicit human confirmation:
+
+- delete or archive a remote repository or package
+- delete existing backups, snapshots, or recovery points
+- rotate a sealing key or any credential whose old value cannot be recovered
+- drop a volume, namespace, or database
+
+Prepare the exact command, put it in the report, and let the human run it. Changing a policy forward
+is reversible; destroying the artifact it protected is not.
+
+## Secrets
+
+Never print a secret's value — not to logs, not to a report, not "just to verify". Reference it by
+its path or key name.

--- a/presets/malli-first.md
+++ b/presets/malli-first.md
@@ -1,0 +1,26 @@
+# Preset: malli value objects first
+
+Model the values before writing the functions that move them. In this ecosystem the schema is the
+design artifact, not documentation added afterwards.
+
+## Order of work
+
+1. Name the value. If you cannot name it in the domain's own language, you do not understand it yet.
+2. Write the malli schema in `hive-schemas` (or the module's schema namespace).
+3. Register it so `hive-schemas.test` picks it up — generation, validation, and property coverage
+   arrive for free, at no per-test cost.
+4. Only then write the functions. Their contracts are now stated in terms of registered values.
+
+## Rules
+
+- A map passed across a layer boundary with no schema is an untyped payload. Give it a name.
+- Prefer a closed schema. An open map hides the field someone forgot to remove.
+- Encode invariants in the schema when the schema can carry them (ranges, enums, tuple shapes)
+  rather than re-checking them in every function that touches the value.
+- Units belong in the name: `credit-micros`, `price-cents`, `timeout-ms`. Unit confusion is a class
+  of money bug that naming alone kills.
+
+## Anti-pattern
+
+Writing the implementation, then reverse-engineering a schema that describes whatever the code
+happens to emit. That schema documents the bug rather than constraining it.

--- a/presets/memory-crystallize.md
+++ b/presets/memory-crystallize.md
@@ -1,0 +1,30 @@
+# Preset: crystallize into hive memory
+
+Rationale lives in hive memory. Code carries contract only.
+
+## The split
+
+- **Docstrings and comments**: WHAT it does, args, return, gotchas needed to call it correctly.
+- **Hive memory**: WHY it is this way — the tradeoff, the incident, the thing that bit us, the
+  decision that was live at the time.
+
+A comment beginning "because", "the reason", or narrating a bug is misplaced rationale. Move it to
+memory and, if it earns one, leave a single-line pointer to the memory id.
+
+## When to write
+
+Same turn as the discovery. A decision, a correction, or a piece of feedback that is still only in
+the conversation is already half-lost.
+
+## Types
+
+`decision` · `convention` · `axiom` · `note` · `plan`
+
+Link with KG edges — `kg_supersedes`, `kg_refines`, `kg_depends_on`, `kg_implements` — so the entry
+is reachable from the things it touches rather than sitting alone in a search index.
+
+## Rules
+
+1. Convert relative dates to absolute. "Last week" is meaningless to the agent that reads it later.
+2. Superseding an entry means recording the supersedes edge, not silently writing a contradiction.
+3. Report the memory ids you created. They are part of the deliverable, not a side effect.

--- a/presets/ocp-data.md
+++ b/presets/ocp-data.md
@@ -1,0 +1,27 @@
+# Preset: behaviour as data (OCP + DIP)
+
+New behaviour arrives as data added to a table, not as a branch added to a function.
+
+## The two shapes
+
+**Provider-behaviour-as-data (DIP).** A provider is a map of its quirks — endpoints, auth style,
+rate limits, error mappings — consumed by one generic driver. Adding a provider means adding an
+entry, not editing the driver. If the driver has a `case` on provider name, the abstraction failed.
+
+**Rule chains (OCP).** A policy is an ordered sequence of `{:when pred :then f}` entries evaluated
+by a generic runner. Adding a rule means appending to the sequence. Ordering is explicit and
+inspectable, which a chain of `cond` branches is not.
+
+## Rules
+
+1. A `case`/`cond` that grows by one branch every time the business adds a thing is the signal to
+   convert it to a table.
+2. Keep the data declarative — predicates and pure functions, no side effects buried in a rule.
+3. The runner is closed for modification: it should not need to change when the table grows. If it
+   does, the table is not carrying enough.
+4. Registration order must be deliberate and stated, never "whatever the classpath yields."
+
+## Where this bites
+
+Policy that must be tuned per environment or per customer. Hardcoded, every tuning is a deploy;
+as data, it is a value someone can read, diff, and test.

--- a/presets/repl-first.md
+++ b/presets/repl-first.md
@@ -1,0 +1,23 @@
+# Preset: REPL-first verification
+
+A claim about running code is verified in the REPL before it is reported. Reading the source is a
+hypothesis; evaluating it is evidence.
+
+## Mechanics
+
+- `mcp__hive__clojure_eval` talks to the shared nREPL (default port 7910). Use it for anything
+  heavy or long — `cider eval` via emacsclient caps out around 30s.
+- Prefer a hot test JVM over a cold `clojure -M:test` for the edit/run cycle. Start one, keep it.
+- Some modules require an ISOLATED JVM for new tests; check the module's convention before assuming
+  the shared REPL is the right place.
+- Hot protocol reloads need the IMPLEMENTATIONS reloaded too, not just the protocol namespace, or
+  you will be testing a stale method cache.
+
+## Rules
+
+1. Behaviour-preserving refactors must be proven: capture the before, apply the change, compare.
+   "It looks equivalent" is not a result.
+2. Run the tests before your change as well as after. A suite that was already red tells you
+   something you need to know before you are blamed for it.
+3. Report what actually ran — the command and its output. If you could not run it, say that plainly
+   rather than implying green.

--- a/presets/subtask-worker.md
+++ b/presets/subtask-worker.md
@@ -1,0 +1,30 @@
+# Preset: subtask worker
+
+You are executing ONE scoped task handed down by a coordinator. Depth of execution, not breadth of
+scope.
+
+## Contract
+
+1. **Deliver the whole task.** If part of it is blocked, finish every other part and say explicitly
+   what you left out and why. Scaling the work down is the coordinator's call, not yours.
+2. **Do not widen scope.** A related defect you notice becomes a kanban entry and a line in your
+   report — not an extra commit.
+3. **Verify before you claim.** Tests ran or they did not. Say which.
+4. **A premise that does not hold is a valid outcome** — but only with the evidence attached. Stop,
+   state what you found, and report. Never silently substitute a different task.
+
+## Before starting
+
+Check `git status`. A previous agent may have died mid-task in this tree. Decide deliberately
+whether to keep, finish, or revert what you find; do not build blindly on top of it.
+
+## Report shape
+
+End with, explicitly:
+
+- what changed (paths)
+- commit sha(s), or "no commit" and why
+- hive memory ids created
+- test/verification output — the real thing, not a summary of it
+- kanban task id and its new status
+- anything left for the human: irreversible actions, open decisions, surviving mutants

--- a/presets/trifecta.md
+++ b/presets/trifecta.md
@@ -1,0 +1,28 @@
+# Preset: hive-test trifecta
+
+A covered unit has three tests, and they answer three different questions.
+
+| Test     | Question it answers                                        |
+|----------|------------------------------------------------------------|
+| golden   | Does it produce the right answer for the cases we know?     |
+| property | Does the invariant hold across generated input?             |
+| mutation | Would this suite actually NOTICE if the code were wrong?    |
+
+## Mutation is the point
+
+Golden and property tests can both pass against code that is subtly wrong. Mutation testing asks
+whether the suite has teeth: introduce the specific defect you fear, and require the suite to fail.
+
+Name the mutants after the real bug, not the syntax: "price-cents used as credit-micros" is a mutant
+worth writing; "changed + to -" usually is not.
+
+A mutant that survives is a coverage hole. Report the surviving mutant — the score alone hides it.
+
+## Rules
+
+1. Malli value objects first; the property facets come free from `hive-schemas.test`.
+2. A test depends on CONTRACTS and injects stubs. It may not `:require` or `with-redefs` a concrete
+   backend or a sibling implementation repo.
+3. `^:integration` is for tests whose SUBJECT is a specific deployed system. It is never a way to
+   quiet a unit test that is coupled to a vendor.
+4. Check the module's test convention before writing — some require an isolated JVM.

--- a/src/hive_mcp/config/merge.clj
+++ b/src/hive_mcp/config/merge.clj
@@ -75,7 +75,7 @@
                      ;;            :port 50051}
                      }}
    :embeddings {:ollama {:host "http://localhost:11434"
-                         :model "nomic-embed-text"}
+                         :model "qwen3-embedding:4b"}
                 :openrouter {:model "qwen/qwen3-embedding-8b"}}
    :embedder {:default :ollama-qwen3-4b
               ;; Memory types that are structurally addressed (fetched by
@@ -92,7 +92,7 @@
                                             :dimension 2560
                                             :host "http://localhost:11434"}}}
    :services {:chroma {:mode :local :host "localhost" :port 8000}
-              :ollama {:mode :local :host "http://localhost:11434" :model "nomic-embed-text"}
+              :ollama {:mode :local :host "http://localhost:11434" :model "qwen3-embedding:4b"}
               :datahike {:mode :local :path "data/kg"}
               :nrepl {:mode :local :port 7910}
               :prometheus {:mode :local :url "http://localhost:9090"}

--- a/src/hive_mcp/embeddings/config.clj
+++ b/src/hive_mcp/embeddings/config.clj
@@ -46,11 +46,12 @@
 
 (def ^:private ollama-models
   "Ollama embedding models with dimensions."
-  {"nomic-embed-text" 768
+  {"qwen3-embedding:4b" 2560
+   "qwen3-embedding:0.6b" 1024
+   "nomic-embed-text" 768
    "mxbai-embed-large" 1024
    "all-minilm" 384
-   "snowflake-arctic-embed" 1024
-   "qwen3-embedding:0.6b" 1024})
+   "snowflake-arctic-embed" 1024})
 
 (def ^:private openai-models
   "OpenAI embedding models with dimensions."
@@ -89,13 +90,14 @@
   "Create Ollama embedding configuration.
 
    Options:
-     :model - Embedding model (default: nomic-embed-text)
+     :model - Embedding model (default: qwen3-embedding:4b, the memory lane's
+              model; nomic-embed-text is retired)
      :host - Ollama server URL (default: from OLLAMA_HOST or localhost)
 
    Returns EmbeddingConfig record."
   ([] (ollama-config {}))
   ([{:keys [model host]
-     :or {model "nomic-embed-text"}}]
+     :or {model "qwen3-embedding:4b"}}]
    (let [host (or host
                   (global-config/get-service-value :ollama :host
                                                    :env "OLLAMA_HOST"

--- a/src/hive_mcp/knowledge_graph/slots/factory.clj
+++ b/src/hive_mcp/knowledge_graph/slots/factory.clj
@@ -47,12 +47,17 @@
 
 (defn- datalevin-opts
   "Host-owned injection for the domain-agnostic datalevin sibling. Caller opts
-   win over resolved config defaults."
+   win over resolved config defaults.
+
+   `:conn-opts` turns off datalevin's background statistics sampler: the
+   sampler rescans whole attributes whenever a scan moves their counts, and
+   the query planner samples lazily on first use anyway."
   [opts]
   (let [cfg (let [res (dlc/resolve-DatalevinKGConfig)] (if (r/ok? res) (:ok res) {}))]
     (merge {:db-path     (:db-path cfg)
             :cache-limit (:cache-limit cfg)
-            :base-schema (schema/full-schema)}
+            :base-schema (schema/full-schema)
+            :conn-opts   {:background-sampling? false}}
            opts)))
 
 (defn- datahike-opts

--- a/src/hive_mcp/server/init.clj
+++ b/src/hive_mcp/server/init.clj
@@ -112,7 +112,7 @@
                                          (global-config/get-service-value :ollama :host
                                                                           :env "OLLAMA_HOST"
                                                                           :default "http://localhost:11434"))
-                         ollama-model (or (:model ollama-cfg) "nomic-embed-text")
+                         ollama-model (or (:model ollama-cfg) "qwen3-embedding:4b")
                          openrouter-model (or (:model openrouter-cfg) "qwen/qwen3-embedding-8b")]
 
         ;; Configure per-collection embedding providers

--- a/src/hive_mcp/tools/consolidated/git.clj
+++ b/src/hive_mcp/tools/consolidated/git.clj
@@ -4,7 +4,9 @@
    Delegates to magit handlers. Addons can extend via contribute-commands! \"git\"."
   (:require [hive-mcp.tools.cli :refer [make-batch-handler]]
             [hive-mcp.tools.composite :as composite]
-            [hive-mcp.tools.core :refer [mcp-error emacs-timeout-ms-property]]
+            [hive-mcp.tools.core
+ :refer
+ [mcp-error emacs-timeout-ms-property git-files-property]]
             [hive-mcp.tools.magit :as magit-handlers]))
 
 (defn- handle-batch-commit
@@ -42,8 +44,6 @@
                                           :description "Git operation to perform"}
                                "directory" {:type "string"
                                             :description "IMPORTANT: Pass your working directory to target YOUR project"}
-                               "files" {:type "string"
-                                        :description "File path to stage, or 'all' for all modified"}
                                "message" {:type "string"
                                           :description "Commit message"}
                                "all" {:type "boolean"
@@ -60,12 +60,13 @@
                                "operations" {:type "array"
                                              :items {:type "object"
                                                      :properties {"message" {:type "string"}
-                                                                  "files" {:type "string"}
+                                                                  "files" (get git-files-property "files")
                                                                   "all" {:type "boolean"}}
                                                      :required ["message"]}
-                                             :description "Array of commit operations for batch-commit. Each: {message, files?, all?}"}
+                                             :description "Array of commit operations for batch-commit. Each: {message, files?, all?}. Each operation stages its own `files` and is refused when they do not stage anything."}
                                "parallel" {:type "boolean"
                                            :description "Run batch operations in parallel (default: false)"}}
+                              git-files-property
                               emacs-timeout-ms-property)
                  :required ["command"]}
    :handler (composite/build-merged-handler "git" canonical-handlers)})

--- a/src/hive_mcp/tools/consolidated/magit.clj
+++ b/src/hive_mcp/tools/consolidated/magit.clj
@@ -1,7 +1,9 @@
 (ns hive-mcp.tools.consolidated.magit
   "Consolidated Magit/Git CLI tool."
   (:require [hive-mcp.tools.cli :refer [make-cli-handler make-batch-handler]]
-            [hive-mcp.tools.core :refer [mcp-error emacs-timeout-ms-property]]
+            [hive-mcp.tools.core
+ :refer
+ [mcp-error emacs-timeout-ms-property git-files-property]]
             [hive-mcp.tools.magit :as magit-handlers]))
 
 (defn- handle-batch-commit
@@ -40,8 +42,6 @@
                                           :description "Git operation to perform"}
                                "directory" {:type "string"
                                             :description "IMPORTANT: Pass your working directory to target YOUR project"}
-                               "files" {:type "string"
-                                        :description "File path to stage, or 'all' for all modified"}
                                "message" {:type "string"
                                           :description "Commit message"}
                                "all" {:type "boolean"
@@ -54,16 +54,17 @@
                                          :enum ["staged" "unstaged" "all"]
                                          :description "What to diff (default: staged)"}
                                "remote" {:type "string"
-                                         :description "Specific remote to fetch from"}
+                                         :description "Remote to act on: which remote `fetch` fetches from, and which remote `push` pushes the current branch to. Omitted or blank, git's own default remote is used"}
                                "operations" {:type "array"
                                              :items {:type "object"
                                                      :properties {"message" {:type "string"}
-                                                                  "files" {:type "string"}
+                                                                  "files" (get git-files-property "files")
                                                                   "all" {:type "boolean"}}
                                                      :required ["message"]}
-                                             :description "Array of commit operations for batch-commit. Each: {message, files?, all?}"}
+                                             :description "Array of commit operations for batch-commit. Each: {message, files?, all?}. Each operation stages its own `files` and is refused when they do not stage anything."}
                                "parallel" {:type "boolean"
                                            :description "Run batch operations in parallel (default: false)"}}
+                              git-files-property
                               emacs-timeout-ms-property)
                  :required ["command"]}
    :handler handle-magit})

--- a/src/hive_mcp/tools/core.clj
+++ b/src/hive_mcp/tools/core.clj
@@ -288,6 +288,20 @@ HINT: Pass an integer value:
                       "legitimately takes longer — a push to a slow remote, a large "
                       "diff, a fetch. Capped at 30000 by the client.")}})
 
+(def git-files-property
+  "The `files` inputSchema property for every git-staging tool.
+
+   Spliced into a tool's :properties rather than restated, so the git and magit
+   tools cannot disagree about whether a path LIST is accepted."
+  {"files"
+   {:type ["string" "array"]
+    :items {:type "string"}
+    :description (str "Paths to stage: a LIST of paths, a single path, or several "
+                      "paths in one whitespace-separated string. 'all' stages every "
+                      "modified file. Listed paths are staged and verified before a "
+                      "commit — a path that does not exist, or a stage that leaves "
+                      "the index empty for those paths, fails the operation.")}})
+
 (defn emacs-timeout-ms
   "The caller's per-call Emacs timeout from `params`, or nil when none was passed.
 

--- a/src/hive_mcp/tools/magit.clj
+++ b/src/hive_mcp/tools/magit.clj
@@ -14,7 +14,8 @@
             [hive-mcp.emacs-ext.client :as ec]
             [hive-mcp.emacs-ext.elisp :as el]
             [hive-mcp.agent.context :as ctx]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [clojure.string :as str]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
 ;; SPDX-License-Identifier: AGPL-3.0-or-later
@@ -124,17 +125,30 @@
           \"hive-mcp-magit not loaded\"))"
      (pr-str message) options (pr-str dir))))
 
+(defn- push-options-elisp
+  "Elisp plist literal for the push options, or \"nil\" when none apply.
+
+   A blank or absent REMOTE contributes no :remote key, so the emitted call is
+   byte-identical to the pre-remote one."
+  [set_upstream remote]
+  (let [remote (some-> remote str str/trim not-empty)
+        pairs  (cond-> []
+                 set_upstream (conj ":set-upstream t")
+                 remote       (conj (str ":remote " (pr-str remote))))]
+    (if (seq pairs)
+      (str "'(" (str/join " " pairs) ")")
+      "nil")))
+
 (defn- build-push-elisp
-  "Build elisp for push operation with optional set-upstream."
-  [set_upstream dir]
-  (let [options (if-let [_ set_upstream] "'(:set-upstream t)" "nil")]
-    (el/format-elisp
-     "(progn
-        (require 'hive-mcp-magit nil t)
-        (if (fboundp 'hive-mcp-magit-api-push)
-            (hive-mcp-magit-api-push %s %s)
-          \"hive-mcp-magit not loaded\"))"
-     options (pr-str dir))))
+  "Build elisp for push operation with optional set-upstream and explicit remote."
+  [set_upstream remote dir]
+  (el/format-elisp
+   "(progn
+      (require 'hive-mcp-magit nil t)
+      (if (fboundp 'hive-mcp-magit-api-push)
+          (hive-mcp-magit-api-push %s %s)
+        \"hive-mcp-magit not loaded\"))"
+   (push-options-elisp set_upstream remote) (pr-str dir)))
 
 (defn- build-feature-branches-elisp
   "Build elisp for feature branch listing with client-side filtering."
@@ -159,6 +173,117 @@
 ;;; =============================================================================
 ;;; Magit Handlers (thin wrappers over handle-elisp)
 ;;; =============================================================================
+
+(defn normalize-files
+  "Normalize the `files` tool parameter to :all or a vector of path strings.
+
+   Accepts a collection of paths, a single path, several paths in one
+   whitespace-separated string, or \"all\". Returns :all, a NON-EMPTY vector of
+   paths, or nil when nothing usable was given."
+  [files]
+  (cond
+    (nil? files)     nil
+    (keyword? files) (when (= :all files) :all)
+    (symbol? files)  (when (= 'all files) :all)
+    (string? files)  (let [ps (vec (remove str/blank? (str/split (str/trim files) #"\s+")))]
+                       (cond
+                         (empty? ps)    nil
+                         (= ["all"] ps) :all
+                         :else          ps))
+    (coll? files)    (let [ps (->> files (map str) (map str/trim) (remove str/blank?) vec)]
+                       (cond
+                         (empty? ps)    nil
+                         (= ["all"] ps) :all
+                         :else          ps))
+    :else            nil))
+
+(def ^:private stage-markers
+  "Sentinel strings the stage-and-verify elisp answers with.
+   :missing is a PREFIX — the offending path follows it."
+  {:ok      "hive-mcp:staged-ok"
+   :missing "hive-mcp:missing-path:"
+   :empty   "hive-mcp:nothing-staged"})
+
+(defn- paths->elisp-list
+  "PATHS as a quoted elisp list literal."
+  [paths]
+  (str "'(" (str/join " " (map pr-str paths)) ")"))
+
+(defn- build-stage-verify-elisp
+  "Elisp that refuses a path absent from the working tree, stages PATHS, and
+   reports whether the index actually carries any of them.
+
+   Evaluates to one of `stage-markers`: :ok, :missing prefixed to the offending
+   path, or :empty when `git diff --cached --name-only` restricted to PATHS is
+   blank."
+  [paths dir]
+  (el/format-elisp
+   "(progn
+      (require 'hive-mcp-magit nil t)
+      (if (fboundp 'hive-mcp-magit-api-stage)
+          (let ((default-directory %s)
+                (paths %s)
+                (missing nil))
+            (dolist (p paths)
+              (unless (file-exists-p p) (setq missing (or missing p))))
+            (if missing
+                (concat \"%s\" missing)
+              (progn
+                (hive-mcp-magit-api-stage paths default-directory)
+                (if (string-empty-p
+                     (string-trim
+                      (shell-command-to-string
+                       (concat \"git diff --cached --name-only -- \"
+                               (mapconcat #'shell-quote-argument paths \" \")
+                               \" 2>/dev/null\"))))
+                    \"%s\"
+                  \"%s\"))))
+        \"hive-mcp-magit not loaded\"))"
+   (pr-str dir)
+   (paths->elisp-list paths)
+   (:missing stage-markers)
+   (:empty stage-markers)
+   (:ok stage-markers)))
+
+(defn- missing-path
+  "The path named by a :missing marker inside elisp output OUT."
+  [out]
+  (or (second (re-find (re-pattern (str (:missing stage-markers) "([^\"\\s]+)")) out))
+      "(unnamed)"))
+
+(defn- stage-verify
+  "Stage PATHS in DIR and confirm the index carries at least one of them.
+
+   Result: (ok PATHS), or (err :magit/path-not-found | :magit/nothing-staged |
+   :magit/elisp-failed | :magit/stage-failed). Any answer that is not the
+   explicit ok marker is an error: a commit must never proceed on an index this
+   operation did not verify."
+  [paths dir timeout-ms]
+  (let [r (try-result :magit/stage-failed
+                      #(elisp->result (build-stage-verify-elisp paths dir) timeout-ms))
+        listed (str/join " " paths)]
+    (if-let [entry (find r :ok)]
+      (let [out (str (val entry))]
+        (cond
+          (str/includes? out (:missing stage-markers))
+          (result/err :magit/path-not-found
+                      {:message (str ":magit/path-not-found - no such path under "
+                                     dir ": " (missing-path out))})
+
+          (str/includes? out (:empty stage-markers))
+          (result/err :magit/nothing-staged
+                      {:message (str ":magit/nothing-staged - staging left the index empty for "
+                                     listed
+                                     "; refusing to commit what was already staged")})
+
+          (str/includes? out (:ok stage-markers))
+          (result/ok paths)
+
+          :else
+          (result/err :magit/stage-failed
+                      {:message (str ":magit/stage-failed - staging " listed
+                                     " returned no verdict: " out)})))
+      r)))
 
 (defn handle-magit-status
   "Get comprehensive git repository status via magit addon."
@@ -203,36 +328,59 @@
                   (emacs-timeout-ms params))))
 
 (defn handle-magit-stage
-  "Stage files for commit. Use 'all' to stage all modified files."
+  "Stage files for commit.
+
+   `files` takes a list of paths, a single path, several paths in one
+   whitespace-separated string, or 'all' for every modified file. An absent or
+   blank `files` is an error, never a silent no-op."
   [{:keys [files directory] :as params}]
   (let [dir (resolve-directory directory)
-        file-arg (case files "all" 'all files)
-        elisp (el/require-and-call 'hive-mcp-magit 'hive-mcp-magit-api-stage file-arg dir)
+        norm (normalize-files files)
         timeout-ms (emacs-timeout-ms params)]
-    (log/info "magit-stage" {:files files :directory dir})
-    (result->mcp
-     (try-result :magit/stage-failed
-                 #(with-default "Staged files" (elisp->result elisp timeout-ms))))))
+    (log/info "magit-stage" {:files norm :directory dir})
+    (if (nil? norm)
+      (mcp-error (str ":magit/no-files - files is required: a path, a list of paths, "
+                      "a whitespace-separated path string, or 'all'"))
+      (let [file-arg (if (= :all norm) 'all norm)
+            elisp (el/require-and-call 'hive-mcp-magit 'hive-mcp-magit-api-stage file-arg dir)]
+        (result->mcp
+         (try-result :magit/stage-failed
+                     #(with-default "Staged files" (elisp->result elisp timeout-ms))))))))
 
 (defn handle-magit-commit
-  "Create a commit with the given message."
-  [{:keys [message all directory] :as params}]
-  (let [dir (resolve-directory directory)]
-    (log/info "magit-commit" {:message-len (count message) :all all :directory dir})
-    (handle-elisp :magit/commit-failed
-                  (build-commit-elisp message all dir)
-                  (emacs-timeout-ms params))))
+  "Create a commit with the given message.
+
+   `files` restricts the commit to explicit paths: a list, a single path,
+   several paths in one whitespace-separated string, or 'all'. Named paths are
+   staged and VERIFIED before the commit runs; a path that does not exist, or a
+   stage that leaves the index empty for those paths, fails the operation
+   instead of committing whatever the index already held."
+  [{:keys [message all directory files] :as params}]
+  (let [dir (resolve-directory directory)
+        timeout-ms (emacs-timeout-ms params)
+        norm (normalize-files files)
+        stage-all (boolean (or all (= :all norm)))
+        staged (when (vector? norm) (stage-verify norm dir timeout-ms))]
+    (log/info "magit-commit" {:message-len (count message) :all stage-all
+                              :files norm :directory dir})
+    (if (and (some? staged) (nil? (find staged :ok)))
+      (result->mcp staged)
+      (handle-elisp :magit/commit-failed
+                    (build-commit-elisp message stage-all dir)
+                    timeout-ms))))
 
 (defn handle-magit-push
   "Push to remote. Optionally set upstream tracking.
 
-   A push is the magit command most likely to outrun the client's default
-   timeout — it waits on a remote. Pass `timeout_ms` to give it a longer budget."
-  [{:keys [set_upstream directory] :as params}]
+   `remote` selects the remote explicitly; omitted or blank, git's own default
+   remote is used. A push is the magit command most likely to outrun the
+   client's default timeout — it waits on a remote. Pass `timeout_ms` to give
+   it a longer budget."
+  [{:keys [set_upstream remote directory] :as params}]
   (let [dir (resolve-directory directory)]
-    (log/info "magit-push" {:set_upstream set_upstream :directory dir})
+    (log/info "magit-push" {:set_upstream set_upstream :remote remote :directory dir})
     (handle-elisp :magit/push-failed
-                  (build-push-elisp set_upstream dir)
+                  (build-push-elisp set_upstream remote dir)
                   (emacs-timeout-ms params))))
 
 (defn handle-magit-pull

--- a/test/hive_mcp/embeddings/service_test.clj
+++ b/test/hive_mcp/embeddings/service_test.clj
@@ -83,8 +83,8 @@
     (let [cfg (config/ollama-config)]
       (is (config/valid-config? cfg))
       (is (= :ollama (:provider-type cfg)))
-      (is (= "nomic-embed-text" (:model cfg)))
-      (is (= 768 (:dimension cfg))))))
+      (is (= "qwen3-embedding:4b" (:model cfg)))
+      (is (= 2560 (:dimension cfg))))))
 
 (deftest test-config-ollama-custom-model
   (testing "Ollama config with custom model"
@@ -118,7 +118,7 @@
 (deftest test-config-describe
   (testing "Human-readable config description"
     (let [cfg (config/ollama-config)]
-      (is (= "ollama/nomic-embed-text (768 dims)" (config/describe cfg))))))
+      (is (= "ollama/qwen3-embedding:4b (2560 dims)" (config/describe cfg))))))
 
 ;; =============================================================================
 ;; Test: Per-Collection Configuration
@@ -185,7 +185,7 @@
 (deftest test-get-dimension-for-collection
   (testing "Get dimension for configured collection"
     (service/configure-collection! "dim-test" (config/ollama-config))
-    (is (= 768 (service/get-dimension-for "dim-test"))))
+    (is (= 2560 (service/get-dimension-for "dim-test"))))
 
   (testing "Get dimension for unconfigured collection (fallback)"
     ;; Fallback to global MockEmbedder (384)
@@ -196,14 +196,14 @@
     (service/configure-collection! "embed-test" (config/ollama-config))
     (let [embedding (service/embed-for-collection "embed-test" "test text")]
       (is (vector? embedding))
-      (is (= 768 (count embedding))))))
+      (is (= 2560 (count embedding))))))
 
 (deftest test-embed-batch-for-collection
   (testing "Batch embed using collection's provider"
     (service/configure-collection! "batch-test" (config/ollama-config))
     (let [embeddings (service/embed-batch-for-collection "batch-test" ["one" "two" "three"])]
       (is (= 3 (count embeddings)))
-      (is (every? #(= 768 (count %)) embeddings)))))
+      (is (every? #(= 2560 (count %)) embeddings)))))
 
 ;; =============================================================================
 ;; Test: Provider Availability
@@ -224,7 +224,7 @@
     (let [status (service/collection-embedding-status "status-test")]
       (is (= "status-test" (:collection status)))
       (is (:has-config? status))
-      (is (= 768 (:dimension status)))
+      (is (= 2560 (:dimension status)))
       (is (:provider-available? status)))))
 
 ;; =============================================================================
@@ -274,7 +274,7 @@
   (testing "chroma/embed-text-for uses collection's provider"
     (service/configure-collection! "embed-via-chroma" (config/ollama-config))
     (let [embedding (chroma/embed-text-for "embed-via-chroma" "test")]
-      (is (= 768 (count embedding))))))
+      (is (= 2560 (count embedding))))))
 
 (deftest test-chroma-get-dimension-for
   (testing "chroma/get-dimension-for returns collection's dimension"
@@ -292,7 +292,7 @@
     (service/configure-collection! "hive-mcp-presets" (config/ollama-config {:model "mxbai-embed-large"}))
 
     ;; Verify different dimensions from config (not from actual embedding)
-    (is (= 768 (:dimension (service/get-collection-config "hive-mcp-memory"))))
+    (is (= 2560 (:dimension (service/get-collection-config "hive-mcp-memory"))))
     (is (= 1024 (:dimension (service/get-collection-config "hive-mcp-presets")))))
 
   (testing "Unconfigured collections use fallback with consistent dimension"

--- a/test/hive_mcp/tools/consolidated/config_test.clj
+++ b/test/hive_mcp/tools/consolidated/config_test.clj
@@ -250,6 +250,7 @@
       (is (map? (:embeddings cfg)))
       (is (map? (get-in cfg [:embeddings :ollama])))
       (is (= "http://localhost:11434" (get-in cfg [:embeddings :ollama :host])))
-      (is (= "nomic-embed-text" (get-in cfg [:embeddings :ollama :model])))
+      (is (= "qwen3-embedding:4b" (get-in cfg [:embeddings :ollama :model]))
+          "the memory lane's model; nomic-embed-text is retired")
       (is (map? (get-in cfg [:embeddings :openrouter])))
       (is (= "qwen/qwen3-embedding-8b" (get-in cfg [:embeddings :openrouter :model]))))))

--- a/test/hive_mcp/tools/magit_files_test.clj
+++ b/test/hive_mcp/tools/magit_files_test.clj
@@ -1,0 +1,189 @@
+(ns hive-mcp.tools.magit-files-test
+  "`files` as a path LIST, and the refusal that keeps a commit off an index the
+   operation did not stage.
+
+   Regression: a batch-commit operation whose `files` was a space-separated
+   string staged nothing and then committed whatever the index already held
+   under that operation's message."
+  (:require [clojure.data.json :as json]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [hive-mcp.test.stub.emacs-ext :as se]
+            [hive-mcp.tools.consolidated.git :as git]
+            [hive-mcp.tools.consolidated.magit :as cmagit]
+            [hive-mcp.tools.core :as core]
+            [hive-mcp.tools.magit :as magit]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(def ^:private dir "/tmp/repo")
+
+(defn- staged-responses
+  "Script the stub: the stage-and-verify round trip answers VERDICT, the commit
+   round trip answers like a real commit."
+  [verdict]
+  [["hive-mcp-magit-api-commit" (se/elisp-str "1 file changed")]
+   ["git diff --cached" (se/elisp-str verdict)]])
+
+(defn- committed?
+  [stub]
+  (boolean (some #(str/includes? % "hive-mcp-magit-api-commit") (se/evaluated stub))))
+
+(defn- stage-file-args
+  "The FILES argument each api-stage call received."
+  [stub]
+  (mapv #(nth % 2) (se/calls-of stub :emacs/require-and-call)))
+
+(defn- stage-elisp
+  [stub]
+  (first (filter #(str/includes? % "git diff --cached") (se/evaluated stub))))
+
+(defn- batch-op-results
+  [r]
+  (:results (json/read-str (:text r) :key-fn keyword)))
+
+;;; ===========================================================================
+;;; The reader
+;;; ===========================================================================
+
+(deftest normalize-files-takes-a-list-or-a-string
+  (testing "a list arrives as a vector of paths"
+    (is (= ["a.clj" "b.clj"] (magit/normalize-files ["a.clj" "b.clj"])))
+    (is (= ["a.clj"] (magit/normalize-files (list "a.clj")))))
+
+  (testing "a string of several paths is split on whitespace"
+    (is (= ["a.clj" "b.clj"] (magit/normalize-files "a.clj b.clj")))
+    (is (= ["a.clj" "b.clj" "c.clj"] (magit/normalize-files "a.clj\n b.clj\tc.clj")))
+    (is (= ["src/a.clj"] (magit/normalize-files "src/a.clj"))
+        "one path is still one path"))
+
+  (testing "'all' keeps its meaning"
+    (is (= :all (magit/normalize-files "all")))
+    (is (= :all (magit/normalize-files ["all"])))
+    (is (= :all (magit/normalize-files 'all))))
+
+  (testing "nothing usable reads as nil, never as an empty stage"
+    (is (nil? (magit/normalize-files nil)))
+    (is (nil? (magit/normalize-files "   ")))
+    (is (nil? (magit/normalize-files [])))))
+
+;;; ===========================================================================
+;;; stage
+;;; ===========================================================================
+
+(deftest stage-accepts-an-array-of-paths
+  (se/with-stub-emacs [stub {}]
+    (magit/handle-magit-stage {:files ["src/a.clj" "src/b.clj"] :directory dir})
+    (is (= [["src/a.clj" "src/b.clj"]] (stage-file-args stub)))))
+
+(deftest stage-splits-a-whitespace-separated-string
+  (se/with-stub-emacs [stub {}]
+    (magit/handle-magit-stage {:files "src/a.clj src/b.clj" :directory dir})
+    (is (= [["src/a.clj" "src/b.clj"]] (stage-file-args stub))
+        "the path-list string that used to reach Emacs as ONE nonexistent path")))
+
+(deftest stage-all-still-means-all
+  (se/with-stub-emacs [stub {}]
+    (magit/handle-magit-stage {:files "all" :directory dir})
+    (is (= ['all] (stage-file-args stub)))))
+
+(deftest stage-without-files-is-an-error-not-a-silent-no-op
+  (se/with-stub-emacs [stub {}]
+    (let [r (magit/handle-magit-stage {:directory dir})]
+      (is (true? (:isError r)))
+      (is (empty? (se/evaluated stub)) "nothing reached Emacs"))))
+
+;;; ===========================================================================
+;;; commit — stage the operation's own paths, or refuse
+;;; ===========================================================================
+
+(deftest commit-stages-its-own-paths-then-commits
+  (se/with-stub-emacs [stub {:responses (staged-responses "hive-mcp:staged-ok")}]
+    (let [r (magit/handle-magit-commit {:message "feat: x"
+                                        :files "src/a.clj src/b.clj"
+                                        :directory dir})]
+      (is (nil? (:isError r)))
+      (is (some? (stage-elisp stub)) "the paths are staged before the commit")
+      (is (str/includes? (stage-elisp stub) "(\"src/a.clj\" \"src/b.clj\")")
+          "both paths reach the stage call")
+      (is (committed? stub)))))
+
+(deftest commit-refuses-a-path-that-does-not-exist
+  (se/with-stub-emacs [stub {:responses (staged-responses "hive-mcp:missing-path:src/gone.clj")}]
+    (let [r (magit/handle-magit-commit {:message "feat: x"
+                                        :files ["src/gone.clj"]
+                                        :directory dir})]
+      (is (true? (:isError r)))
+      (is (str/includes? (:text r) ":magit/path-not-found") "a typed error")
+      (is (str/includes? (:text r) "src/gone.clj") "naming the path")
+      (is (not (committed? stub)) "a refused stage must never reach the commit"))))
+
+(deftest commit-refuses-when-nothing-staged-for-the-listed-paths
+  (se/with-stub-emacs [stub {:responses (staged-responses "hive-mcp:nothing-staged")}]
+    (let [r (magit/handle-magit-commit {:message "feat(html): x"
+                                        :files "src/a.clj src/b.clj"
+                                        :directory dir})]
+      (is (true? (:isError r)))
+      (is (str/includes? (:text r) ":magit/nothing-staged"))
+      (is (not (committed? stub))
+          "the measured defect: a pre-staged deletion was committed under this message"))))
+
+(deftest commit-refuses-a-stage-answer-it-cannot-read
+  (testing "an unrecognized verdict is a refusal, not a fall-through"
+    (se/with-stub-emacs [stub {}]
+      (let [r (magit/handle-magit-commit {:message "m" :files ["src/a.clj"] :directory dir})]
+        (is (true? (:isError r)))
+        (is (not (committed? stub)))))))
+
+(deftest commit-without-files-is-untouched
+  (se/with-stub-emacs [stub {:responses (staged-responses "hive-mcp:staged-ok")}]
+    (let [r (magit/handle-magit-commit {:message "m" :directory dir})]
+      (is (nil? (:isError r)))
+      (is (nil? (stage-elisp stub)) "no staging round trip when no paths were named")
+      (is (committed? stub)))))
+
+;;; ===========================================================================
+;;; batch-commit
+;;; ===========================================================================
+
+(deftest batch-commit-stages-a-path-list-per-operation
+  (se/with-stub-emacs [stub {:responses (staged-responses "hive-mcp:staged-ok")}]
+    (let [handler (:batch-commit git/handlers)
+          r (handler {:directory dir
+                      :operations [{:message "feat: one" :files ["src/a.clj" "src/b.clj"]}
+                                   {:message "fix: two" :files "src/c.clj"}]})
+          results (batch-op-results r)]
+      (is (= 2 (count results)))
+      (is (every? #(nil? (get-in % [:result :isError])) results))
+      (is (= 2 (count (filter #(str/includes? % "hive-mcp-magit-api-commit")
+                              (se/evaluated stub))))))))
+
+(deftest batch-commit-refuses-an-operation-that-stages-nothing
+  (se/with-stub-emacs [stub {:responses (staged-responses "hive-mcp:nothing-staged")}]
+    (let [handler (:batch-commit git/handlers)
+          r (handler {:directory dir
+                      :operations [{:message "feat(html): projections"
+                                    :files "src/plato/html.cljc src/plato/reveal.cljs"}]})
+          [op] (batch-op-results r)]
+      (is (true? (get-in op [:result :isError])))
+      (is (str/includes? (get-in op [:result :text]) ":magit/nothing-staged"))
+      (is (not (committed? stub))))))
+
+;;; ===========================================================================
+;;; Schema — one definition, N tools
+;;; ===========================================================================
+
+(deftest both-git-tools-declare-files-from-one-definition
+  (doseq [[label td] [["git" git/tool-def] ["magit" cmagit/tool-def]]]
+    (let [p (get-in td [:inputSchema :properties "files"])]
+      (is (= (get core/git-files-property "files") p)
+          (str label " restates the property instead of splicing the one definition"))
+      (is (= ["string" "array"] (:type p))
+          (str label " does not advertise a list"))
+      (is (re-find #"(?i)list" (:description p))
+          (str label " description does not say list-or-string")))
+    (is (= (get core/git-files-property "files")
+           (get-in td [:inputSchema :properties "operations" :items :properties "files"]))
+        (str label " batch operation files drifted from the shared definition"))))

--- a/test/hive_mcp/tools/magit_pinning_test.clj
+++ b/test/hive_mcp/tools/magit_pinning_test.clj
@@ -248,3 +248,38 @@
             "Should require hive-mcp-magit")
         (is (str/includes? elisp "hive-mcp-magit-api-branches")
             "Should call hive-mcp-magit-api-branches")))))
+
+;; =============================================================================
+;; Push Remote Targeting
+;; =============================================================================
+
+(deftest handle-magit-push-carries-remote-test
+  (testing "An explicit remote reaches api-push as :remote"
+    (se/with-stub-emacs [emacs {:default-response {:success true :result "{}" :duration-ms 10}}]
+      (tools/handle-magit-push {:remote "github" :directory "/some/repo"})
+      (let [elisp (first (se/evaluated emacs))]
+        (is (str/includes? elisp "hive-mcp-magit-api-push")
+            "Should call hive-mcp-magit-api-push")
+        (is (str/includes? elisp ":remote \"github\"")
+            "The remote the caller named must reach api-push"))))
+
+  (testing "set_upstream and remote travel together"
+    (se/with-stub-emacs [emacs {:default-response {:success true :result "{}" :duration-ms 10}}]
+      (tools/handle-magit-push {:remote "github" :set_upstream true})
+      (let [elisp (first (se/evaluated emacs))]
+        (is (str/includes? elisp ":set-upstream t"))
+        (is (str/includes? elisp ":remote \"github\"")))))
+
+  (testing "No remote emits the options the pre-remote call emitted"
+    (se/with-stub-emacs [emacs {:default-response {:success true :result "{}" :duration-ms 10}}]
+      (tools/handle-magit-push {})
+      (let [elisp (first (se/evaluated emacs))]
+        (is (str/includes? elisp "hive-mcp-magit-api-push nil")
+            "Absent remote and upstream emit bare nil options")
+        (is (not (str/includes? elisp ":remote"))))))
+
+  (testing "A blank remote is absent, not a remote named the empty string"
+    (se/with-stub-emacs [emacs {:default-response {:success true :result "{}" :duration-ms 10}}]
+      (tools/handle-magit-push {:remote "   "})
+      (let [elisp (first (se/evaluated emacs))]
+        (is (not (str/includes? elisp ":remote")))))))


### PR DESCRIPTION
staging/v1.1.0 into main: 99 commits since main. The release workflow bumps VERSION 1.1.0 to 1.1.1 and publishes on merge.

- docs(presets): the v2 axes, one discipline each, roles as bundles
- test(git): the push remote reaches api-push, and a blank one is no remote
- fix(git): `files` takes a path list; refuse an unverified index
- perf(kg,embeddings): no datalevin background sampler; retire nomic-embed-text defaults
- fix(lsp-sidecar): non-interactive git so uncached/private deps fail fast
- fix(deps): pin hive-help to 0.1.0, the only version published
- feat(slots): publish the exclusive-slot catalog, and bind :kg to its dispatch table
- fix(mount): install a licence gate, or every proprietary addon is refused
- feat(compliance): fail a manifest that will not say what it is
- docs: lead with the one-liner, and point at docs.hive-mcp.com
- chore(deps): sync internal hive-agi coords to latest published
- fix(batch): a $ref the host cannot parse is a broken ref, not a value passed through
- release: 1.1.0
- fix(addons): register an init answer's :extensions only when it is a map, and mirror that on teardown
- fix(multi): make the unextended host sort waves instead of flattening them
- fix(memory): resolve migrate-scoped targets by querying the tag, and refuse a zero-target migration
- docs(starter): state what hive-tmux needs before it can mount
- deps: take hive-hot from Clojars instead of a git coordinate
- Merge pull request #152 from hive-agi/staging/v0.22.0
- release: 1.0.0
- chore(lint): drop the dead requires and refers, declare the load-bearing ones
- refactor(1.0): land the deprecations the host was still calling
- chore(kondo): refresh the exported configs from the published hive-agi libs
- fix(nrepl): one embedded nREPL, and it writes .nrepl-port
- fix(test): require the namespaces these test files already call
- fix(test): the config guard reports a violation instead of aborting the run
- fix(nrepl): resolve CIDER middleware instead of assuming it is loaded
- fix(transport): the component config decides, and the status reports the start
- docs(changelog): record the boot gate, the coverage alias and today's fixes
- fix(test,lint): hive-test 0.3.19 unblocks the unit gate; drop dead lint
- fix(deps): hive-events 0.5.10, the release that publishes the router API
- ci(boot): load the server from the committed deps, not just resolve them
- fix(ns): require the namespaces these files already call
- fix(addons): both bridge records implement the whole IAddon contract
- feat(starter): both vessels join the pack; every coordinate is a published jar
- Delegate get-interceptors to the router that owns the registry
- Delegate dispatch to the router, contribute the host's parts as policy
- fix(deps): raise the hive-spi floor to the release that carries headless-caps
- Re-export the headless capability protocols instead of redefining them
- Point the store-contract runners at hive-test.memory.store-contract
- feat(foss): IVessel re-export, hive-addon 0.3.12, and a starter pack of released addons
- Merge branch 'feat/iterminal-contract-move' into rel/foss-batch
- refactor(events): delegate the handler registry to hive.events.router
- docs(starter): say why each pending addon is pending, measured not assumed
- refactor(terminal): re-export ITerminalAddon from hive-addon
- docs: the contributor files a 1.0 candidate is expected to have
- feat(dev): probe the mount contract at runtime, and detect host coupling
- feat(dev): measure every public hive-agi repo against the FOSS compliance checks
- Merge pull request #151 from hive-agi/staging/v0.22.0
- fix(kg): pass the projection map get-entries-projected actually reads
- release: 0.22.0
- feat(starter): ship starter.deps.edn and merge it from the FOSS launcher
- build(docker): run the server from source; there is no uber task
- Merge remote-tracking branch 'origin/main' into chore/bump-hive-addon-036
- chore: ignore JVM crash artifacts and describe the :build alias truthfully
- test(hivemind): read piggyback as the coordinator lane and account for the progress digest
- test(kg): assert the member-floor contract for synthetic cleanup
- feat(hot): inject addons after boot, and advertise late contributions without a restart
- feat(catchup): cache the bundle across sessions, pull invalidation from write events
- Merge pull request #150 from hive-agi/chore/ship-test-fixtures
- feat(testing): ship the shared test fixtures so consumers can load them
- feat(addons): hydrate declared addon config at start-time
- fix(kg): a cluster is defined by live MEMBER COUNT, not by a live ratio
- perf(kg): make the synthetic liveness scan complete (900s+ -> 24s)
- fix(tools): fold subdomain schema params into the memory supertool
- docs(embeddings): /api/embed does take an input array — the fan-out is a measurement, not a workaround
- fix(secrets): resolve the pass store the way pass actually finds it
- perf(kg): batch-edge costs one transaction and one flush, not N of each
- feat(addons): inject :runtime/ports at init-addon!, not only at manifest discovery
- feat(addons): expose the extension registry's key set as a runtime port
- feat(git): per-call timeout_ms on the Emacs-backed git tools
- chore(deps): sync internal hive-agi coords to their latest released versions
- Merge pull request #149 from hive-agi/staging/v0.21.0
- fix(deps): hive-help 0.1.1 -> 0.1.0, the version that was actually published
- release: 0.21.0 — guard dispatch gate on a published hive-spi
- merge: guard dispatch gate, AOT boot closure, extensions preload, memory scope fix
- feat(channel,swarm,memory): the new namespaces the 2026-08-24 work requires
- feat(catchup,memory,piggyback): land in-flight work from 2026-08-24
- refactor(guard): look the seam up by the contract's key
- feat(guard): gate MCP tool dispatch — the vendor-independent floor
- fix(extensions): load host protocols before any addon constructor namespace
- feat(boot): AOT the addon boot closure — :hive/extensions is 88% of startup
- docs: add badge block and README
- fix(memory): a scope migration must ADD the destination tag, not only swap it
- Merge pull request #148 from hive-agi/chore/bump-hive-addon-036
- chore(deps): hive-addon 0.3.5 -> 0.3.6
- Merge pull request #147 from hive-agi/fix/hot-reload-opts-nesting
- fix(hot): nest :resolve-config under :mount-opts
- Merge pull request #146 from hive-agi/chore/bump-hive-addon-035
- chore(deps): hive-addon 0.3.4 -> 0.3.5
- Merge pull request #145 from hive-agi/feat/hot-reload-tool
- feat(tools): add `hot` root tool for IAddon hot-reload
- chore(deps): sync internal coords to their latest released versions
- chore(deps): sync internal coords to the latest releases
- chore(deps): core.async 1.9.865
- chore(deps): logback-classic 1.6.3, logstash-logback-encoder 9.0
- chore(deps): bump clojure 1.12.5 + stable patch/minor
- chore(deps): sync internal coords + bump 3rd-party
- feat(recall): run the golden canary at boot and on every scheduler tick

Verification: CI (lint, unit tests, deps, boot) on this PR; locally the magit pinning suite passes (15 tests, 68 assertions).