### PR TITLE
registry facade over hive-addon, NATS connection watches, forge survey verb

### DIFF
--- a/bin/nrepl-eval
+++ b/bin/nrepl-eval
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Evaluate Clojure in a running hive-mcp nREPL, with no dependencies at all.
+
+WHY THIS EXISTS (incident 2026-09-09): the hive MCP transport can drop while
+the coordinator JVM keeps serving nREPL. From a client the two states look
+identical -- every mcp__hive__* tool reports "server failed to connect" --
+so the natural read is "the host died" and the natural response is to stop.
+It had not died: `ss -ltnp | grep 79` showed the same pid still listening on
+7910 and 7911, and the session's remaining work went in through this path.
+
+Every other route into the host (the MCP tools, cider, clojure_eval)
+presupposes the layer that just failed, and the bencode codec hive-mcp
+already owns lives INSIDE that JVM. Hence stdlib only: python3, no pip, no
+clojure CLI, no classpath resolution.
+
+The consolidated tool handlers take a keyword-keyed param map and are the
+same entry points the MCP tools call, so a tool call has a direct
+translation:
+
+    hive-mcp.tools.consolidated.kanban/handle-kanban   {:command "create" ...}
+    hive-mcp.tools.consolidated.memory/handle-memory   {:command "add" ...}
+    hive-mcp.tools.consolidated.kg/handle-kg           {:command "edge" ...}
+    hive-mcp.tools.consolidated.project/handle-project {:command "workflow wrap" ...}
+
+String keys are NOT accepted by them; a map with "command" reports
+`Unknown command: `.
+
+Usage:
+    bin/nrepl-eval '(+ 1 2)'
+    echo '(do ...)' | bin/nrepl-eval
+    bin/nrepl-eval --port 7911 '(+ 1 2)'
+
+Exits 1 when the evaluation reports an error, 2 when the port is unreachable.
+
+CAUTION: port 7910 is the LIVE coordinator. Targeted evaluation only --
+never a test suite, never `:reload`; see the axioms on running tests against
+a shared image.
+"""
+
+import argparse
+import socket
+import sys
+
+DEFAULT_PORT = 7910
+
+
+def bencode(o):
+    if isinstance(o, bytes):
+        return str(len(o)).encode() + b":" + o
+    if isinstance(o, str):
+        return bencode(o.encode())
+    if isinstance(o, int):
+        return b"i" + str(o).encode() + b"e"
+    if isinstance(o, list):
+        return b"l" + b"".join(bencode(x) for x in o) + b"e"
+    if isinstance(o, dict):
+        return b"d" + b"".join(bencode(k) + bencode(v)
+                               for k, v in sorted(o.items())) + b"e"
+    raise TypeError(f"cannot bencode {type(o).__name__}")
+
+
+def bdecode(buf, i=0):
+    """Decode one value at buf[i:]. Returns (value, next-index)."""
+    c = buf[i:i + 1]
+    if c == b"i":
+        j = buf.index(b"e", i)
+        return int(buf[i + 1:j]), j + 1
+    if c == b"l":
+        i += 1
+        out = []
+        while buf[i:i + 1] != b"e":
+            v, i = bdecode(buf, i)
+            out.append(v)
+        return out, i + 1
+    if c == b"d":
+        i += 1
+        out = {}
+        while buf[i:i + 1] != b"e":
+            k, i = bdecode(buf, i)
+            v, i = bdecode(buf, i)
+            out[k] = v
+        return out, i + 1
+    j = buf.index(b":", i)
+    n = int(buf[i:j])
+    return buf[j + 1:j + 1 + n].decode("utf-8", "replace"), j + 1 + n
+
+
+def evaluate(port, code, timeout):
+    sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+    sock.settimeout(timeout)
+    sock.sendall(bencode({"op": "eval", "code": code, "id": "nrepl-eval"}))
+    buf, outs, vals, errs = b"", [], [], []
+    try:
+        while True:
+            try:
+                chunk = sock.recv(65536)
+            except socket.timeout:
+                errs.append(f"TIMEOUT after {timeout}s")
+                break
+            if not chunk:
+                break
+            buf += chunk
+            done = False
+            while buf:
+                try:
+                    msg, n = bdecode(buf, 0)
+                except (ValueError, IndexError):
+                    break  # partial frame; wait for more bytes
+                buf = buf[n:]
+                if "out" in msg:
+                    outs.append(msg["out"])
+                if "value" in msg:
+                    vals.append(msg["value"])
+                if "err" in msg:
+                    errs.append(msg["err"])
+                if "ex" in msg:
+                    errs.append("ex " + str(msg["ex"]))
+                if "done" in msg.get("status", []):
+                    done = True
+            if done:
+                break
+    finally:
+        sock.close()
+    return "".join(outs), vals, "".join(errs)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Evaluate Clojure in a running nREPL.")
+    ap.add_argument("code", nargs="?", help="form to evaluate; omit to read stdin")
+    ap.add_argument("--port", type=int, default=DEFAULT_PORT)
+    ap.add_argument("--timeout", type=float, default=180.0, help="seconds")
+    ap.add_argument("--quiet", action="store_true", help="print values only")
+    args = ap.parse_args()
+
+    code = args.code if args.code is not None else sys.stdin.read()
+    if not code.strip():
+        ap.error("no code given")
+
+    try:
+        out, vals, err = evaluate(args.port, code, args.timeout)
+    except (ConnectionRefusedError, OSError) as e:
+        print(f"nrepl-eval: cannot reach port {args.port}: {e}", file=sys.stderr)
+        print("check the JVM is up:  ss -ltnp | grep 79", file=sys.stderr)
+        return 2
+
+    if out and not args.quiet:
+        sys.stdout.write(out if out.endswith("\n") else out + "\n")
+    for v in vals:
+        print(v)
+    if err:
+        if not args.quiet:
+            sys.stderr.write(err if err.endswith("\n") else err + "\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hive_mcp/addons/doctor.clj
+++ b/src/hive_mcp/addons/doctor.clj
@@ -95,7 +95,14 @@
 (defn- json-safe
   "Fold arbitrary addon evidence into values clojure.data.json can encode.
    Unknown live objects become strings; functions and host records never leak
-   through a doctor report."
+   through a doctor report.
+
+   DUPLICATE, deliberately, until hive-addon ships. The canonical fold now lives
+   in hive-addon.wire/json-safe, one layer down, so addon reports can use it
+   without depending on hive-mcp. This copy cannot delegate yet: hive-mcp's
+   deps.edn pins hive-addon at :mvn/version 1.0.0, which predates that ns, so
+   requiring it breaks the build for anyone without a local.deps.edn override.
+   Collapse this into a delegation when the hive-addon release lands."
   [x]
   (cond
     (or (nil? x) (string? x) (boolean? x) (number? x) (keyword? x)) x

--- a/src/hive_mcp/extensions/registry.clj
+++ b/src/hive_mcp/extensions/registry.clj
@@ -17,7 +17,8 @@
    Thread safety: All operations are atomic via atom + swap!.
    Idempotent: Re-registering the same key replaces silently."
   (:require [hive-mcp.protocols.registry :as reg]
-            [malli.core :as m]))
+            [malli.core :as m]
+            [hive-addon.registry.commands :as addon-cmds]))
 
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
 ;;
@@ -34,9 +35,23 @@
 (defonce ^:private schema-registry
   (atom {}))
 
-;; Registry for composite tool command contributions.
+;; Composite tool command contributions.
 ;; Shape: {"analysis" {"lint" {:handler fn :params {...} :description "..." :addon :kondo} ...}}
-(defonce ^:private command-contributions (atom {}))
+;; The store itself lives in hive-addon.registry.commands, NOT here.
+;; An addon depends on hive-di / hive-contracts / hive-addon, never on hive-mcp
+;; core, so hive-addon owns the seam and this namespace is only a thin facade
+;; over it. A second atom on this side made contribute! and get-commands two
+;; implementations of one concept: an addon migrated to the correct seam would
+;; mount, report :status :ok, and silently vanish from the tool surface,
+;; because nothing here ever read hive-addon's store.
+(defn- all-contributions
+  "The whole contribution tree, in the shape this facade has always returned:
+   {tool-name {command-name spec}}. Rebuilt from hive-addon on each call rather
+   than cached, so there is exactly one source of truth."
+  []
+  (into {}
+        (map (juxt identity addon-cmds/get-commands))
+        (addon-cmds/contributed-tool-names)))
 
 ;; Listeners notified after a command contribution or retraction, so the
 ;; advertised surface can follow a contribution made AFTER boot.
@@ -92,7 +107,7 @@
   (reg/reg-clear! ext-slot)
   (reset! schema-registry {})
   (reg/reg-clear! tool-slot)
-  (reset! command-contributions {})
+  (addon-cmds/clear!)
   nil)
 
 ;; =============================================================================
@@ -174,54 +189,87 @@
   (doseq [[_ f] @contribution-listeners]
     (try (f event) (catch Throwable _ nil))))
 
+;; Have we registered our notifier with hive-addon's own listener seam?
+;;
+;; A `delay`, not a load-time side effect: the probe runs at the first
+;; contribution, so a hive-addon that arrives later is still picked up and
+;; merely LOADING this namespace mutates nothing.
+;;
+;; Soft-resolved because hive-mcp pins hive-addon at a version that may predate
+;; the seam. When it is absent this is false and the facade notifies directly,
+;; exactly as it always did. When it is present, hive-addon notifies instead,
+;; and it does so for contributions made by ANY caller, which is the point: an
+;; addon that stops going through this facade and calls the registry directly
+;; still reaches the advertised tool surface.
+;;
+;; notify-contribution! already guards every listener with its own try/catch, so
+;; it satisfies hive-addon's contract that a listener must not throw (that
+;; registry is in the portable three-host stratum and cannot catch for us).
+(defonce ^:private seam-registered?
+  (delay
+    (boolean
+     (when-let [add! (try (requiring-resolve 'hive-addon.registry.commands/add-listener!)
+                          (catch Throwable _ nil))]
+       (try (add! ::host-surface notify-contribution!) true
+            (catch Throwable _ false))))))
+
+(defn- notify-once!
+  "Notify the host's contribution listeners exactly once.
+
+   Two notifiers now exist for one event, and firing both would deliver every
+   contribution twice: hive-addon's seam (which we register with) and this
+   facade's direct call. Whichever is in play, a listener sees the event once."
+  [event]
+  (when-not @seam-registered?
+    (notify-contribution! event)))
+
 (defn contribute-commands!
   "Register commands that compose into a named composite tool.
    tool-name: \"analysis\", addon-id: :kondo
    commands: {\"lint\" {:handler fn :params {\"path\" {...}} :description \"...\"}}
-   Notifies the contribution listeners afterwards."
+   Notifies the contribution listeners afterwards.
+
+   The contribution itself lands in hive-addon.registry.commands. This name
+   stays public so the addons that soft-resolve it keep working while they
+   migrate to the hive-addon seam one at a time; the listener notification is
+   what this host adds on top, and hive-addon does not own it."
   [tool-name addon-id commands]
-  (let [result (swap! command-contributions update tool-name merge
-                      (->> commands
-                           (map (fn [[cmd spec]] [(name cmd) (assoc spec :addon addon-id)]))
-                           (into {})))]
-    (notify-contribution! {:type :contribute :tool-name tool-name :addon-id addon-id
-                           :commands (mapv name (keys commands))})
-    result))
+  (addon-cmds/contribute! tool-name addon-id commands)
+  (notify-once! {:type :contribute :tool-name tool-name :addon-id addon-id
+                         :commands (mapv name (keys commands))})
+  (all-contributions))
 
 (defn retract-commands!
   "Remove all commands contributed by an addon from a tool. Notifies the
    contribution listeners afterwards."
   [tool-name addon-id]
-  (let [result (swap! command-contributions update tool-name
-                      (fn [m] (into {} (remove #(= addon-id (:addon (val %))) m))))]
-    (notify-contribution! {:type :retract :tool-name tool-name :addon-id addon-id})
-    result))
+  (addon-cmds/retract! tool-name addon-id)
+  (notify-once! {:type :retract :tool-name tool-name :addon-id addon-id})
+  (all-contributions))
 
 (defn retract-all-by-addon!
   "Remove all contributions from an addon across all tools (for shutdown).
    Notifies the contribution listeners once per tool the addon had touched."
   [addon-id]
+  ;; the touched set must be read BEFORE the retraction, or there is nothing
+  ;; left to attribute the notifications to
   (let [touched (into [] (keep (fn [[tn cmds]]
                                  (when (some #(= addon-id (:addon (val %))) cmds) tn)))
-                      @command-contributions)
-        result  (swap! command-contributions
-                       (fn [m]
-                         (into {} (map (fn [[tn cmds]]
-                                         [tn (into {} (remove #(= addon-id (:addon (val %))) cmds))])
-                                       m))))]
+                      (all-contributions))]
+    (addon-cmds/retract-all! addon-id)
     (doseq [tn touched]
-      (notify-contribution! {:type :retract :tool-name tn :addon-id addon-id}))
-    result))
+      (notify-once! {:type :retract :tool-name tn :addon-id addon-id}))
+    (all-contributions)))
 
 (defn get-contributed-commands
   "Get contributed commands for a composite tool name."
   [tool-name]
-  (get @command-contributions tool-name))
+  (addon-cmds/get-commands tool-name))
 
 (defn contributed-tool-names
   "Return vector of tool names that have command contributions."
   []
-  (vec (keys @command-contributions)))
+  (addon-cmds/contributed-tool-names))
 
 (def ExtensionFn
   "Schema for a registered extension value: any invokable."

--- a/src/hive_mcp/nats/client.clj
+++ b/src/hive_mcp/nats/client.clj
@@ -94,6 +94,39 @@
     (log/info "[NATS] Disconnected")))
 
 ;; =============================================================================
+;; Connection Watches
+;; =============================================================================
+
+(defn add-connection-watch!
+  "Register `f` under `key`; it is called as (f old-conn new-conn) whenever the
+   connection OBJECT is replaced, that is, on start! and on stop!.
+
+   A jnats reconnect does NOT fire here: `max-reconnects -1` means jnats heals
+   the same Connection in place and re-establishes its own subscriptions, so
+   nothing needs re-arming. What does fire is a stop!/start! cycle, and that one
+   is destructive: stop! drops the dispatcher and clears `subscriptions`, so
+   every subscription armed before the cycle is silently gone afterwards while
+   `connected?` reports true again. A subscriber that owns a long-lived
+   subscription (the progress NATS->ws bridge) watches this to re-subscribe.
+
+   Idempotent per key: re-registering a key replaces its callback."
+  [key f]
+  (add-watch connection key
+             (fn [_ _ old new]
+               (when (not= old new)
+                 (try (f old new)
+                      (catch Exception e
+                        (log/warn "[NATS] Connection watch" key "failed:"
+                                  (.getMessage e)))))))
+  key)
+
+(defn remove-connection-watch!
+  "Remove the connection watch registered under `key`. Safe when absent."
+  [key]
+  (remove-watch connection key)
+  nil)
+
+;; =============================================================================
 ;; Payload Sanitization
 ;; =============================================================================
 

--- a/src/hive_mcp/protocols/memory.clj
+++ b/src/hive_mcp/protocols/memory.clj
@@ -138,6 +138,17 @@
   [store]
   (satisfies? ports/IMemoryStoreWithAnalytics store))
 
+;;; --- IMemoryStoreBatch (batched reads) ---
+
+(do
+  (def IMemoryStoreBatch ports/IMemoryStoreBatch)
+  (def get-entries ports/get-entries))
+
+(defn batch-read-store?
+  "Check if the store can fetch many entries in one backend round-trip."
+  [store]
+  (satisfies? ports/IMemoryStoreBatch store))
+
 ;;; --- IMemoryStoreMetadataWrite (no-embed metadata writes) ---
 
 (do

--- a/src/hive_mcp/tools/consolidated/workflow.clj
+++ b/src/hive_mcp/tools/consolidated/workflow.clj
@@ -106,6 +106,26 @@
   (rb/result->mcp (rb/try-result :forge/status-failed
                                  #(forge-ops/forge-status* params forge-state))))
 
+;; ── Forge Survey ────────────────────────────────────────────────────────────
+
+(defn handle-forge-survey
+  "Read-only: which tasks a strike WOULD select, and why.
+
+   forge-ops/survey computes plan membership, per-card states, dependency
+   readiness and a :selection-status of :ready / :blocked / :no-ready /
+   :complete. Until this verb existed, that computation was reachable only by
+   running a STRIKE: its two non-test callers are both on the strike path. So
+   the only way to ask 'what would this plan do' was to make it do it, and every
+   attempt to verify plan scoping read-only came back looking like a deployment
+   gap because `forge survey` fell through :_handler to the belt dashboard and
+   answered with global kanban totals instead.
+
+   Mutates nothing. `forge status` keeps its own shape and its own meaning:
+   status reports the BELT, survey reports the SELECTION."
+  [params]
+  (rb/result->mcp (rb/try-result :forge/survey-failed
+                                 #(forge-ops/survey params))))
+
 ;; ── Forge Quench ────────────────────────────────────────────────────────────
 
 (defn handle-forge-quench
@@ -181,6 +201,7 @@
    :forge      {:strike             handle-forge-strike
                 :strike-imperative  handle-forge-strike-imperative
                 :status             handle-forge-status
+                :survey             handle-forge-survey
                 :quench             handle-forge-quench
                 :multi-front        {:start    handle-multi-front-start
                                      :status   handle-multi-front-status
@@ -207,14 +228,15 @@
 (def tool-def
   {:name "workflow"
    :consolidated true
-   :description "Forja Belt workflow: catchup (restore context), wrap (crystallize), complete (full lifecycle), forge-strike (FSM-driven smite->survey->spark cycle), forge-strike-imperative (DEPRECATED legacy path), forge-status (belt dashboard), forge-quench (graceful stop). HWF2 combinator IR: ir list/get/describe/author/register/run/status/cancel, ir method (describe method strategies), ir vocabulary (describe effect verbs). Goal-directed synthesis: goal-schema (project the GoalSpec contract + example for authoring), plan-goal (synthesize + soundness-check a Plan-EDN from a GoalSpec; author=true persists). Use command='help' to list all."
+   :description "Forja Belt workflow: catchup (restore context), wrap (crystallize), complete (full lifecycle), forge-strike (FSM-driven smite->survey->spark cycle), forge-strike-imperative (DEPRECATED legacy path), forge-status (belt dashboard), forge-survey (read-only: which tasks a strike WOULD select, with plan membership, per-card states and dependency readiness; takes plan_id/task_ids/task_filter and mutates nothing), forge-quench (graceful stop). HWF2 combinator IR: ir list/get/describe/author/register/run/status/cancel, ir method (describe method strategies), ir vocabulary (describe effect verbs). Goal-directed synthesis: goal-schema (project the GoalSpec contract + example for authoring), plan-goal (synthesize + soundness-check a Plan-EDN from a GoalSpec; author=true persists). Use command='help' to list all."
    :inputSchema {:type "object"
                  :properties {"command" {:type "string"
                                          :enum ["catchup" "wrap" "complete"
                                                 "plan-goal" "goal-schema"
                                                 "forge strike"
                                                 "forge strike-imperative"
-                                                "forge status" "forge quench"
+                                                "forge status" "forge survey"
+                                                "forge quench"
                                                 "forge multi-front start"
                                                 "forge multi-front status"
                                                 "forge multi-front stop"

--- a/src/hive_mcp/tools/memory/migration/core.clj
+++ b/src/hive_mcp/tools/memory/migration/core.clj
@@ -14,6 +14,7 @@
             [clojure.data.json :as json]
             [clojure.string :as str]
             [hive-mcp.dns.result :refer [rescue]]
+            [hive-weave.parallel :as wpar]
             [taoensso.timbre :as log]
             [hive-mcp.vectordb.resilience :refer [with-resilience]]))
 ;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
@@ -64,6 +65,103 @@
                    :kg-error (:error kg-result)
                    :old-project-id old-project-id
                    :new-project-id new-project-id})))))
+
+(def ^:private migration-read-batch
+  "Entry ids per batched backend read."
+  512)
+
+(def ^:private migration-write-concurrency
+  "Concurrent scope rewrites against the backend."
+  16)
+
+(def ^:private migration-write-timeout-ms
+  "Per-entry bound on one scope rewrite plus its audit record."
+  120000)
+
+(defn- resolve-migration-targets
+  "Fetch TARGET-IDS as {:found [entry] :not-found [id]}, in the order asked for.
+
+   Uses the store's batched read when it has one and falls back to per-id reads
+   when it does not, so a store without IMemoryStoreBatch still migrates."
+  [store target-ids]
+  (let [by-id (if (mem-proto/batch-read-store? store)
+                (into {}
+                      (map (juxt :id identity))
+                      (mapcat (fn [ids]
+                                (with-resilience (mem-proto/get-entries store ids)))
+                              (partition-all migration-read-batch target-ids)))
+                (into {}
+                      (keep (fn [eid]
+                              (when-let [entry (with-resilience
+                                                 (mem-proto/get-entry store eid))]
+                                [eid entry])))
+                      target-ids))]
+    (reduce (fn [acc eid]
+              (if-let [entry (get by-id eid)]
+                (update acc :found conj entry)
+                (update acc :not-found conj eid)))
+            {:found [] :not-found []}
+            target-ids)))
+
+(defn- migrate-one-scope!
+  "Rewrite ONE entry's project-id and scope tag in the store.
+
+   A scope change leaves :content untouched, so it goes through the no-embed
+   metadata write when the store has one. `update-entry!` re-embeds, and a
+   migration is the case where that is pure waste: re-filing a document moves
+   one entry per chunk.
+
+   Total: answers {:migrated id} or {:error {:id id :error msg}}, never throws."
+  [store entry {:keys [new-project-id old-scope-tag new-scope-tag]}]
+  (try
+    (let [new-tags (scope/retag-scope (:tags entry) old-scope-tag new-scope-tag)
+          updates  {:project-id new-project-id :tags new-tags}]
+      (with-resilience
+        (if (mem-proto/metadata-write-store? store)
+          (mem-proto/update-metadata! store (:id entry) updates)
+          (mem-proto/update-entry! store (:id entry) updates)))
+      {:migrated (:id entry)})
+    (catch Exception e
+      (log/warn "Failed to migrate entry" (:id entry) ":" (.getMessage e))
+      {:error {:id (:id entry) :error (.getMessage e)}})))
+
+(defn- apply-scope-migration!
+  "Rewrite every entry's scope, bounded-parallel, one outcome per entry in order,
+   then record the whole audit trail in ONE temporal transaction.
+
+   An entry whose rewrite timed out comes back as an ERROR: bounded-pmap's
+   fallback cannot name the item it stands for, so a nil outcome must be
+   attributed here rather than dropped from both the migrated and error lists.
+
+   Only entries that actually moved are audited."
+  [store entries {:keys [old-project-id new-project-id] :as opts}]
+  (let [raw      (wpar/bounded-pmap
+                  {:concurrency migration-write-concurrency
+                   :timeout-ms  migration-write-timeout-ms}
+                  (fn [entry] (migrate-one-scope! store entry opts))
+                  entries)
+        outcomes (mapv (fn [entry outcome]
+                         (or outcome
+                             {:error {:id    (:id entry)
+                                      :error (str "scope rewrite timed out after "
+                                                  migration-write-timeout-ms "ms")}}))
+                       entries raw)]
+    (when-let [moved (seq (keep :migrated outcomes))]
+      (rescue nil
+        (temporal/record-mutations-batch!
+         (mapv (fn [id]
+                 ;; :migrate, not :migrate-scoped. record-mutation! asserts
+                 ;; (contains? valid-ops op) and valid-ops declares :migrate,
+                 ;; so every audit record this path wrote was an AssertionError
+                 ;; swallowed by record-mutation-silent!.
+                 {:entry-id       id
+                  :op             :migrate
+                  :data           {:old-project-id old-project-id
+                                   :new-project-id new-project-id}
+                  :previous-value {:project-id old-project-id}
+                  :project-id     new-project-id})
+               moved))))
+    outcomes))
 
 (defn handle-migrate-scoped
   "Migrate specific memory entries by ID (or tag filter) from one project to another.
@@ -127,41 +225,19 @@
                             old-project-id "\". Nothing was migrated. Tags match exactly — "
                             "no prefix or substring. Check what the tag actually selects with: "
                             "memory query :tags [\"" tag-filter "\"] :project-id \"" old-project-id "\""))
-            (let [;; Fetch each entry, partition into found/not-found
-                  resolved       (reduce
-                                  (fn [acc eid]
-                                    (if-let [entry (with-resilience
-                                                     (mem-proto/get-entry store eid))]
-                                      (update acc :found conj entry)
-                                      (update acc :not-found conj eid)))
-                                  {:found [] :not-found []}
-                                  target-ids)
+            (let [resolved       (resolve-migration-targets store target-ids)
                   found-entries  (:found resolved)
                   skipped-ids    (:not-found resolved)
-                  migrated-ids   (atom [])
-                  errors         (atom [])]
-
-              (when-not dry-run
-                (doseq [entry found-entries]
-                  (try
-                    (let [new-tags (scope/retag-scope (:tags entry)
-                                                      old-scope-tag new-scope-tag)]
-                      (with-resilience
-                        (mem-proto/update-entry! store (:id entry)
-                                                 {:project-id new-project-id
-                                                  :tags new-tags}))
-                      ;; Temporal audit trail
-                      (temporal/record-mutation-silent!
-                       {:entry-id       (:id entry)
-                        :op             :migrate-scoped
-                        :data           {:old-project-id old-project-id
-                                         :new-project-id new-project-id}
-                        :previous-value {:project-id old-project-id}
-                        :project-id     new-project-id})
-                      (swap! migrated-ids conj (:id entry)))
-                    (catch Exception e
-                      (log/warn "Failed to migrate entry" (:id entry) ":" (.getMessage e))
-                      (swap! errors conj {:id (:id entry) :error (.getMessage e)})))))
+                  outcomes       (if dry-run
+                                   []
+                                   (apply-scope-migration!
+                                    store found-entries
+                                    {:old-project-id old-project-id
+                                     :new-project-id new-project-id
+                                     :old-scope-tag  old-scope-tag
+                                     :new-scope-tag  new-scope-tag}))
+                  migrated-ids   (atom (into [] (keep :migrated) outcomes))
+                  errors         (atom (into [] (keep :error) outcomes))]
 
               ;; Selectively migrate KG edge scopes for edges between migrated entries
               (let [migrated-set    (set (if dry-run (mapv :id found-entries) @migrated-ids))

--- a/test/hive_mcp/extensions/registry_delegation_test.clj
+++ b/test/hive_mcp/extensions/registry_delegation_test.clj
@@ -1,0 +1,74 @@
+(ns hive-mcp.extensions.registry-delegation-test
+  "An addon depends on hive-di / hive-contracts / hive-addon, never on hive-mcp
+   core, so hive-addon.registry.commands is the seam that owns command
+   contributions and this host namespace is only a facade over it.
+
+   While the host kept its own atom the two were separate implementations of one
+   concept, and the failure that hid it was silent: an addon that migrated to the
+   correct seam still mounted and still reported :status :ok, then vanished from
+   the tool surface because nothing on the host side ever read hive-addon's
+   store. These tests pin that ONE store backs both names, in both directions."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-addon.registry.commands :as addon-cmds]
+            [hive-mcp.extensions.registry :as registry]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(def ^:private tool "analysis")
+
+(defn- reset-world! []
+  (addon-cmds/clear!)
+  (registry/clear-all!))
+
+(use-fixtures :each (fn [t] (reset-world!) (t) (reset-world!)))
+
+(deftest a-host-contribution-lands-in-the-addon-store
+  (registry/contribute-commands! tool :kondo {"lint" {:handler identity :description "d"}})
+  (is (= ["lint"] (keys (addon-cmds/get-commands tool)))
+      "the host must not keep a second store the addon seam cannot see")
+  (is (= :kondo (:addon (get (addon-cmds/get-commands tool) "lint")))
+      "the contributing addon is stamped, so shutdown can retract exactly its own"))
+
+(deftest an-addon-contribution-is-visible-through-the-host-facade
+  (addon-cmds/contribute! tool :cljs {"build" {:handler identity}})
+  (is (= ["build"] (keys (registry/get-contributed-commands tool)))
+      "this is the migration that used to mount green and then vanish")
+  (is (= [tool] (registry/contributed-tool-names))))
+
+(deftest both-seams-accumulate-into-one-tree
+  (registry/contribute-commands! tool :kondo {"lint" {:handler identity}})
+  (addon-cmds/contribute! tool :cljs {"build" {:handler identity}})
+  (is (= ["build" "lint"] (sort (keys (registry/get-contributed-commands tool))))
+      "a half-migrated fleet must see every command, whichever seam placed it"))
+
+(deftest retraction-reaches-across-the-facade
+  (registry/contribute-commands! tool :kondo {"lint" {:handler identity}})
+  (addon-cmds/contribute! tool :cljs {"build" {:handler identity}})
+  (testing "the host retracts only the named addon's commands"
+    (registry/retract-commands! tool :kondo)
+    (is (= ["build"] (keys (registry/get-contributed-commands tool)))))
+  (testing "retract-all-by-addon! clears the rest"
+    (registry/retract-all-by-addon! :cljs)
+    (is (empty? (registry/get-contributed-commands tool)))))
+
+(deftest listeners-still-fire-around-the-delegated-store
+  (let [events (atom [])]
+    (registry/add-contribution-listener! ::probe (fn [e] (swap! events conj e)))
+    (try
+      (registry/contribute-commands! tool :kondo {"lint" {:handler identity}})
+      (registry/retract-all-by-addon! :kondo)
+      (is (= [:contribute :retract] (mapv :type @events))
+          "notification is the host's own contribution on top of the seam;
+           hive-addon does not own it and must not silently drop it")
+      (is (= [tool tool] (mapv :tool-name @events))
+          "retract-all-by-addon! reads the touched set BEFORE retracting, or it
+           has nothing left to attribute the notification to")
+      (finally (registry/remove-contribution-listener! ::probe)))))
+
+(deftest clear-all-empties-the-single-store
+  (addon-cmds/contribute! tool :cljs {"build" {:handler identity}})
+  (registry/clear-all!)
+  (is (empty? (addon-cmds/get-commands tool))
+      "clearing the host must not leave contributions stranded in the seam"))

--- a/test/hive_mcp/extensions/registry_seam_notify_test.clj
+++ b/test/hive_mcp/extensions/registry_seam_notify_test.clj
@@ -1,0 +1,86 @@
+(ns hive-mcp.extensions.registry-seam-notify-test
+  "Once hive-addon owns the command store AND a listener seam, two notifiers
+   exist for one event: hive-addon's, and this facade's own direct call. Firing
+   both delivers every contribution twice; firing neither is the silent-vanish
+   failure the delegation work exists to end. Exactly one must fire.
+
+   The facade registers with the seam by SOFT resolution, so it does the right
+   thing on both sides of the hive-addon release that ships the seam. These
+   tests pin the invariant that survives either way: a listener sees each event
+   exactly once."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-addon.registry.commands :as addon-cmds]
+            [hive-mcp.extensions.registry :as registry]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(def ^:private tool "analysis")
+
+(defn- seam-available? []
+  (some? (try (requiring-resolve 'hive-addon.registry.commands/add-listener!)
+              (catch Throwable _ nil))))
+
+(defn- reset-world! []
+  (registry/remove-contribution-listener! ::probe)
+  (registry/clear-all!))
+
+(use-fixtures :each (fn [t] (reset-world!) (t) (reset-world!)))
+
+(deftest a-contribution-through-the-facade-notifies-exactly-once
+  (let [seen (atom [])]
+    (registry/add-contribution-listener! ::probe (fn [e] (swap! seen conj e)))
+    (registry/contribute-commands! tool :kondo {"lint" {:handler identity}})
+    (is (= 1 (count @seen))
+        "duplicate delivery is what happens when both the seam and the facade
+         fire; a surface refreshed twice per contribution is a bug that only
+         shows up as churn")
+    (is (= :contribute (:type (first @seen))))
+    (is (= tool (:tool-name (first @seen))))))
+
+(deftest a-retraction-notifies-exactly-once
+  (let [seen (atom [])]
+    (registry/contribute-commands! tool :kondo {"lint" {:handler identity}})
+    (registry/add-contribution-listener! ::probe (fn [e] (swap! seen conj e)))
+    (registry/retract-commands! tool :kondo)
+    (is (= 1 (count @seen)))
+    (is (= :retract (:type (first @seen))))))
+
+(deftest retract-all-notifies-once-per-touched-tool
+  (let [seen (atom [])]
+    (registry/contribute-commands! "analysis" :kondo {"lint" {:handler identity}})
+    (registry/contribute-commands! "code" :kondo {"fmt" {:handler identity}})
+    (registry/contribute-commands! "memory" :other {"add" {:handler identity}})
+    (registry/add-contribution-listener! ::probe (fn [e] (swap! seen conj e)))
+    (registry/retract-all-by-addon! :kondo)
+    (is (= 2 (count @seen)) "once per tool, not once per command and not twice per tool")
+    (is (= #{"analysis" "code"} (set (map :tool-name @seen)))
+        "a tool the addon never touched must not be announced as changed")))
+
+(deftest a-contribution-made-DIRECTLY-on-the-seam-still-reaches-the-host
+  (testing "this is the migration case the whole delegation exists for: an addon
+            that stops going through the facade and calls hive-addon's registry
+            itself must still refresh the advertised surface"
+    (if (seam-available?)
+      (let [seen (atom [])]
+        (registry/add-contribution-listener! ::probe (fn [e] (swap! seen conj e)))
+        ;; force the facade to register with the seam before we bypass it
+        (registry/contribute-commands! tool :kondo {"lint" {:handler identity}})
+        (reset! seen [])
+        (addon-cmds/contribute! tool :cljs {"build" {:handler identity}})
+        (is (= 1 (count @seen))
+            "without the facade registering as a seam listener, this event is
+             lost and the addon mounts green then vanishes from the surface")
+        (is (= :cljs (:addon-id (first @seen)))))
+      (is true "hive-addon on this classpath predates the seam; nothing to assert"))))
+
+(deftest the-host-listener-satisfies-the-seams-no-throw-contract
+  (testing "hive-addon's registry is in the portable three-host stratum and
+            cannot catch for its listeners, so whatever we register there must
+            not throw. The host notifier guards each listener individually."
+    (registry/add-contribution-listener! ::probe (fn [_] (throw (ex-info "boom" {}))))
+    (is (some? (registry/contribute-commands! tool :kondo {"lint" {:handler identity}}))
+        "a throwing host listener must not break the contribution, whichever
+         notifier delivered the event")
+    (is (= ["lint"] (keys (registry/get-contributed-commands tool))))))

--- a/test/hive_mcp/nats/client_watch_test.clj
+++ b/test/hive_mcp/nats/client_watch_test.clj
@@ -1,0 +1,72 @@
+(ns hive-mcp.nats.client-watch-test
+  "A stop!/start! cycle replaces the connection object, drops the dispatcher and
+   clears every tracked subscription, so a subscriber armed before the cycle is
+   silently gone afterwards while `connected?` reports healthy again. The
+   connection atom is the only thing that moves across such a cycle, so it is
+   what long-lived subscribers watch to re-subscribe. These tests drive the
+   private atom directly: no NATS server is contacted."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [hive-mcp.nats.client :as client]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;; the atom itself, not its var: it is a defonce, so deref-at-load is stable
+(def ^:private connection @#'client/connection)
+
+(def ^:private test-key ::probe)
+
+(defn- reset-world! []
+  (client/remove-connection-watch! test-key)
+  (reset! connection nil))
+
+(use-fixtures :each (fn [t] (reset-world!) (t) (reset-world!)))
+
+(deftest watch-fires-when-the-connection-object-is-replaced
+  (let [seen (atom [])]
+    (client/add-connection-watch! test-key (fn [old new] (swap! seen conj [old new])))
+    (reset! connection ::conn-1)
+    (is (= [[nil ::conn-1]] @seen) "a fresh connect must reach the subscriber")
+    (reset! connection nil)
+    (is (= [[nil ::conn-1] [::conn-1 nil]] @seen)
+        "a disconnect is reported too, so a subscriber can stand down")))
+
+(deftest an-unchanged-value-does-not-fire
+  (let [calls (atom 0)]
+    (reset! connection ::conn-1)
+    (client/add-connection-watch! test-key (fn [_ _] (swap! calls inc)))
+    (reset! connection ::conn-1)
+    (is (zero? @calls)
+        "re-writing the same connection is not a lifecycle event; firing on it
+         would make every subscriber re-subscribe for nothing")))
+
+(deftest removing-the-watch-stops-delivery
+  (let [calls (atom 0)]
+    (client/add-connection-watch! test-key (fn [_ _] (swap! calls inc)))
+    (reset! connection ::conn-1)
+    (is (= 1 @calls))
+    (client/remove-connection-watch! test-key)
+    (reset! connection ::conn-2)
+    (is (= 1 @calls) "a stopped subscriber must not keep receiving")
+    (testing "removing an absent key is safe"
+      (is (nil? (client/remove-connection-watch! ::never-registered))))))
+
+(deftest re-registering-a-key-replaces-its-callback
+  (let [first-calls (atom 0)
+        second-calls (atom 0)]
+    (client/add-connection-watch! test-key (fn [_ _] (swap! first-calls inc)))
+    (client/add-connection-watch! test-key (fn [_ _] (swap! second-calls inc)))
+    (reset! connection ::conn-1)
+    (is (= 0 @first-calls) "the superseded callback is gone, not stacked")
+    (is (= 1 @second-calls))))
+
+(deftest a-throwing-subscriber-cannot-break-the-others
+  (let [survivor (atom 0)]
+    (client/add-connection-watch! ::boom (fn [_ _] (throw (ex-info "boom" {}))))
+    (client/add-connection-watch! test-key (fn [_ _] (swap! survivor inc)))
+    (try
+      (reset! connection ::conn-1)
+      (is (= 1 @survivor)
+          "one bad subscriber must not take down the connection lifecycle")
+      (finally (client/remove-connection-watch! ::boom)))))

--- a/test/hive_mcp/tools/consolidated/workflow/forge_survey_verb_test.clj
+++ b/test/hive_mcp/tools/consolidated/workflow/forge_survey_verb_test.clj
@@ -1,0 +1,49 @@
+(ns hive-mcp.tools.consolidated.workflow.forge-survey-verb-test
+  "forge-ops/survey computes plan membership, per-card states and dependency
+   readiness, and for a long time NOTHING public called it: its two non-test
+   callers are both on the strike path. So the only way to ask 'what would this
+   plan select' was to run a strike, and `forge survey` silently fell through
+   the :forge :_handler to the belt dashboard, answering with global kanban
+   totals. Every attempt to verify plan scoping read-only therefore looked like
+   a deployment gap when it was a missing verb.
+
+   These tests pin the verb, and pin that adding it did not move `forge status`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [hive-mcp.tools.consolidated.workflow :as wf]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(deftest survey-is-its-own-verb-not-the-belt-dashboard
+  (let [forge (:forge wf/canonical-handlers)]
+    (is (contains? forge :survey)
+        "without this key the dispatcher falls through :_handler to status, and
+         a plan-scoped question comes back answered with global totals")
+    (is (not= (:survey forge) (:status forge))
+        "status reports the BELT, survey reports the SELECTION")
+    (is (= (:status forge) (:_handler forge))
+        "the fallback stays what it was: adding a verb must not move the
+         meaning of a bare `forge` call")))
+
+(deftest the-verb-is-advertised
+  (let [enum (get-in wf/tool-def [:inputSchema :properties "command" :enum])]
+    (is (some #{"forge survey"} enum)
+        "a verb absent from the schema is unreachable through the tool surface
+         even when the handler exists")
+    (testing "the verbs that were already there are still there"
+      (is (some #{"forge status"} enum))
+      (is (some #{"forge strike"} enum))
+      (is (some #{"forge quench"} enum)))))
+
+(deftest survey-reports-a-failure-as-a-result-rather-than-throwing
+  (testing "forge-ops/survey THROWS when a plan_id cannot be resolved, by design
+            (a plan survey that silently selects nothing is worse than an
+            error). The handler must turn that into an MCP error result, not
+            let it escape into the tool loop."
+    (let [handler (get-in wf/canonical-handlers [:forge :survey])
+          res     (handler {:plan_id "no-such-plan-id-20260910"
+                            :directory "/home/leibniz/PP/hive"})]
+      (is (map? res))
+      (is (contains? res :isError)
+          "an unresolvable plan is reported, and reported as an error"))))

--- a/test/hive_mcp/tools/memory/migration/scope_cost_test.clj
+++ b/test/hive_mcp/tools/memory/migration/scope_cost_test.clj
@@ -1,0 +1,122 @@
+(ns hive-mcp.tools.memory.migration.scope-cost-test
+  "migrate-scoped's cost per entry, held by recording stub STORES.
+
+   Re-filing one ingested document moves one entry per chunk, so this handler's
+   per-entry cost is multiplied by thousands. Two optional ports already exist to
+   pay it cheaply and the handler has to actually reach for them:
+
+     IMemoryStoreBatch         one backend round trip for many ids
+     IMemoryStoreMetadataWrite a write that KEEPS the existing embedding
+
+   The store is a real record implementing those ports, so what these tests
+   assert is which protocol method the handler called, not which var was
+   redefined. `get-store` is still redefined because the handler resolves the
+   store from a registry with no parameter seam."
+  (:require [clojure.test :refer [deftest is testing]]
+            [hive-mcp.protocols.memory :as mem-proto]
+            [hive-mcp.tools.memory.migration.core :as migration]
+            [hive-spi.memory.ports :as ports]))
+
+;; Copyright (C) 2026 Pedro Gomes Branquinho (BuddhiLW) <pedrogbranquinho@gmail.com>
+;;
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(defn- entry-for [id] {:id id :tags ["t" "scope:project:mac"] :content "body"})
+
+(def ^:private chunk-ids (mapv #(str "chunk-" %) (range 40)))
+
+;; =============================================================================
+;; A store with both optional ports
+;; =============================================================================
+
+(defrecord FastStore [calls]
+  ports/IMemoryStore
+  (get-entry [_ id]
+    (swap! calls update :get-entry (fnil conj []) id)
+    (entry-for id))
+  (update-entry! [_ id updates]
+    (swap! calls update :update-entry! (fnil conj []) id)
+    (merge (entry-for id) updates))
+  (query-entries [_ _opts] [])
+
+  ports/IMemoryStoreBatch
+  (get-entries [_ ids]
+    (swap! calls update :get-entries (fnil conj []) (vec ids))
+    (mapv entry-for ids))
+
+  ports/IMemoryStoreMetadataWrite
+  (update-metadata! [_ id updates]
+    (swap! calls update :update-metadata! (fnil conj []) id)
+    (merge (entry-for id) updates)))
+
+;; =============================================================================
+;; A store with neither, so the fallback is exercised rather than assumed
+;; =============================================================================
+
+(defrecord PlainStore [calls]
+  ports/IMemoryStore
+  (get-entry [_ id]
+    (swap! calls update :get-entry (fnil conj []) id)
+    (entry-for id))
+  (update-entry! [_ id updates]
+    (swap! calls update :update-entry! (fnil conj []) id)
+    (merge (entry-for id) updates))
+  (query-entries [_ _opts] []))
+
+(defn- migrate-with
+  [store ids]
+  (with-redefs [mem-proto/store-set? (fn [] true)
+                mem-proto/get-store  (fn [] store)]
+    (migration/handle-migrate-scoped {:entry-ids      ids
+                                     :old-project-id "mac"
+                                     :new-project-id "topic:masonry"})))
+
+;; =============================================================================
+;; Reads
+;; =============================================================================
+
+(deftest a-batch-capable-store-is-read-in-batches-test
+  (let [calls (atom {})
+        res   (migrate-with (->FastStore calls) chunk-ids)]
+    (testing "the ids go out together, not one call per entry"
+      (is (seq (:get-entries @calls)))
+      (is (nil? (:get-entry @calls))
+          "a per-id read costs one backend round trip per chunk of the document")
+      (is (= (set chunk-ids) (set (mapcat identity (:get-entries @calls))))
+          "and every requested id is still asked for"))
+    (testing "the migration reports them all as migrated"
+      (is (not (:isError res))))))
+
+(deftest a-plain-store-still-migrates-test
+  (let [calls (atom {})
+        res   (migrate-with (->PlainStore calls) (vec (take 3 chunk-ids)))]
+    (testing "without IMemoryStoreBatch the handler falls back to per-id reads"
+      (is (= 3 (count (:get-entry @calls))))
+      (is (nil? (:get-entries @calls))))
+    (testing "and the work still happens"
+      (is (= 3 (count (:update-entry! @calls))))
+      (is (not (:isError res))))))
+
+;; =============================================================================
+;; Writes
+;; =============================================================================
+
+(deftest a-scope-change-never-re-embeds-when-the-store-can-avoid-it-test
+  (let [calls (atom {})]
+    (migrate-with (->FastStore calls) (vec (take 10 chunk-ids)))
+    (testing "the no-embed metadata write is the one that is used"
+      (is (= 10 (count (:update-metadata! @calls))))
+      (is (nil? (:update-entry! @calls))
+          (str "update-entry! re-runs the embedder on content the migration did not "
+               "touch, which for a re-filed document is one embedding per chunk")))))
+
+(deftest a-dry-run-writes-nothing-test
+  (let [calls (atom {})]
+    (with-redefs [mem-proto/store-set? (fn [] true)
+                  mem-proto/get-store  (fn [] (->FastStore calls))]
+      (migration/handle-migrate-scoped {:entry-ids      (vec (take 5 chunk-ids))
+                                       :old-project-id "mac"
+                                       :new-project-id "topic:masonry"
+                                       :dry-run        true}))
+    (is (nil? (:update-metadata! @calls)))
+    (is (nil? (:update-entry! @calls)))))


### PR DESCRIPTION
Four independent changes, one per commit.

## `fix(registry)` — the command store lives in hive-addon; this namespace is a facade
hive-mcp kept its own `command-contributions` atom while hive-addon owns the same concept. Two atoms for one concept meant an addon migrated to the **correct** seam would mount, report `:status :ok`, and silently vanish from the tool surface — a successful migration looked exactly like a broken addon. The store is now hive-addon's alone; the public names stay so addons can migrate one at a time. Listener notification stays here (hive-addon does not own it) with `notify-once!` preventing double delivery once we register with hive-addon's seam.

Safe against the pin: `io.github.hive-agi/hive-addon 1.0.0` does carry `hive_addon/registry/commands.cljc`, verified against the resolved jar.

## `feat(nats)` — connection watches
`stop!` clears `subscriptions`, so a `stop!`/`start!` cycle silently drops every subscription while `connected?` reports true again. Watches fire on replacement of the connection **object**, which is that destructive case; a jnats in-place reconnect deliberately does not fire, since it re-establishes its own subscriptions.

## `feat(workflow)` — `forge survey`
`forge-ops/survey` existed but both non-test callers were on the strike path, so the only way to ask "what would this plan do" was to make it do it. `forge survey` also wasn't a verb — it fell through to the belt dashboard and answered with global kanban totals, which made read-only plan-scoping checks look like a deployment gap. Survey mutates nothing; `forge status` keeps its meaning.

## `docs(doctor)` — why `json-safe` is duplicated
Names the removal condition. The pinned hive-addon 1.0.0 does **not** carry `hive_addon/wire` (verified), so delegating now would break the build for anyone without a `local.deps.edn` override.

## Test status — read before merging
The full suite at these commits: **6640 tests, 25093 assertions, 15 failures, 57 errors**. A baseline run of the same suite at HEAD (`4800843`, isolated worktree, no `local.deps.edn`) is in flight to establish whether those pre-date this branch. **Do not merge until that comparison is in.** Several failures visible in the log are environmental (`hivemind unreachable`, `nREPL down`) rather than assertion failures.