### PR TITLE
build(deps): the :addons alias gives hive.carto a committed coordinate

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -193,8 +193,25 @@
         meta-merge/meta-merge {:mvn/version "1.0.0"}
 }
 
+ ;; The private registry, consulted only for coordinates no public registry
+ ;; holds (the :addons alias). Credentials: ~/.m2/settings.xml, server id
+ ;; hive-gitea. The default classpath and every CI alias resolve without it.
+ :mvn/repos {"hive-gitea" {:url "https://gitea.hive-mcp.com/api/packages/hive-agi/maven"}}
+
  :aliases
- {:mcp
+ {;; :addons: the proprietary addon tier as PUBLISHED coordinates: hive.carto
+  ;; (with hive-shape transitively), hive.knowledge and hive.shape.go, each
+  ;; carrying its META-INF/hive-addons manifest, so the mounter finds them on
+  ;; a cold classpath with no local.deps.edn. Opt-in, because they resolve
+  ;; from the private registry above. A local.deps.edn :local/root override
+  ;; still wins over these when both are present.
+  ;;
+  ;;   clojure -M:addons:mcp ...
+  :addons {:extra-deps {io.github.hive-agi/hive-knowledge {:mvn/version "0.5.534"}
+                        io.github.hive-agi/hive-carto     {:mvn/version "0.2.513"}
+                        io.github.hive-agi/hive-shape-go  {:mvn/version "0.3.51"}}}
+
+  :mcp
   {:exec-fn hive-mcp.server.core/start!
    :exec-args {}
    :extra-deps {nrepl/nrepl {:mvn/version "1.7.0"}


### PR DESCRIPTION
## What

An opt-in `:addons` alias in `deps.edn` with the proprietary addon tier as published Gitea coordinates: hive-carto 0.2.513, hive-knowledge 0.5.534, hive-shape-go 0.3.51 (hive-shape 0.4.149 transitively). The private registry is declared at top level; it is consulted only for these coordinates.

## Why an alias

hive-mcp is public and its CI runs on GitHub. A top-level Gitea coordinate would fail every cold clone and CI run without registry credentials. Behind an alias the default classpath stays public-only, and anyone with `~/.m2/settings.xml` (server id `hive-gitea`) gets the addons with `clojure -M:addons:mcp`. A `local.deps.edn` `:local/root` override still wins when both are present.

## Verified

- default classpath: 244 entries, zero addon jars, no Gitea fetch
- `-A:addons`: resolves the four addon jars
- cold load through the alias: `hive-carto.carto-init` and `hive-shape-go.go-init` require cleanly, six `META-INF/hive-addons` roots on the classpath
- CI aliases (`:test-unit`, `:dev:test`, `:mcp`) do not include `:addons`, so nothing in CI changes

Closes the third item of kanban SHAPE-RELEASE (20260905223719-4edfc6f2).