### PR TITLE
feat(agent): providers are config; core honours config-declared providers and secrets

### DIFF
--- a/src/hive_mcp/agent/cider.clj
+++ b/src/hive_mcp/agent/cider.clj
@@ -139,11 +139,12 @@
   "Factory function for creating LLM backends.
 
    Named types: :ollama :cider :openrouter :openai-compat :auto.
-   Any other keyword that names a provider in
-   openrouter/provider-registry (e.g. :venice :groq :together :fireworks
-   :openai :ollama-compat) is routed through openai-compat-backend with
-   that :provider, so config keys like :models.synthesis-backend can
-   select a provider directly without a bespoke case."
+   Any other keyword that names a provider in the effective provider
+   registry (static openrouter/provider-registry merged with config
+   :llm-providers — e.g. :venice :axon :groq :together :fireworks :openai
+   :ollama-compat) is routed through openai-compat-backend with that
+   :provider, so config keys like :models.synthesis-backend can select a
+   provider directly without a bespoke case."
   ([type] (make-backend type {}))
   ([type opts]
    (case type
@@ -154,10 +155,11 @@
      :openrouter (openrouter/openrouter-backend opts)
      :openai-compat (openrouter/openai-compat-backend opts)
      :auto (openrouter/auto-backend opts)
-     (if (contains? openrouter/provider-registry type)
-       (openrouter/openai-compat-backend (assoc opts :provider type))
-       (throw (ex-info "Unknown backend type"
-                       {:type type
-                        :available (into [:ollama :cider :openrouter
-                                          :openai-compat :auto]
-                                         (keys openrouter/provider-registry))}))))))
+     (let [registry (openrouter/effective-provider-registry)]
+       (if (contains? registry type)
+         (openrouter/openai-compat-backend (assoc opts :provider type))
+         (throw (ex-info "Unknown backend type"
+                         {:type type
+                          :available (into [:ollama :cider :openrouter
+                                            :openai-compat :auto]
+                                           (keys registry))})))))))

--- a/src/hive_mcp/agent/openrouter.clj
+++ b/src/hive_mcp/agent/openrouter.clj
@@ -26,7 +26,10 @@
    (OAuth when available, else API key) via hive-agent.llm.anthropic.
    The `:dispatch :anthropic-oauth` marker tells the spawn plumbing to
    route through the anthropic HTTP client rather than the OpenAI-compat
-   path. All others hit OpenAI-compat /v1/chat/completions endpoints."
+   path. All others hit OpenAI-compat /v1/chat/completions endpoints.
+
+   `:axon` is axon.bz: Anthropic- and OpenAI-compatible relay, Bearer auth,
+   one flat per-token rate across every model it fronts."
   {:anthropic     {:dispatch      :anthropic-oauth
                    :secret-key    :anthropic-api-key
                    :default-model "claude-sonnet-4-6"}
@@ -36,7 +39,10 @@
    :venice        {:api-url       "https://api.venice.ai/api/v1/chat/completions"
                    :secret-key    :venice-api-key
                    :default-model "venice-uncensored"}
-   :groq          {:api-url       "https://api.groq.com/openai/v1/chat/completions"
+   :axon          {:api-url       "https://axon.bz/v1/chat/completions"
+                   :secret-key    :axon-api-key
+                   :default-model "deepseek-v4-flash-0731"}
+   :groq         {:api-url       "https://api.groq.com/openai/v1/chat/completions"
                    :secret-key    :groq-api-key
                    :default-model "llama-3.3-70b-versatile"}
    :together      {:api-url       "https://api.together.xyz/v1/chat/completions"
@@ -477,7 +483,10 @@
 (defn openai-compat-backend
   "Create an OpenAI-compatible LLM backend.
    Options:
-     :provider   - keyword from provider-registry (e.g. :openrouter, :venice, :groq)
+     :provider   - keyword from the EFFECTIVE provider registry: the static
+                   entries merged with config :llm-providers, so a provider
+                   that exists only in config (or a config override of a
+                   static entry's :default-model) is honoured here too
      :api-url    - explicit URL (overrides provider registry)
      :api-key    - explicit API key (overrides secret resolution)
      :model      - model string
@@ -487,7 +496,7 @@
    registry entry, e.g. :anthropic) and no :api-url override is supplied —
    such a provider has no chat-completions endpoint."
   [{:keys [provider api-url api-key model secret-key]}]
-  (let [reg-entry      (get provider-registry provider)
+  (let [reg-entry      (get (effective-provider-registry) provider)
         dispatch       (:dispatch reg-entry)
         effective-url  (or api-url (:api-url reg-entry))
         effective-sk   (or secret-key (:secret-key reg-entry))

--- a/src/hive_mcp/agent/openrouter.clj
+++ b/src/hive_mcp/agent/openrouter.clj
@@ -28,8 +28,9 @@
    route through the anthropic HTTP client rather than the OpenAI-compat
    path. All others hit OpenAI-compat /v1/chat/completions endpoints.
 
-   `:axon` is axon.bz: Anthropic- and OpenAI-compatible relay, Bearer auth,
-   one flat per-token rate across every model it fronts."
+   This is a SEED, not the definition: config `:llm-providers` extends and
+   overrides it through `effective-provider-registry`, so a new provider is
+   a config entry, never an edit here."
   {:anthropic     {:dispatch      :anthropic-oauth
                    :secret-key    :anthropic-api-key
                    :default-model "claude-sonnet-4-6"}
@@ -39,9 +40,6 @@
    :venice        {:api-url       "https://api.venice.ai/api/v1/chat/completions"
                    :secret-key    :venice-api-key
                    :default-model "venice-uncensored"}
-   :axon          {:api-url       "https://axon.bz/v1/chat/completions"
-                   :secret-key    :axon-api-key
-                   :default-model "deepseek-v4-flash-0731"}
    :groq         {:api-url       "https://api.groq.com/openai/v1/chat/completions"
                    :secret-key    :groq-api-key
                    :default-model "llama-3.3-70b-versatile"}

--- a/src/hive_mcp/config/secrets.clj
+++ b/src/hive_mcp/config/secrets.clj
@@ -83,19 +83,37 @@
         {:value pv :source :pass}
         {:value nil :source :missing}))))
 
+(defn env-var-for
+  "ENV_VAR name for a secret keyword, by the rule `hive-mcp.config.resolve/get-secret`
+   applies at read time: `:axon-api-key` -> \"AXON_API_KEY\"."
+  [secret-key]
+  (-> (name secret-key) (str/replace "-" "_") str/upper-case))
+
 (defn resolve-all-secrets
-  "Resolve all registered secrets against the current config's :secrets map.
+  "Resolve every secret against the current config's :secrets map.
+
+   The set is OPEN: `secret-registry` entries carry a known env var and pass
+   path, and any further key the config declares is resolved too, with its
+   env var derived from the keyword and no pass path of its own (a `pass:`
+   config value is still honoured downstream by resolve.clj). A key the
+   config declares must never be dropped here, or `get-secret` answers nil
+   for a secret that is sitting in the file.
+
    Returns {:secrets {kw value ...} :sources {kw :env|:pass|:config|:missing ...}}."
   [config-secrets]
-  (reduce-kv
-   (fn [acc secret-key [env-var pass-path]]
-     (let [config-val (get config-secrets secret-key)
-           {:keys [value source]} (resolve-secret config-val env-var pass-path)]
-       (-> acc
-           (assoc-in [:secrets secret-key] value)
-           (assoc-in [:sources secret-key] source))))
-   {:secrets {} :sources {}}
-   secret-registry))
+  (let [declared (into {}
+                       (for [k (keys config-secrets)
+                             :when (and (keyword? k) (not (contains? secret-registry k)))]
+                         [k [(env-var-for k) nil]]))]
+    (reduce-kv
+     (fn [acc secret-key [env-var pass-path]]
+       (let [config-val (get config-secrets secret-key)
+             {:keys [value source]} (resolve-secret config-val env-var pass-path)]
+         (-> acc
+             (assoc-in [:secrets secret-key] value)
+             (assoc-in [:sources secret-key] source))))
+     {:secrets {} :sources {}}
+     (merge secret-registry declared))))
 
 ;; =============================================================================
 ;; Startup Logging

--- a/src/hive_mcp/server/routes/async_task/schema.clj
+++ b/src/hive_mcp/server/routes/async_task/schema.clj
@@ -1,0 +1,138 @@
+(ns hive-mcp.server.routes.async-task.schema
+  "Value objects for an async tool call.
+
+   The single source for this subsystem's shapes: `m/=>` contracts and the
+   synthesized property tests both read from here."
+  (:require [malli.core :as m]
+            [hive-dsl.adt :as adt :refer [defadt]]))
+
+;; =============================================================================
+;; Identifiers
+;; =============================================================================
+
+(def TaskId    [:string {:min 1}])
+(def ToolName  [:string {:min 1}])
+(def CallerId  [:string {:min 1}])
+
+;; =============================================================================
+;; Lifecycle
+;; =============================================================================
+
+(defadt AsyncTaskState
+  "Where a task is, as reported to a caller.
+
+   `:cancelled` and `:timed-out` are distinct on purpose: both stop the work,
+   but one is an operator's decision and the other is the task exceeding a
+   bound it was given. Collapsing them loses the only fact that says which.
+
+   Named `AsyncTaskState`, not `TaskState`: the adt registry is keyed by BARE
+   NAME and is process-global, so a generic name is last-writer-wins against
+   any other library in the same JVM."
+  :task/queued
+  :task/running
+  :task/done
+  :task/cancelled
+  :task/timed-out
+  :task/failed)
+
+(def TaskState
+  "Malli projection of `AsyncTaskState`.
+
+   Derived, never retyped: an enum listing the variants a second time is the
+   copy that goes stale the first time a variant is added."
+  (into [:enum] (sort (adt/type-variants :AsyncTaskState))))
+
+(def terminal-states
+  "The variants that mean the task has stopped.
+
+   A subset of the ADT, checked against it at load: naming a variant here that
+   `AsyncTaskState` does not declare is a typo that would otherwise make
+   `terminal?` quietly answer false forever."
+  (let [ts #{:task/done :task/cancelled :task/timed-out :task/failed}
+        declared (set (adt/type-variants :AsyncTaskState))]
+    (assert (every? declared ts)
+            (str "terminal-states names variants AsyncTaskState does not declare: "
+                 (remove declared ts)))
+    ts))
+
+(def HandleView
+  "What the pure layer is allowed to know about a running handle.
+
+   A `java.util.concurrent.Future` never crosses into the pure layer; this is
+   its projection, so state decisions stay testable without a thread."
+  [:map {:closed true}
+   [:present? :boolean]
+   [:done?    :boolean]
+   [:cancelled? :boolean]])
+
+(def TaskEntry
+  "One registry row, as the pure layer sees it."
+  [:map {:closed true}
+   [:tool        ToolName]
+   [:caller-id   CallerId]
+   [:state       TaskState]
+   [:started-at  :int]
+   [:timeout-ms  [:maybe pos-int?]]
+   [:handle      HandleView]])
+
+(def TaskSummary
+  "One row rendered for a caller."
+  [:map {:closed true}
+   [:task-id     TaskId]
+   [:tool        ToolName]
+   [:caller-id   CallerId]
+   [:state       TaskState]
+   [:elapsed-ms  :int]
+   [:timeout-ms {:optional true} pos-int?]])
+
+;; =============================================================================
+;; Cancellation
+;; =============================================================================
+
+(defadt AsyncCancelOutcome
+  "What a cancel request achieved.
+
+   A closed set, so it is a sum rather than a `:reason` keyword floating in a
+   map: `adt-case` over this is exhaustive, and adding an outcome breaks every
+   dispatch that has not considered it, which is the point.
+
+   `:cancel/unknown-task` is an ANSWER, not an error: asking about a task that
+   has already been swept is a reasonable question."
+  [:cancel/interrupted      {:task-id string?}]
+  [:cancel/already-finished {:task-id string? :state keyword?}]
+  [:cancel/not-started      {:task-id string?}]
+  [:cancel/unknown-task     {:task-id string?}])
+
+(def CancelReason
+  "Malli projection of `AsyncCancelOutcome`'s variant tags."
+  (into [:enum] (sort (adt/type-variants :AsyncCancelOutcome))))
+
+(def CancelOutcome
+  "Malli shape of an `AsyncCancelOutcome` value.
+
+   Open, not `:closed true`: the variants carry different fields, and a closed
+   map here would reject the ones that carry more than `:task-id`."
+  [:map
+   [:adt/type    [:= :AsyncCancelOutcome]]
+   [:adt/variant CancelReason]
+   [:task-id     TaskId]
+   [:state {:optional true} TaskState]])
+
+;; =============================================================================
+;; Submission
+;; =============================================================================
+
+(def TaskSpec
+  "What a caller must supply to start a task.
+
+   `:timeout-ms` is optional because most async calls have no defensible
+   bound; a caller who knows one supplies it, and the task then ends by itself
+   rather than needing an operator."
+  [:map
+   [:task-id    TaskId]
+   [:tool       ToolName]
+   [:caller-id  CallerId]
+   [:timeout-ms {:optional true} [:maybe pos-int?]]
+   [:f          fn?]])
+
+(def valid-state? (m/validator TaskState))

--- a/src/hive_mcp/server/routes/async_task/state.clj
+++ b/src/hive_mcp/server/routes/async_task/state.clj
@@ -1,0 +1,103 @@
+(ns hive-mcp.server.routes.async-task.state
+  "Pure decisions about an async task's lifecycle.
+
+   One function, one decision. Nothing here touches a thread, a clock or an
+   atom: a `java.util.concurrent.Future` reaches this layer only as a
+   `schema/HandleView`, so every rule below is testable without concurrency."
+  (:require [malli.core :as m]
+            [hive-mcp.server.routes.async-task.schema :as s]
+            [hive-dsl.adt :as adt :refer [adt-case]]))
+
+;; =============================================================================
+;; Promoters
+;; =============================================================================
+
+(defn terminal?
+  "Has the task stopped, for any reason?"
+  [state]
+  (contains? s/terminal-states state))
+
+(defn reported-state
+  "The state to show a caller, given what we RECORDED and what the handle says.
+
+   The recorded state is an intention; the handle is the fact. Where they
+   disagree the handle wins, so a task that died on its own is never listed as
+   running. The exception is a recorded terminal state: `:task/cancelled`,
+   `:task/timed-out` and `:task/failed` all leave a handle that merely reads as
+   done, and that reading would erase the only record of WHY it stopped."
+  [recorded {:keys [present? done? cancelled?]}]
+  (cond
+    (terminal? recorded) recorded
+    (not present?)       recorded
+    cancelled?           :task/cancelled
+    done?                :task/done
+    :else                recorded))
+
+(defn cancel-outcome
+  "What a cancel request achieves against `entry`, decided before acting.
+
+   Separated from the act so the decision is testable and so a caller can see
+   a refusal without a side effect. Returns an `AsyncCancelOutcome` variant."
+  [task-id entry]
+  (cond
+    (nil? entry)
+    (s/async-cancel-outcome :cancel/unknown-task {:task-id task-id})
+
+    (not (get-in entry [:handle :present?]))
+    (s/async-cancel-outcome :cancel/not-started {:task-id task-id})
+
+    (or (terminal? (:state entry))
+        (get-in entry [:handle :done?]))
+    (s/async-cancel-outcome :cancel/already-finished
+                            {:task-id task-id
+                             :state   (reported-state (:state entry) (:handle entry))})
+
+    :else
+    (s/async-cancel-outcome :cancel/interrupted {:task-id task-id})))
+
+(defn summarize
+  "Render one registry row for a caller, as of `now-ms`."
+  [task-id {:keys [tool caller-id state started-at timeout-ms handle]} now-ms]
+  (cond-> {:task-id    task-id
+           :tool       tool
+           :caller-id  caller-id
+           :state      (reported-state state handle)
+           :elapsed-ms (- now-ms started-at)}
+    timeout-ms (assoc :timeout-ms timeout-ms)))
+
+(defn completion-state
+  "The state a task lands in when its body returns.
+
+   A body that returns has not necessarily WON: it may be unwinding from an
+   interrupt, and the cancel that caused it already recorded why. Only a task
+   still believed to be running is promoted to done."
+  [recorded]
+  (if (= :task/running recorded) :task/done recorded))
+
+(defn collectable?
+  "May this row be dropped by a sweep? Only a finished one."
+  [entry]
+  (terminal? (reported-state (:state entry) (:handle entry))))
+
+(defn stops-the-work?
+  "Did this outcome actually interrupt something? Exhaustive over the sum.
+
+   `adt-case` rather than a truthy field: a new outcome variant then fails
+   here instead of silently defaulting to false."
+  [outcome]
+  (adt-case s/AsyncCancelOutcome outcome
+    :cancel/interrupted      true
+    :cancel/already-finished false
+    :cancel/not-started      false
+    :cancel/unknown-task     false))
+
+;; =============================================================================
+;; Contracts
+;; =============================================================================
+
+(m/=> terminal? [:=> [:cat :any] :boolean])
+(m/=> reported-state [:=> [:cat s/TaskState s/HandleView] s/TaskState])
+(m/=> cancel-outcome [:=> [:cat s/TaskId [:maybe s/TaskEntry]] s/CancelOutcome])
+(m/=> summarize [:=> [:cat s/TaskId s/TaskEntry :int] s/TaskSummary])
+(m/=> completion-state [:=> [:cat s/TaskState] s/TaskState])
+(m/=> collectable? [:=> [:cat s/TaskEntry] :boolean])

--- a/src/hive_mcp/server/routes/async_tasks.clj
+++ b/src/hive_mcp/server/routes/async_tasks.clj
@@ -131,6 +131,21 @@
         res))
     f))
 
+(defn- complete-state!
+  "Record that a task's body returned, without overwriting why it stopped.
+
+   Atomic on purpose. A read-modify-write through bget/bput! loses a
+   concurrent cancel: the body's `finally` can read :task/running, a cancel
+   can then write :task/cancelled, and the `finally` overwrites it with
+   :task/done, erasing the only record that someone stopped it. bounded-swap!
+   sees the raw entry map, so the decision and the write are one step."
+  [task-id]
+  (bounded-swap! tasks
+                 (fn [m]
+                   (if (get m task-id)
+                     (update-in m [task-id :data :state] st/completion-state)
+                     m))))
+
 (defn submit!
   "Run `f` under `task-id`, registering a cancellable handle. Returns the handle."
   [{:keys [task-id tool caller-id timeout-ms f]}]
@@ -147,9 +162,7 @@
                        (try
                          (body)
                          (finally
-                           (when-let [e (bget tasks task-id)]
-                             (bput! tasks task-id
-                                    (assoc e :state (st/completion-state (:state e)))))))))]
+                           (complete-state! task-id)))))]
     (when-let [e (bget tasks task-id)]
       (bput! tasks task-id (assoc e :handle-obj handle)))
     handle))

--- a/src/hive_mcp/server/routes/async_tasks.clj
+++ b/src/hive_mcp/server/routes/async_tasks.clj
@@ -1,0 +1,187 @@
+(ns hive-mcp.server.routes.async-tasks
+  "Registry of in-flight async tool calls: bounded, inspectable, cancellable.
+
+   Boundary layer. Decisions live in `async-task.state` (pure); shapes live in
+   `async-task.schema`. This namespace only holds state and performs effects.
+
+   Execution goes through `ITaskRunner`, so a caller may substitute the
+   thread-backed runner. The default is backed by `hive-weave`: a fixed pool
+   rather than unbounded `future` threads, and `safe-future-call` for a task
+   that carries its own deadline.
+
+   Rationale, incident and the alternative designs considered:
+   memory 20260907-async-boundable (see kanban card for this work)."
+  (:require [hive-dsl.bounded-atom :refer [bounded-atom bget bput! bkeys bclear!
+                                           bounded-swap! register-sweepable!]]
+            [hive-weave.pool :as pool]
+            [hive-weave.safe :as safe]
+            [hive-mcp.server.routes.async-task.state :as st]
+            [taoensso.timbre :as log])
+  (:import [java.util.concurrent Future]))
+
+;; =============================================================================
+;; Execution port (DIP)
+;; =============================================================================
+
+(defprotocol ITaskRunner
+  "How a task is started, stopped and observed.
+
+   The seam exists so the lifecycle rules can be exercised without real
+   concurrency, and so the execution strategy can change without touching the
+   registry above it."
+  (-run    [this f]      "Start f. Returns an opaque handle.")
+  (-cancel [this handle] "Interrupt the handle's work. Returns true if this call stopped it.")
+  (-view   [this handle] "Project the handle into a schema/HandleView."))
+
+(def default-pool-size
+  "Concurrent async tool calls; beyond this they QUEUE rather than run.
+
+   These calls are long (an ingest runs for hours), so this bounds genuinely
+   slow work rather than tuning throughput."
+  8)
+
+(def default-queue-capacity
+  "Queued calls before the submitting thread runs the task itself.
+
+   Reaching it turns an async call synchronous, which is correct backpressure
+   and a bad surprise, so it should take a pathological backlog."
+  256)
+
+(defrecord WeavePoolRunner [pool]
+  ITaskRunner
+  (-run [_ f] (pool/submit! pool f))
+  (-cancel [_ handle] (.cancel ^Future handle true))
+  (-view [_ handle]
+    (if (nil? handle)
+      {:present? false :done? false :cancelled? false}
+      {:present?   true
+       :done?      (.isDone ^Future handle)
+       :cancelled? (.isCancelled ^Future handle)})))
+
+(defonce ^:private default-runner
+  (delay (->WeavePoolRunner (pool/make-pool {:name           "mcp-async"
+                                             :size           default-pool-size
+                                             :queue-capacity default-queue-capacity}))))
+
+(defonce ^{:doc "The active ITaskRunner. Rebind to substitute execution."}
+  runner
+  (atom nil))
+
+(defn current-runner []
+  (or @runner @default-runner))
+
+;; =============================================================================
+;; Registry
+;; =============================================================================
+
+(defonce ^{:doc "task-id -> entry. Bounded: a registry that only grows is a leak."}
+  tasks
+  (bounded-atom {:max-entries     500
+                 :ttl-ms          1800000
+                 :eviction-policy :lru}))
+(register-sweepable! tasks :async-tasks)
+
+(defn- entry-view
+  "Registry row with its handle projected, which is what the pure layer takes."
+  [task-id]
+  (when-let [e (bget tasks task-id)]
+    (-> e
+        (assoc :handle (-view (current-runner) (:handle-obj e)))
+        (dissoc :handle-obj))))
+
+(defn get-task
+  [task-id]
+  (when-let [e (entry-view task-id)]
+    (st/summarize task-id e (System/currentTimeMillis))))
+
+(defn list-tasks
+  []
+  (let [now (System/currentTimeMillis)]
+    (->> (bkeys tasks)
+         (keep (fn [id] (when-let [e (entry-view id)] (st/summarize id e now))))
+         (sort-by :elapsed-ms)
+         vec)))
+
+(defn running-tasks
+  []
+  (vec (remove (comp st/terminal? :state) (list-tasks))))
+
+(defn- set-state!
+  [task-id state]
+  (when-let [e (bget tasks task-id)]
+    (bput! tasks task-id (assoc e :state state))))
+
+;; =============================================================================
+;; Lifecycle
+;; =============================================================================
+
+(defn- bounded-body
+  "Wrap `f` so a task carrying `timeout-ms` ends itself at the deadline.
+
+   The wait happens on the POOL thread, never on the caller's: the caller has
+   already been acknowledged. `safe-future-call` returns the timeout as a
+   value, so the deadline needs no scheduler of its own."
+  [task-id f timeout-ms]
+  (if (and timeout-ms (pos-int? timeout-ms))
+    (fn []
+      (let [res (safe/safe-future-call {:timeout-ms timeout-ms :name task-id} f)]
+        (when (= :weave/timeout (:error res))
+          (log/warn "async task exceeded its bound" {:task-id task-id :timeout-ms timeout-ms})
+          (set-state! task-id :task/timed-out))
+        res))
+    f))
+
+(defn submit!
+  "Run `f` under `task-id`, registering a cancellable handle. Returns the handle."
+  [{:keys [task-id tool caller-id timeout-ms f]}]
+  (bput! tasks task-id {:tool       tool
+                        :caller-id  caller-id
+                        :state      :task/queued
+                        :started-at (System/currentTimeMillis)
+                        :timeout-ms timeout-ms
+                        :handle-obj nil})
+  (let [body   (bounded-body task-id f timeout-ms)
+        handle (-run (current-runner)
+                     (fn []
+                       (set-state! task-id :task/running)
+                       (try
+                         (body)
+                         (finally
+                           (when-let [e (bget tasks task-id)]
+                             (bput! tasks task-id
+                                    (assoc e :state (st/completion-state (:state e)))))))))]
+    (when-let [e (bget tasks task-id)]
+      (bput! tasks task-id (assoc e :handle-obj handle)))
+    handle))
+
+(defn cancel!
+  "Stop `task-id`. Returns an `AsyncCancelOutcome`; never throws for a stranger.
+
+   Whether to act is decided by the pure layer, so a refusal is a value rather
+   than a side effect that did nothing."
+  [task-id]
+  (let [outcome (st/cancel-outcome task-id (entry-view task-id))]
+    (when (st/stops-the-work? outcome)
+      (let [handle (:handle-obj (bget tasks task-id))
+            ok?    (-cancel (current-runner) handle)]
+        (set-state! task-id :task/cancelled)
+        (log/info "async task cancelled" {:task-id task-id :interrupted? ok?})))
+    outcome))
+
+(defn forget!
+  "Drop finished rows. Running ones are kept."
+  []
+  (let [gone (->> (bkeys tasks)
+                  (filter #(some-> (entry-view %) st/collectable?))
+                  vec)]
+    ;; bounded-atom has no per-key delete, and `bput! nil` would store a nil
+    ;; ROW rather than remove one. bounded-swap! sees the raw entry map, so
+    ;; dissoc there is the actual removal.
+    (when (seq gone)
+      (bounded-swap! tasks #(apply dissoc % gone)))
+    {:forgotten (count gone)}))
+
+(defn reset-registry!
+  "Clear every row. For tests and for a cold boot, not for operational use."
+  []
+  (bclear! tasks))

--- a/src/hive_mcp/server/routes/middleware.clj
+++ b/src/hive_mcp/server/routes/middleware.clj
@@ -13,6 +13,7 @@
             [hive-mcp.agent.context :as ctx]
             [hive-mcp.crystal.core :as crystal]
             [hive-mcp.channel.async-result :as async-buf]
+            [hive-mcp.server.routes.async-tasks :as async-tasks]
             [hive-mcp.dsl.response :as compress]
             [hive-mcp.extensions.registry :as ext]
             [hive-dsl.context.identity :as ctx-id]
@@ -157,26 +158,55 @@
                  should-default? (assoc :async true))))))
 
 (defn wrap-handler-async
-  "Intercept async:true calls — return ack, spawn future for real execution."
+  "Intercept async:true calls: return an ack, run the work on the async pool.
+
+   The work goes to `async-tasks/submit!`, NOT to a bare `future`, so the
+   handle is retained. A bare future's handle was discarded, which left a
+   long-running call impossible to list, bound or stop by any API: the only
+   remedy was killing the JVM, and on a shared coordinator that ends every
+   other agent's work too.
+
+   `:async-timeout-ms` bounds one call. It is consumed here alongside
+   `:async` and never reaches the handler, for the same reason `:async` does
+   not: it addresses THIS wrapper, not the tool.
+
+   NOTE for addon authors: a top-level `:async` is consumed here and is gone
+   before any handler runs, so a tool must not name a parameter `async` and
+   expect to receive it. Spell such a flag `background` (see
+   `hive-ingestor.addon.registry/dispatcher-shadowed-params`)."
   [handler tool-name]
   (fn [args]
     (if (:async args)
-      (let [task-id (str "atask-" (random-uuid))
-            caller-id (or (:_caller_id args) "coordinator")]
-        (future
-          (try
-            (let [clean-args (dissoc args :async)
-                  result (handler clean-args)]
-              (async-buf/enqueue-result! caller-id
-                                         {:task-id task-id :tool tool-name
-                                          :status :completed :result result}))
-            (catch Exception e
-              (log/error e "async-result: background execution failed for task" task-id)
-              (async-buf/enqueue-result! caller-id
-                                         {:task-id task-id :tool tool-name
-                                          :status :error :error (.getMessage e)}))))
+      (let [task-id    (str "atask-" (random-uuid))
+            caller-id  (or (:_caller_id args) "coordinator")
+            timeout-ms (:async-timeout-ms args)]
+        (async-tasks/submit!
+         {:task-id    task-id
+          :tool       tool-name
+          :caller-id  caller-id
+          :timeout-ms timeout-ms
+          :f          (fn []
+                        (try
+                          (let [clean-args (dissoc args :async :async-timeout-ms)
+                                result (handler clean-args)]
+                            (async-buf/enqueue-result! caller-id
+                                                       {:task-id task-id :tool tool-name
+                                                        :status :completed :result result}))
+                          (catch InterruptedException _
+                            ;; Cancelled on purpose. Say so rather than
+                            ;; reporting it as a failure of the work.
+                            (log/info "async-result: task cancelled" {:task-id task-id})
+                            (async-buf/enqueue-result! caller-id
+                                                       {:task-id task-id :tool tool-name
+                                                        :status :cancelled}))
+                          (catch Exception e
+                            (log/error e "async-result: background execution failed for task" task-id)
+                            (async-buf/enqueue-result! caller-id
+                                                       {:task-id task-id :tool tool-name
+                                                        :status :error :error (.getMessage e)}))))})
         [{:type "text"
-          :text (pr-str {:queued true :task-id task-id :tool tool-name})}])
+          :text (pr-str (cond-> {:queued true :task-id task-id :tool tool-name}
+                          timeout-ms (assoc :timeout-ms timeout-ms)))}])
       (handler args))))
 
 (defn- guard-refusal

--- a/test/hive_mcp/agent/openai_compat_test.clj
+++ b/test/hive_mcp/agent/openai_compat_test.clj
@@ -172,17 +172,13 @@
       (let [b (openrouter/openai-compat-backend {:provider :acme :api-key "sk-test"})]
         (is (= "https://acme.test/v1/chat/completions" (:api-url b)))
         (is (= "acme-1" (proto/model-name b)))
-        (is (= "acme" (:provider-name b)))))))
-
-(deftest axon-is-a-registered-provider-test
-  (testing "axon.bz is a static provider with Bearer-auth chat completions"
-    (let [e (get openrouter/provider-registry :axon)]
-      (is (= "https://axon.bz/v1/chat/completions" (:api-url e)))
-      (is (= :axon-api-key (:secret-key e)))
-      (is (nil? (openrouter/validate-provider :axon)))
-      (is (= {:provider :axon :model "glm-5.3-flash"}
-             (openrouter/resolve-provider-model {:model "axon:glm-5.3-flash"
-                                                 :agent-type :ling}))))))
+        (is (= "acme" (:provider-name b))))
+      (is (nil? (openrouter/validate-provider :acme)))
+      (is (= {:provider :acme :model "acme-2"}
+             (openrouter/resolve-provider-model {:model "acme:acme-2" :agent-type :ling}))
+          "the <provider>:<model> prefix resolves for a config-only provider too")))
+  (testing "nothing in the static registry names a provider that only config should"
+    (is (not (contains? openrouter/provider-registry :axon)))))
 
 (deftest openai-compat-backend-ollama-no-key-test
   (testing "ollama-compat works without API key"

--- a/test/hive_mcp/agent/openai_compat_test.clj
+++ b/test/hive_mcp/agent/openai_compat_test.clj
@@ -155,6 +155,34 @@
              {:provider :groq :api-key "sk-test"})]
       (is (= "llama-3.3-70b-versatile" (proto/model-name b))))))
 
+(deftest openai-compat-backend-reads-the-effective-registry-test
+  (testing "a config override of a static entry's :default-model is honoured"
+    (with-redefs [config/get-config-value
+                  (fn [k] (when (= k "llm-providers")
+                            {:venice {:default-model "e2ee-deepseek-v4-flash"}}))]
+      (is (= "e2ee-deepseek-v4-flash"
+             (proto/model-name (openrouter/openai-compat-backend
+                                {:provider :venice :api-key "sk-test"}))))))
+  (testing "a provider that exists only in config is constructible"
+    (with-redefs [config/get-config-value
+                  (fn [k] (when (= k "llm-providers")
+                            {:acme {:api-url "https://acme.test/v1/chat/completions"
+                                    :secret-key :acme-api-key
+                                    :default-model "acme-1"}}))]
+      (let [b (openrouter/openai-compat-backend {:provider :acme :api-key "sk-test"})]
+        (is (= "https://acme.test/v1/chat/completions" (:api-url b)))
+        (is (= "acme-1" (proto/model-name b)))
+        (is (= "acme" (:provider-name b)))))))
+
+(deftest axon-is-a-registered-provider-test
+  (testing "axon.bz is a static provider with Bearer-auth chat completions"
+    (let [e (get openrouter/provider-registry :axon)]
+      (is (= "https://axon.bz/v1/chat/completions" (:api-url e)))
+      (is (= :axon-api-key (:secret-key e)))
+      (is (nil? (openrouter/validate-provider :axon)))
+      (is (= {:provider :axon :model "glm-5.3-flash"}
+             (openrouter/resolve-provider-model {:model "axon:glm-5.3-flash"}))))))
+
 (deftest openai-compat-backend-ollama-no-key-test
   (testing "ollama-compat works without API key"
     (let [b (openrouter/openai-compat-backend

--- a/test/hive_mcp/agent/openai_compat_test.clj
+++ b/test/hive_mcp/agent/openai_compat_test.clj
@@ -181,7 +181,8 @@
       (is (= :axon-api-key (:secret-key e)))
       (is (nil? (openrouter/validate-provider :axon)))
       (is (= {:provider :axon :model "glm-5.3-flash"}
-             (openrouter/resolve-provider-model {:model "axon:glm-5.3-flash"}))))))
+             (openrouter/resolve-provider-model {:model "axon:glm-5.3-flash"
+                                                 :agent-type :ling}))))))
 
 (deftest openai-compat-backend-ollama-no-key-test
   (testing "ollama-compat works without API key"

--- a/test/hive_mcp/config/secrets_test.clj
+++ b/test/hive_mcp/config/secrets_test.clj
@@ -1,0 +1,22 @@
+(ns hive-mcp.config.secrets-test
+  "Startup secret resolution: the registered set plus whatever the config
+   declares on its own."
+  (:require [clojure.test :refer [deftest is testing]]
+            [hive-mcp.config.secrets :as secrets]))
+
+(deftest a-config-declared-secret-outside-the-registry-survives-resolution
+  (testing "registered keys resolve, and so does a key only the config knows"
+    (let [{:keys [secrets sources]}
+          (with-redefs [secrets/pass-show (constantly nil)]
+            (secrets/resolve-all-secrets {:venice-api-key "pass:Venice/key"
+                                          :axon-api-key   "pass:ai/k"}))]
+      (is (= "pass:ai/k" (:axon-api-key secrets))
+          "kept verbatim: resolve.clj expands the pass: prefix at read time")
+      (is (= :config (:axon-api-key sources)))
+      (is (= "pass:Venice/key" (:venice-api-key secrets)))
+      (is (every? #(contains? secrets %) (keys secrets/secret-registry))
+          "every registered key is still reported, missing ones included"))))
+
+(deftest a-declared-secret-is-named-in-the-environment-by-its-keyword
+  (is (= "AXON_API_KEY" (secrets/env-var-for :axon-api-key)))
+  (is (= "OPENROUTER_API_KEY" (secrets/env-var-for :openrouter-api-key))))

--- a/test/hive_mcp/server/routes/async_tasks_test.clj
+++ b/test/hive_mcp/server/routes/async_tasks_test.clj
@@ -1,0 +1,170 @@
+(ns hive-mcp.server.routes.async-tasks-test
+  "An async tool call must be listable, boundable and cancellable.
+
+   The predecessor spawned a bare `(future ...)` and discarded the handle, so
+   none of the three was possible: nothing could name a running call, nothing
+   could stop it, and nothing could bound it. Every assertion here is
+   unsatisfiable against that design, which is what makes them worth having."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-mcp.server.routes.async-tasks :as at]
+            [hive-mcp.server.routes.async-task.state :as st])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn- clean-registry [f]
+  (at/reset-registry!)
+  (try (f) (finally (at/reset-registry!))))
+
+(use-fixtures :each clean-registry)
+
+(defn- await-latch
+  "Block on `latch` up to `ms`. Returns true when it opened.
+
+   Every wait in this namespace is a CONDITION with a ceiling, never a bare
+   sleep: a fixed pause either flakes on a slow box or wastes time on a fast
+   one, and it cannot tell 'not yet' from 'never'."
+  [^CountDownLatch latch ms]
+  (.await latch ms TimeUnit/MILLISECONDS))
+
+;; =============================================================================
+;; It runs at all
+;; =============================================================================
+
+(deftest a-submitted-task-runs-and-completes
+  (let [done (CountDownLatch. 1)
+        ran  (atom false)]
+    (at/submit! {:task-id "t-ok" :tool "memory" :caller-id "test"
+                 :f (fn [] (reset! ran true) (.countDown done))})
+    (is (await-latch done 5000) "the task should have run")
+    (is (true? @ran))
+    (is (= :task/done (:state (at/get-task "t-ok")))
+        "a task that reached its own end is :done")))
+
+;; =============================================================================
+;; It can be seen while running
+;; =============================================================================
+
+(deftest a-running-task-is-listed
+  (let [started (CountDownLatch. 1)
+        release (CountDownLatch. 1)]
+    (at/submit! {:task-id "t-visible" :tool "memory" :caller-id "test"
+                 :f (fn [] (.countDown started) (await-latch release 5000))})
+    (is (await-latch started 5000))
+    (testing "a task in flight is reported, with the tool that owns it"
+      (let [t (at/get-task "t-visible")]
+        (is (= :task/running (:state t)))
+        (is (= "memory" (:tool t)))
+        (is (some #(= "t-visible" (:task-id %)) (at/running-tasks)))))
+    (.countDown release)))
+
+;; =============================================================================
+;; It can be stopped
+;; =============================================================================
+
+(deftest cancel-interrupts-a-running-task
+  (let [started     (CountDownLatch. 1)
+        interrupted (CountDownLatch. 1)]
+    (at/submit! {:task-id "t-cancel" :tool "memory" :caller-id "test"
+                 :f (fn []
+                      (.countDown started)
+                      (try
+                        ;; Stands in for a long call. Only an interrupt ends it.
+                        (Thread/sleep 60000)
+                        (catch InterruptedException _
+                          (.countDown interrupted))))})
+    (is (await-latch started 5000))
+    (let [res (at/cancel! "t-cancel")]
+      (is (true? (st/stops-the-work? res)))
+      (is (= :cancel/interrupted (:adt/variant res))))
+    (is (await-latch interrupted 5000)
+        "cancellation must reach the task's own thread, not merely mark a flag")
+    (is (= :task/cancelled (:state (at/get-task "t-cancel"))))))
+
+(deftest cancelling-an-unknown-task-answers-rather-than-throws
+  ;; Asking about a task that already finished, or never existed, is a
+  ;; reasonable question. It gets an answer with a reason.
+  (let [res (at/cancel! "t-nonexistent")]
+    (is (false? (st/stops-the-work? res)))
+    (is (= :cancel/unknown-task (:adt/variant res)))))
+
+(deftest cancelling-a-finished-task-says-so
+  (let [done (CountDownLatch. 1)]
+    (at/submit! {:task-id "t-finished" :tool "memory" :caller-id "test"
+                 :f (fn [] (.countDown done))})
+    (is (await-latch done 5000))
+    ;; The future is done the instant f returns; give the state write its turn
+    ;; by asserting on the reason, which does not depend on that race.
+    (let [res (at/cancel! "t-finished")]
+      (is (false? (st/stops-the-work? res)))
+      (is (= :cancel/already-finished (:adt/variant res))))))
+
+;; =============================================================================
+;; It can be bounded
+;; =============================================================================
+
+(deftest a-timeout-cancels-a-runaway-task
+  (let [started     (CountDownLatch. 1)
+        interrupted (CountDownLatch. 1)]
+    (at/submit! {:task-id "t-bounded" :tool "memory" :caller-id "test"
+                 :timeout-ms 300
+                 :f (fn []
+                      (.countDown started)
+                      (try (Thread/sleep 60000)
+                           (catch InterruptedException _
+                             (.countDown interrupted))))})
+    (is (await-latch started 5000))
+    (is (await-latch interrupted 5000)
+        "a task with a deadline must end WITHOUT anyone calling cancel!")
+    (is (= :task/timed-out (:state (at/get-task "t-bounded")))
+        "and it must say the bound is why it stopped, not report a plain cancel")))
+
+(deftest a-task-inside-its-bound-is-untouched
+  ;; The deadline must not be a fixed pause that fires regardless: a task that
+  ;; finishes in time keeps its own outcome.
+  (let [done (CountDownLatch. 1)]
+    (at/submit! {:task-id "t-inside" :tool "memory" :caller-id "test"
+                 :timeout-ms 10000
+                 :f (fn [] (.countDown done))})
+    (is (await-latch done 5000))
+    (is (= :task/done (:state (at/get-task "t-inside"))))))
+
+;; =============================================================================
+;; The execution seam (DIP)
+;; =============================================================================
+
+(deftest the-runner-is-substitutable
+  ;; The point of the port: the registry's rules can be exercised with no
+  ;; threads at all. A runner that runs f on the calling thread is a legitimate
+  ;; ITaskRunner, and everything above it must still behave.
+  (let [ran (atom false)
+        inline (reify at/ITaskRunner
+                 (-run [_ f] (f) ::handle)
+                 (-cancel [_ _] false)
+                 (-view [_ h] {:present? (some? h) :done? true :cancelled? false}))]
+    (reset! at/runner inline)
+    (try
+      (at/submit! {:task-id "t-inline" :tool "memory" :caller-id "test"
+                   :f (fn [] (reset! ran true))})
+      (is (true? @ran) "the injected runner executed the body")
+      (is (= :task/done (:state (at/get-task "t-inline"))))
+      (testing "cancelling work that already finished is refused, not attempted"
+        (is (= :cancel/already-finished (:adt/variant (at/cancel! "t-inline")))))
+      (finally (reset! at/runner nil)))))
+
+;; =============================================================================
+;; Housekeeping
+;; =============================================================================
+
+(deftest forget-drops-finished-tasks-and-keeps-running-ones
+  (let [done    (CountDownLatch. 1)
+        started (CountDownLatch. 1)
+        release (CountDownLatch. 1)]
+    (at/submit! {:task-id "t-gone" :tool "memory" :caller-id "test"
+                 :f (fn [] (.countDown done))})
+    (at/submit! {:task-id "t-stays" :tool "memory" :caller-id "test"
+                 :f (fn [] (.countDown started) (await-latch release 5000))})
+    (is (await-latch done 5000))
+    (is (await-latch started 5000))
+    (at/forget!)
+    (is (nil? (at/get-task "t-gone")) "a finished task is dropped")
+    (is (some? (at/get-task "t-stays")) "a running task is never dropped")
+    (.countDown release)))

--- a/test/hive_mcp/server/routes/async_tasks_test.clj
+++ b/test/hive_mcp/server/routes/async_tasks_test.clj
@@ -25,6 +25,20 @@
   [^CountDownLatch latch ms]
   (.await latch ms TimeUnit/MILLISECONDS))
 
+(defn- await-state
+  "Wait up to `ms` for `task-id` to report `state`. Returns true if it did.
+
+   A latch says the task's BODY reached a point; the registry write that
+   records why it stopped happens afterwards. Anything asserting on state
+   must wait for the state itself, not for a proxy that merely precedes it."
+  [task-id state ms]
+  (let [deadline (+ (System/currentTimeMillis) ms)]
+    (loop []
+      (cond
+        (= state (:state (at/get-task task-id)))   true
+        (> (System/currentTimeMillis) deadline)    false
+        :else (do (Thread/sleep 10) (recur))))))
+
 ;; =============================================================================
 ;; It runs at all
 ;; =============================================================================
@@ -114,7 +128,12 @@
     (is (await-latch started 5000))
     (is (await-latch interrupted 5000)
         "a task with a deadline must end WITHOUT anyone calling cancel!")
-    (is (= :task/timed-out (:state (at/get-task "t-bounded")))
+    ;; The interrupt reaching the body and the STATE being recorded are two
+    ;; different events: `bounded-body` writes :task/timed-out only after
+    ;; safe-future-call returns, which is strictly after the latch opens.
+    ;; Asserting straight off the latch is a race that passes on a fast
+    ;; machine and fails on a loaded CI runner, which is exactly what it did.
+    (is (await-state "t-bounded" :task/timed-out 5000)
         "and it must say the bound is why it stopped, not report a plain cancel")))
 
 (deftest a-task-inside-its-bound-is-untouched


### PR DESCRIPTION
## What

Adding an OpenAI-compatible provider is a config entry (`:llm-providers.<name>` + `:secrets.<name>-api-key`), never an edit to core. This PR fixes the seams that made that false:

- `openai-compat-backend` and `cider/make-backend` resolve the provider from `effective-provider-registry` (seed merged with config), like `validate-provider` and `resolve-provider-model` already did. A provider that exists only in config used to throw `API URL required for custom provider`; a config override of a seed entry's `:default-model` was ignored.
- `config.secrets/resolve-all-secrets` no longer drops `:secrets` keys the config declares beyond the seven registered ones. A declared key resolves with an env var derived from its name (`:axon-api-key` -> `AXON_API_KEY`) and no pass path; `pass:` values are still expanded by resolve.clj. Before, `get-secret` answered nil for a value sitting in config.edn after every `load-global-config!`.
- `provider-registry` is documented as the seed. No provider-specific entry is added (an earlier commit on this branch added `:axon`; retracted).

## Evidence

- `hive-mcp.agent.openai-compat-test` + `hive-mcp.config.secrets-test` green in a fresh `-M:test` nREPL and on CI; the test asserts a config-only provider resolves through `validate-provider`, the `<provider>:<model>` prefix and `openai-compat-backend`, and that the seed carries nothing provider-specific.
- Against the live config: `(openai-compat-backend {:provider :axon})` builds with the pass-resolved key after `load-global-config!`; `(openai-compat-backend {:provider :venice})` answers the config default model.
