### PR TITLE
ci: run the suite on staging, not only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # staging is a GATE, not a mirror. Without it here, landing on staging ran
+    # nothing, so "merge staging, then promote to main if CI is green" had no
+    # CI to be green: the first real signal arrived only once main had already
+    # taken the change. release.yml deliberately still lists main alone, so
+    # staging is where the suite runs and never where a version is published.
+    branches: [main, staging]
     paths-ignore:
       - '**.md'
       - 'resources/presets/**'
       - 'docs/**'
   pull_request:
-    branches: [main]
+    # PRs INTO staging need the same gate, or a promotion PR is first graded
+    # only on its eventual PR into main.
+    branches: [main, staging]
     paths-ignore:
       - '**.md'
       - 'resources/presets/**'


### PR DESCRIPTION
`staging` was a mirror, not a gate. Nothing ran when a change landed on it, so "merge staging, then promote to main if CI is green" had **no CI to be green** — the first real signal arrived only once main had already taken the change.

Both triggers needed it:

- **push** — so landing on staging is graded at all
- **pull_request** — its `[main]` filter meant a PR *into* staging ran nothing, and was first graded only on its eventual PR into main

`release.yml` is deliberately untouched and still lists `main` alone: staging is where the suite runs, never where a version is published.

This file is outside `release.yml`'s path filter (`src/**`, `resources/**`, `deps.edn`, `VERSION`), so merging it mints nothing and needs no VERSION bump.

The matching change landed on hive-knowledge as `624abc1`; there `pull_request` already carried no branch filter, so only `push` needed it.