### PR TITLE
ci(release): create the GitHub Release again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ on:
       - 'resources/**'
       - 'deps.edn'
       - 'VERSION'
-      - '.github/workflows/release.yml'
+  # A change to this file alone must not fire a release: VERSION is already
+  # published, so the run could only end red. Re-run a release by hand instead.
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
@@ -37,7 +39,22 @@ jobs:
       - name: Test
         run: clojure -M:test-unit
 
+      # A published coordinate is immutable, so a version already on Clojars
+      # makes Deploy a no-op rather than a 403. The tag step below still says
+      # whether this commit is the one that shipped it.
+      - name: Already on Clojars?
+        id: published
+        run: |
+          VER=$(tr -d '[:space:]' < VERSION)
+          if curl -fsS -o /dev/null "https://repo.clojars.org/io/github/hive-agi/hive-mcp/$VER/hive-mcp-$VER.pom"; then
+            echo "hive-mcp $VER is already on Clojars; Deploy is skipped."
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy
+        if: steps.published.outputs.published != 'true'
         env:
           CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
@@ -62,3 +79,25 @@ jobs:
           fi
           git tag "v$VER" "$GITHUB_SHA"
           git push origin "refs/tags/v$VER"
+
+      # The Releases page lists Release objects, not tags. The body is this
+      # version's CHANGELOG section; GitHub appends its generated notes.
+      - name: Release notes from the changelog
+        id: notes
+        run: |
+          VER=$(tr -d '[:space:]' < VERSION)
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          awk -v v="$VER" '$0 ~ "^## \\[" v "\\]" {p=1; next} /^## \[/ {p=0} p' CHANGELOG.md \
+            > "$RUNNER_TEMP/release-notes.md"
+          if [ ! -s "$RUNNER_TEMP/release-notes.md" ]; then
+            echo "No CHANGELOG section for $VER; see the generated notes below." \
+              > "$RUNNER_TEMP/release-notes.md"
+          fi
+
+      - name: GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.notes.outputs.version }}
+          name: v${{ steps.notes.outputs.version }}
+          body_path: ${{ runner.temp }}/release-notes.md
+          generate_release_notes: true


### PR DESCRIPTION
Restores the GitHub Release step the release workflow lost in 3b1dc57 (every tag since v0.18.1 had no Release object, so the Releases page still called v0.18.0 latest; v0.22.0, v1.0.0, v1.1.0 and v1.1.1 were backfilled by hand from their CHANGELOG sections). The body of a Release is that version's CHANGELOG section, with GitHub's generated notes appended.

Two guards: the workflow no longer triggers on changes to its own file (such a run can only end red against an already-published VERSION; workflow_dispatch replaces it), and Deploy is skipped when the version is already on Clojars, which is the no-op the tag guard's message already describes.

Verification: the YAML parses and the step list is as intended; CI on this PR. No release run fires on merge, by design.